### PR TITLE
fix(UI): 修复子页面表格溢出并恢复移动端目录跳转

### DIFF
--- a/_layouts/paper.html
+++ b/_layouts/paper.html
@@ -102,6 +102,21 @@ layout: default
 <script>
 (function() {
   var body = document.getElementById('paper-body');
+  if (!body) return;
+
+  body.querySelectorAll('table').forEach(function(table) {
+    if (table.parentElement && table.parentElement.classList.contains('table-wrapper')) return;
+    var wrapper = document.createElement('div');
+    wrapper.className = 'table-wrapper';
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  });
+})();
+</script>
+
+<script>
+(function() {
+  var body = document.getElementById('paper-body');
   var nav = document.getElementById('toc-nav');
   if (!body || !nav) return;
 
@@ -132,6 +147,34 @@ layout: default
 
   var links = nav.querySelectorAll('.toc-link');
   var headingArr = Array.from(headings);
+  var sidebar = document.getElementById('toc-sidebar');
+  var overlay = document.getElementById('sidebar-overlay');
+  var mobileQuery = window.matchMedia('(max-width: 1200px)');
+
+  function closeMobileSidebar() {
+    if (sidebar) sidebar.classList.remove('open');
+    if (overlay) overlay.classList.remove('show');
+    document.body.style.overflow = '';
+  }
+
+  links.forEach(function(link) {
+    link.addEventListener('click', function(e) {
+      var hash = link.getAttribute('href');
+      if (!hash || hash.charAt(0) !== '#') return;
+      var target = document.querySelector(hash);
+      if (!target) return;
+      e.preventDefault();
+
+      if (mobileQuery.matches) {
+        closeMobileSidebar();
+      }
+
+      window.history.replaceState(null, '', hash);
+      var headerOffset = 90;
+      var targetTop = target.getBoundingClientRect().top + window.scrollY - headerOffset;
+      window.scrollTo({ top: targetTop, behavior: 'smooth' });
+    });
+  });
 
   function updateActive() {
     var scrollPos = window.scrollY + 100;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -721,15 +721,18 @@ body {
   overflow-x: auto;
   margin: 1rem 0;
   border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
   -webkit-overflow-scrolling: touch;
 }
 
 .paper-body table {
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
+  max-width: none;
   border-collapse: collapse;
   margin: 0;
   font-size: 0.92em;
-  min-width: 600px; /* Ensure table doesn't squash too much */
 }
 
 .paper-body th, .paper-body td {
@@ -890,24 +893,16 @@ html[data-lang-mode="zh"] .footer-text-zh {
   .mermaid-container {
     margin-bottom: 2.8rem;
   }
-  /* Wide tables overflow main column on phones — switch to block
-     so the table itself scrolls horizontally; cell content unchanged. */
-  .paper-body table {
-    display: block;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+  .paper-body th, .paper-body td {
+    padding: 0.45rem 0.6rem;
+    font-size: 0.9em;
   }
 }
 
-/* Tablet column is also narrow — same horizontal-scroll fallback so
-   wide reference tables don't get squashed. */
+/* Tablet column gets denser spacing to keep readability. */
 @media (max-width: 1200px) and (min-width: 601px) {
-  .paper-body table {
-    display: block;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+  .paper-body th, .paper-body td {
+    padding: 0.48rem 0.68rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- 避免论文子页面中的表格撑出主内容列或超出布局，在小屏上需能优雅显示（横向滑动或压缩）。
- 修复移动端子页面侧边栏（TOC）点击跳转失效或跳位的问题，提升移动端可用性。

### Description
- 在 `/_layouts/paper.html` 中增加运行时代码：自动为页面中未被包裹的 `table` 注入外层容器 `.table-wrapper`，并避免重复包裹。
- 在 `assets/css/style.css` 中调整表格样式：新增 `.table-wrapper` 的边框与背景，移除固定 `min-width: 600px`，将 `.paper-body table` 设为 `width: max-content; min-width: 100%; max-width: none;`，使窄表铺满主列、宽表由外层容器横向滚动。 
- 针对移动端与平板端压缩表格单元格内边距与字号（通过 media queries 调整 `th`/`td` 的 `padding` 与 `font-size`），改善窄屏阅读体验。 
- 修复 TOC 链接行为：在生成的目录链接上添加点击处理器，移动端点击时先关闭抽屉侧栏（移除 `open`/`show`），再按固定头部偏移做平滑滚动与 URL hash 更新，避免跳转不到位或不响应。 
- 影响文件：`_layouts/paper.html`、`assets/css/style.css`。

### Testing
- 运行 `git diff --check` 验证无空白错误，检查通过。 
- 尝试本地构建 `bundle exec jekyll build` 时环境缺少 `jekyll` 可执行文件导致无法运行构建（错误：`bundler: command not found: jekyll`），因此未能在当前环境完成静态站点全量构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0169d74f483238975226877cbece8)