### PR TITLE
fix(UI): 限制移动端子页面横向溢出仅显示主栏

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -438,6 +438,13 @@ body {
 
 /* Show TOC only on wide screens */
 @media (max-width: 1200px) {
+  html,
+  body {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
   .toc-sidebar {
     position: fixed;
     top: 0;
@@ -461,6 +468,11 @@ body {
   }
   .paper-layout {
     display: block;
+  }
+
+  .paper-body {
+    width: 100%;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
### Motivation
- 修复移动端子页面可以向右滑出出现空白区域的问题，要求移动端只显示正文主 column。

### Description
- 在 `@media (max-width: 1200px)` 下为 `html, body` 添加 `width: 100%`、`max-width: 100%` 和 `overflow-x: hidden`，防止页面整体横向滚动溢出。
- 为移动端的 `.paper-body` 添加 `width: 100%` 与 `max-width: 100%`，确保正文主列贴合视口宽度显示。
- 修改文件：`assets/css/style.css`，仅在移动/平板断点生效，桌面端布局与侧栏行为不变。

### Testing
- 通过 `git diff -- assets/css/style.css` 验证了修改已写入，命令执行成功。
- 通过 `git status --short` 确认工作区干净，命令执行成功。
- 已用提交信息 `fix(UI): 限制移动端子页面横向溢出仅显示主栏` 完成提交，提交命令执行成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01979af78832384d2bd5334fd361a)