### PR TITLE
fix(UI): 修复移动端 site-header 固定与安全区遮挡

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -445,6 +445,18 @@ body {
     overflow-x: hidden;
   }
 
+  .site-header {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1200;
+  }
+
+  .container {
+    padding-top: calc(57px + env(safe-area-inset-top, 0px));
+  }
+
   .toc-sidebar {
     position: fixed;
     top: 0;
@@ -880,10 +892,10 @@ html[data-lang-mode="zh"] .footer-text-zh {
     top: 0;
     right: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 1200;
   }
   .container {
-    padding: calc(57px + 1rem) 1rem 1rem;
+    padding: calc(57px + env(safe-area-inset-top, 0px) + 1rem) 1rem 1rem;
   }
   .paper-body h1 {
     font-size: 1.4rem;


### PR DESCRIPTION
### Motivation
- 移动端/平板在上滑时 `site-header` 会随内容一起滚动，且固定头部可能遮挡正文，需要保证头部在小屏幕上固定并为内容留出安全区高度。

### Description
- 在 `assets/css/style.css` 的 `@media (max-width: 1200px)` 中将 `.site-header` 设为 `position: fixed` 并提升 `z-index`，同时为 `.container` 添加 `padding-top: calc(57px + env(safe-area-inset-top, 0px))` 以补偿头部高度与安全区；并同步在 `@media (max-width: 600px)` 中调整 `z-index` 与容器顶部内边距计算。`

### Testing
- 尝试运行 `npx --yes playwright --version` 进行自动化验证，但因 npm registry 访问被策略拒绝返回 `403`，无法在当前环境完成浏览器端自动化测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f028e195048323b80b4fe00481a575)