### PR TITLE
Improve mobile responsive layout and TOC sidebar stacking/overflow

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -457,23 +457,6 @@ body {
     padding-top: calc(57px + env(safe-area-inset-top, 0px));
   }
 
-  .header-inner {
-    flex-wrap: wrap;
-    align-items: flex-start;
-  }
-
-  .site-title {
-    flex: 1 1 100%;
-    white-space: normal;
-    overflow: visible;
-    text-overflow: unset;
-  }
-
-  .header-right {
-    width: 100%;
-    justify-content: flex-end;
-  }
-
   .toc-sidebar {
     position: fixed;
     top: 0;
@@ -499,31 +482,6 @@ body {
   }
   .sidebar-overlay {
     z-index: 1250;
-  }
-  .paper-layout {
-    display: block;
-    width: 100%;
-    max-width: 100%;
-  }
-
-  .paper-body {
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
-  }
-
-  .paper-body h1,
-  .paper-body h2,
-  .paper-body h3,
-  .paper-body p,
-  .paper-body li {
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
-
-  .paper-content {
-    max-width: 100%;
-    overflow-x: clip;
   }
 }
 
@@ -1081,3 +1039,49 @@ html[data-lang-mode="zh"] .footer-text-zh {
 :root:not([data-theme="dark"]) .highlight .sr, :root:not([data-theme="dark"]) .highlight .ss, :root:not([data-theme="dark"]) .highlight .se, :root:not([data-theme="dark"]) .highlight .sc { color: #0a3069; }
 :root:not([data-theme="dark"]) .highlight .err { color: #cf222e; }
 :root:not([data-theme="dark"]) .highlight .p,  :root:not([data-theme="dark"]) .highlight .n  { color: #24292f; }
+
+/* ===== Mobile overrides (isolated to reduce future merge conflicts) ===== */
+@media (max-width: 1200px) {
+  .header-inner {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .site-title {
+    flex: 1 1 100%;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .paper-layout {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .paper-body {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .paper-body h1,
+  .paper-body h2,
+  .paper-body h3,
+  .paper-body p,
+  .paper-body li {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .paper-content {
+    max-width: 100%;
+    overflow-x: clip;
+  }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -445,6 +445,35 @@ body {
     overflow-x: hidden;
   }
 
+  .site-header {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1200;
+  }
+
+  .container {
+    padding-top: calc(57px + env(safe-area-inset-top, 0px));
+  }
+
+  .header-inner {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .site-title {
+    flex: 1 1 100%;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
   .toc-sidebar {
     position: fixed;
     top: 0;
@@ -456,23 +485,45 @@ body {
     padding: 20px;
     box-shadow: 2px 0 12px rgba(0,0,0,0.15);
     border-radius: 0 16px 16px 0;
-    z-index: 1000;
+    z-index: 1300;
     transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     display: block; /* Overriding previous display: none */
+    margin-left: 0;
   }
   .toc-sidebar.open {
     left: 0;
   }
   .sidebar-toggle {
     display: flex;
+    z-index: 1350;
+  }
+  .sidebar-overlay {
+    z-index: 1250;
   }
   .paper-layout {
     display: block;
+    width: 100%;
+    max-width: 100%;
   }
 
   .paper-body {
     width: 100%;
     max-width: 100%;
+    min-width: 0;
+  }
+
+  .paper-body h1,
+  .paper-body h2,
+  .paper-body h3,
+  .paper-body p,
+  .paper-body li {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .paper-content {
+    max-width: 100%;
+    overflow-x: clip;
   }
 }
 
@@ -730,6 +781,7 @@ body {
 /* Tables */
 .table-wrapper {
   width: 100%;
+  max-width: 100%;
   overflow-x: auto;
   margin: 1rem 0;
   border-radius: 6px;
@@ -880,10 +932,10 @@ html[data-lang-mode="zh"] .footer-text-zh {
     top: 0;
     right: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 1200;
   }
   .container {
-    padding: calc(57px + 1rem) 1rem 1rem;
+    padding: calc(57px + env(safe-area-inset-top, 0px) + 1rem) 1rem 1rem;
   }
   .paper-body h1 {
     font-size: 1.4rem;
@@ -899,11 +951,7 @@ html[data-lang-mode="zh"] .footer-text-zh {
     gap: 0.75rem;
   }
   .site-title {
-    flex: 1;
     min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     line-height: 1.3;
   }
   .header-right {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -927,13 +927,6 @@ html[data-lang-mode="zh"] .footer-text-zh {
 
 /* ===== Responsive ===== */
 @media (max-width: 600px) {
-  .site-header {
-    position: fixed;
-    top: 0;
-    right: 0;
-    left: 0;
-    z-index: 1200;
-  }
   .container {
     padding: calc(57px + env(safe-area-inset-top, 0px) + 1rem) 1rem 1rem;
   }


### PR DESCRIPTION
### Motivation
- Fix stacking and layout issues on narrow viewports so the header and TOC sidebar behave correctly and content doesn't overflow. 
- Ensure safe-area support on devices with notches and improve text wrapping for long titles and body content. 

### Description
- Made header fixed on small screens and added safe-area-aware top padding via `padding-top: calc(57px + env(safe-area-inset-top, 0px))`. 
- Adjusted header layout to wrap and allow the `.site-title` to use full width with normal wrapping, and changed `.header-right` alignment for small screens. 
- Converted the TOC into a fixed sidebar for narrow screens, changed sidebar/open overlay stacking order with updated `z-index` values (`.toc-sidebar` 1300, `.sidebar-toggle` 1350, `.sidebar-overlay` 1250), and ensured the sidebar can slide in via `.toc-sidebar.open`. 
- Constrained content overflow and table behavior by setting `.paper-layout`/`.paper-body` to full width, adding `min-width: 0`, enabling `overflow-wrap`/`word-break` for text, clipping horizontal overflow in `.paper-content`, and limiting `.table-wrapper` to `max-width: 100%`. 
- Tweaked small-screen padding and typography adjustments, including raising header z-index to `1200` and removing truncation on `.site-title`. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f028e195048323b80b4fe00481a575)