### PR TITLE
fix(CSS): 修复移动端 Mermaid 导致主列右侧留白

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -610,7 +610,19 @@ body {
   background: var(--card-bg);
   padding: 1rem;
   border-radius: 8px;
+  max-width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Mermaid sometimes injects fixed-width SVGs that can stretch the document
+   on mobile Safari. Keep the diagram inside its own horizontal scroller. */
+.mermaid svg {
+  display: block;
+  max-width: 100% !important;
+  height: auto !important;
+  margin: 0 auto;
 }
 
 [data-theme="dark"] .mermaid {
@@ -1104,5 +1116,10 @@ html[data-lang-mode="zh"] .footer-text-zh {
     max-width: 100%;
     overflow-x: hidden; /* fallback for older Safari */
     overflow-x: clip;   /* preferred: no scroll container */
+  }
+
+  .paper-body .mermaid {
+    width: 100%;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
### Motivation
- 解决在移动端（尤其是 Safari）某些论文页面中 Mermaid 渲染生成的固定宽度 SVG 将主列横向撑宽，导致右侧出现大块空白的问题。 

### Description
- 在 `assets/css/style.css` 中为 `.mermaid` 添加 `max-width: 100%`、`overflow-y: hidden` 和 `-webkit-overflow-scrolling: touch`，新增 `.mermaid svg { max-width: 100% !important; height: auto !important; }` 以约束 Mermaid 注入的固定宽度 SVG，并在移动端媒体查询中为 `.paper-body .mermaid` 设置 `width: 100%` / `max-width: 100%`，避免图表撑开主内容列。 

### Testing
- 尝试运行 `bundle exec jekyll build --quiet` 进行站点构建但在当前环境中因缺少 `jekyll` 可执行文件而失败（环境依赖问题），并使用 `git status --short` 验证工作区状态为干净。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0450d0308832397d1dc9a7840871a)