### PR TITLE
docs(Meta): 将“当前快照”从 README 迁移到 TODO_v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 **🛠️ 仓库开发待办**: [papers/todos/TODO_v5.md](papers/todos/TODO_v5.md) — 笔记 / 站点 / 工具链的开发任务（最新 v5，侧重脚本健壮性与代码质量，历史版本见 [`papers/todos/`](papers/todos/)）。
 
-**📌 当前快照**: 已覆盖 14 个分类、48 篇笔记；`prepare_pages.py` 当前无 `[STUB]` 告警。下一阶段重点已从"扩充骨架"转向"工程质量校准"，包括统一统计口径、增强元数据安全、以及脚本重构。
-
 ## Agent Skills & 工程质量
 
 项目已集成 [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) 生产级工程规范，在后续维护中强制执行以下质量门禁：

--- a/papers/todos/TODO_v5.md
+++ b/papers/todos/TODO_v5.md
@@ -3,6 +3,11 @@
 ## Overview
 Based on the code review findings from `code-review-and-quality`, this plan aims to improve the robustness, consistency, and security of the project's maintenance scripts. It focuses on unifying the logic between `prepare_pages.py` and `sync_progress.py`, securing metadata handling, and improving architectural clarity.
 
+## 当前快照（从 README 迁移）
+- 已覆盖 14 个分类、48 篇笔记。
+- `prepare_pages.py` 当前无 `[STUB]` 告警。
+- 下一阶段重点已从“扩充骨架”转向“工程质量校准”，包括统一统计口径、增强元数据安全、以及脚本重构。
+
 ## Architecture Decisions
 - **Source of Truth Consistency**: Align `is_stub` logic across all scripts to ensure consistent status reporting.
 - **Defensive Metadata Handling**: Implement proper escaping for YAML frontmatter to prevent parsing errors.


### PR DESCRIPTION
### Motivation
- 将容易过期的阶段性“📌 当前快照”从首页 `README.md` 移除以避免信息失真并降低维护成本。 
- 将该快照集中到开发待办文档 `papers/todos/TODO_v5.md` 中以便持续更新并与当前开发计划保持一致.

### Description
- 从 `README.md` 中删除了“📌 当前快照”段落以精简主页内容。 
- 在 `papers/todos/TODO_v5.md` 中新增了 `## 当前快照（从 README 迁移）` 小节并填入原快照内容（覆盖分类数、笔记数、脚本告警与下一阶段重点）。
- 使用中文 Conventional Commits 风格提交变更，提交信息为 `docs(Meta): 将当前快照从 README 迁移到 TODO_v5`。

### Testing
- 运行 `rg --files | rg 'AGENTS.md|README|TODO|Todo|todo'` 以列出相关文件以验证文件存在，命令执行成功。 
- 使用 `sed -n '1,220p' README.md` 和 `sed -n '1,220p' papers/todos/TODO_v5.md` 检查并确认 `README.md` 已移除段落且 `TODO_v5.md` 已新增小节，检查成功。 
- 通过 `git add` + `git commit` 提交更改并用 `git log --oneline -n 6` 验证提交历史，提交与日志检查均成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b94f3e408323bcce2b27a6695027)