### PR TITLE
🔒 Fix YAML Injection in Front Matter Generation

### DIFF
--- a/scripts/prepare_pages.py
+++ b/scripts/prepare_pages.py
@@ -204,7 +204,10 @@ def process_papers():
 
                 # Add front matter if not present
                 if not has_frontmatter(content):
-                    frontmatter = f'---\nlayout: paper\ntitle: "{title}"\ncategory: "{category_display}"\n---\n\n'
+                    # Use json.dumps to safely escape title and category for YAML
+                    safe_title = json.dumps(title, ensure_ascii=False)
+                    safe_category = json.dumps(category_display, ensure_ascii=False)
+                    frontmatter = f'---\nlayout: paper\ntitle: {safe_title}\ncategory: {safe_category}\n---\n\n'
                     with open(fpath, 'w', encoding='utf-8') as f:
                         f.write(frontmatter + content)
                     print(f"  Added front matter: {fpath}")


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Potential YAML Injection in the Jekyll front matter generation within `scripts/prepare_pages.py`.

### ⚠️ Risk: The potential impact if left unfixed
If a paper title or category contains double quotes (e.g., `# Paper "Title"`), the generated front matter would be `title: "Paper "Title""`, which is invalid YAML. This causes Jekyll parsing errors and could potentially be exploited to inject arbitrary YAML keys if the title or category were maliciously crafted.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix uses `json.dumps(..., ensure_ascii=False)` to safely escape the `title` and `category_display` variables before they are inserted into the front matter. Since JSON strings are valid YAML double-quoted scalars, this ensures that any special characters (like quotes, backslashes, or newlines) are properly escaped, maintaining the integrity and security of the generated YAML.


---
*PR created automatically by Jules for task [5414722331649330936](https://jules.google.com/task/5414722331649330936) started by @ImChong*