### PR TITLE
Fix HTML entities inside math before rendering

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -272,10 +272,13 @@
       // Kramdown converts > to &gt; and < to &lt; inside table cells etc.
       document.querySelectorAll('td, th, li, p, span, strong, em, b, i, h1, h2, h3, h4, h5, h6').forEach(function(el) {
         var html = el.innerHTML;
-        // Only process if there's a $ or \[ that suggests math content
-        if (html.indexOf('$') === -1 && html.indexOf('\\[') === -1) return;
-        // Replace HTML entities back inside math delimiters
-        html = html.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
+        // Only process if there's a math delimiter that suggests math content
+        if (html.indexOf('$') === -1 && html.indexOf('\\(') === -1 && html.indexOf('\\[') === -1) return;
+        // Replace HTML entities back inside math delimiters (only if they are inside math blocks)
+        var mathRegex = /(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\]|\$[\s\S]*?\$|\\\([\s\S]*?\\\))/g;
+        html = html.replace(mathRegex, function(match) {
+          return match.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
+        });
         el.innerHTML = html;
       });
 


### PR DESCRIPTION
The current implementation of `initKaTeX` in `_layouts/default.html` performs a broad `innerHTML.replace` for `&gt;`, `&lt;`, and `&amp;` whenever a math delimiter is detected in an element. This causes HTML entities outside of math blocks to be incorrectly converted back to characters (e.g., `5 &lt; 10` becomes `5 < 10` in HTML source, which can break rendering or be invalid).

This PR improves the logic by:
1. Using a regular expression to identify only content within supported math delimiters (`$$...$$`, `\[...\]`, `$ ... $`, `\( ... \)`).
2. Performing the entity replacement only within those identified blocks.
3. Updating the early-return optimization check to correctly account for all supported delimiters.

Verification was performed using simulation scripts and a test HTML page to ensure entities inside math are restored while entities outside math remain untouched.

---
*PR created automatically by Jules for task [5919134022614278092](https://jules.google.com/task/5919134022614278092) started by @ImChong*