### PR TITLE
⚡ Bolt: Debounce search and throttle scroll listeners to improve UI responsiveness

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Throttling Scroll and Debouncing Search in Jekyll index.html
+**Learning:** In a static site architecture like Jekyll where all content is rendered into a single HTML file and filtered via client-side JavaScript, synchronous DOM manipulations tied to high-frequency events (`scroll` and `input`) create severe main-thread bottlenecks, especially on long pages with many elements (like a large paper index).
+**Action:** Always wrap `scroll` event listeners in `requestAnimationFrame` with a ticking flag, and implement caching (e.g., `lastActive`) to only write to the DOM when state actually changes. Always wrap `input` event listeners for text filtering in a `setTimeout` debounce to delay expensive DOM updates until the user pauses typing.

--- a/index.html
+++ b/index.html
@@ -186,17 +186,21 @@ title: "Home"
   var categories = document.querySelectorAll('.category-section');
   var paperItems = document.querySelectorAll('.paper-list li[data-search]');
 
+  var searchTimeout;
+  // ⚡ Bolt Optimization: Debounce search input to prevent rapid, expensive DOM updates on every keystroke
   searchInput.addEventListener('input', function() {
-    var query = searchInput.value.toLowerCase().trim();
-    var hasAnyMatch = false;
+    clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(function() {
+      var query = searchInput.value.toLowerCase().trim();
+      var hasAnyMatch = false;
 
-    // Handle roadmap TOC item
-    var roadmapTocItem = document.querySelector('.toc-item[data-toc-for="roadmap-title"]');
-    if (roadmapTocItem) {
-      roadmapTocItem.style.display = query === '' ? '' : 'none';
-    }
+      // Handle roadmap TOC item
+      var roadmapTocItem = document.querySelector('.toc-item[data-toc-for="roadmap-title"]');
+      if (roadmapTocItem) {
+        roadmapTocItem.style.display = query === '' ? '' : 'none';
+      }
 
-    categories.forEach(function(cat) {
+      categories.forEach(function(cat) {
       var catHasMatch = false;
       var catTotalMatch = 0;
       var subcategories = cat.querySelectorAll('.subcategory-section');
@@ -255,9 +259,10 @@ title: "Home"
         var countEl = catTocItem.querySelector('.toc-count');
         if (countEl) countEl.textContent = '(' + catTotalMatch + ')';
       }
-    });
+      });
 
-    noResults.style.display = hasAnyMatch || query === '' ? 'none' : 'block';
+      noResults.style.display = hasAnyMatch || query === '' ? 'none' : 'block';
+    }, 150);
   });
 
   var sidebar = document.getElementById('toc-sidebar');
@@ -271,6 +276,7 @@ title: "Home"
   });
   if (targets.length === 0) return;
 
+  var lastActive = -1;
   function updateActive() {
     // Probe just below the sticky header so the link reflects whatever
     // section is currently anchored at the top of the viewport.
@@ -279,11 +285,27 @@ title: "Home"
     for (var i = 0; i < targets.length; i++) {
       if (targets[i].el.getBoundingClientRect().top <= probeY) current = i;
     }
-    targets.forEach(function(t, idx) {
-      t.link.classList.toggle('active', idx === current);
-    });
+
+    // Only update DOM if the active section actually changed
+    if (current !== lastActive) {
+      targets.forEach(function(t, idx) {
+        t.link.classList.toggle('active', idx === current);
+      });
+      lastActive = current;
+    }
   }
-  window.addEventListener('scroll', updateActive);
+
+  var ticking = false;
+  // ⚡ Bolt Optimization: Throttle scroll event listener using requestAnimationFrame to prevent multiple calls per frame
+  window.addEventListener('scroll', function() {
+    if (!ticking) {
+      window.requestAnimationFrame(function() {
+        updateActive();
+        ticking = false;
+      });
+      ticking = true;
+    }
+  });
   updateActive();
 })();
 </script>


### PR DESCRIPTION
💡 **What**:
- Wrapped the `scroll` event listener's DOM updates in `requestAnimationFrame` and added a `lastActive` check to avoid redundant `classList` toggling.
- Wrapped the paper search `input` event listener in a 150ms `setTimeout` debounce to prevent blocking the main thread during typing.

🎯 **Why**:
- Previously, the `scroll` event was firing synchronously multiple times per frame, forcing the browser to perform O(N) DOM writes on every tick.
- The `input` search listener was manipulating the display property of potentially hundreds of elements on every keystroke, causing severe UI jank while typing.

📊 **Impact**:
- Reduces redundant DOM writes during scrolling by nearly 100% (only updates when the active section changes).
- Prevents main thread blocking during search, ensuring smooth typing regardless of the number of papers on the page.

🔬 **Measurement**:
- UI responsiveness can be felt directly when typing rapidly into the search bar, or via Chrome DevTools Performance tab, where the "Scripting" and "Rendering" time per frame during scroll/search operations will be drastically reduced.

---
*PR created automatically by Jules for task [1571734542948494488](https://jules.google.com/task/1571734542948494488) started by @ImChong*