### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reverse Tabnabbing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-04 - [Reverse Tabnabbing]
+**Vulnerability:** Found a `target="_blank"` link pointing to GitHub in `_includes/header.html` without the `rel="noopener noreferrer"` attribute.
+**Learning:** This is a classic "Reverse Tabnabbing" vulnerability where the newly opened tab can gain access to the `window.opener` object and potentially redirect the original page to a malicious site.
+**Prevention:** Always add `rel="noopener noreferrer"` to external links that open in a new tab via `target="_blank"`.

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -398,6 +398,22 @@
         "dir": "TextOp__Real-time_Interactive_Text-Driven_Humanoid_Robot_Motion_Generation_and_C",
         "arxiv": "2602.07439",
         "zhname": "TextOp：实时交互式文本驱动人形机器人动作生成与控制"
+      },
+      {
+        "title": "HiWET: Hierarchical World-Frame End-Effector Tracking for Long-Horizon Humanoid Loco-Manipulation",
+        "path": "papers/04_Loco-Manipulation_and_WBC/HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation/HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation.md",
+        "url": "/papers/04_Loco-Manipulation_and_WBC/HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation/HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation.html",
+        "dir": "HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation",
+        "arxiv": "2602.06341",
+        "zhname": "HiWET：面向长时域人形机器人运动-操作的层级式世界坐标末端执行器跟踪"
+      },
+      {
+        "title": "Learning Soccer Skills for Humanoid Robots: A Progressive Perception-Action Framework",
+        "path": "papers/04_Loco-Manipulation_and_WBC/Learning_Soccer_Skills_for_Humanoid_Robots____A_Progressive_Perception-Action_Fr/Learning_Soccer_Skills_for_Humanoid_Robots____A_Progressive_Perception-Action_Fr.md",
+        "url": "/papers/04_Loco-Manipulation_and_WBC/Learning_Soccer_Skills_for_Humanoid_Robots____A_Progressive_Perception-Action_Fr/Learning_Soccer_Skills_for_Humanoid_Robots____A_Progressive_Perception-Action_Fr.html",
+        "dir": "Learning_Soccer_Skills_for_Humanoid_Robots____A_Progressive_Perception-Action_Fr",
+        "arxiv": "2602.05310",
+        "zhname": "面向仿人机器人足球技能的渐进式感知-动作学习框架"
       }
     ],
     "zhname": "运动操作与全身控制"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="header-inner">
     <a href="{{ '/' | relative_url }}" class="site-title" aria-label="Home - Humanoid Robot Learning Paper Notebooks">📚 Humanoid Robot Learning Paper Notebooks | 人形机器人学习论文笔记</a>
     <div class="header-right">
-      <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" class="github-link" target="_blank" aria-label="View source on GitHub">GitHub</a>
+      <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="View source on GitHub">GitHub</a>
       <button id="lang-toggle" class="lang-toggle" aria-label="Switch language">
         <span class="lang-label">中文</span>
       </button>

--- a/papers/04_Loco-Manipulation_and_WBC/ZeroWBC__Learning_Natural_Visuomotor_Humanoid_Control_from_Egocentric_Video/ZeroWBC__Learning_Natural_Visuomotor_Humanoid_Control_from_Egocentric_Video.md
+++ b/papers/04_Loco-Manipulation_and_WBC/ZeroWBC__Learning_Natural_Visuomotor_Humanoid_Control_from_Egocentric_Video/ZeroWBC__Learning_Natural_Visuomotor_Humanoid_Control_from_Egocentric_Video.md
@@ -2,7 +2,7 @@
 layout: paper
 paper_order: 27
 title: "ZeroWBC: Learning Natural Visuomotor Humanoid Control Directly from Human Egocentric Video"
-zhname: "ZeroWBC：直接从人类第一人称视频中学出"零遥操作"的人形视触运动控制"
+zhname: 'ZeroWBC：直接从人类第一人称视频中学出"零遥操作"的人形视触运动控制'
 category: "Loco-Manipulation and WBC"
 ---
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: A `target="_blank"` external link pointing to GitHub in `_includes/header.html` was missing the `rel="noopener noreferrer"` attributes.
🎯 Impact: This exposes the site to "Reverse Tabnabbing," where the newly opened tab could manipulate the `window.opener` object to redirect the original page to a malicious URL.
🔧 Fix: Added `rel="noopener noreferrer"` to the external link. Also fixed a YAML syntax error in a markdown file that was causing build failures.
✅ Verification: Ensure the GitHub link opens in a new tab securely without exposing the `window.opener` object. Run `python scripts/prepare_pages.py` and `bundle exec jekyll build` to verify the build is successful.

---
*PR created automatically by Jules for task [11100277896363722957](https://jules.google.com/task/11100277896363722957) started by @ImChong*