### PR TITLE
[SUPERSEDED by #54] chore(config): 清理重复 YAML 键、补 .editorconfig、修 pycodestyle 警告

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ kramdown:
   input: GFM
   hard_wrap: false
   syntax_highlighter: rouge
-  syntax_highlighter: rouge
   syntax_highlighter_opts:
     css_class: 'highlight'
 

--- a/scripts/sync_progress.py
+++ b/scripts/sync_progress.py
@@ -5,6 +5,7 @@ import glob
 PROGRESS_FILE = 'progress.json'
 PAPERS_DIR = 'papers'
 
+
 def is_stub(content):
     lines = content.splitlines()
     if len(lines) < 80:
@@ -14,6 +15,7 @@ def is_stub(content):
     if content.count('🚧') >= 5:
         return True
     return False
+
 
 def sync():
     with open(PROGRESS_FILE, 'r') as f:
@@ -26,14 +28,14 @@ def sync():
 
     # Walk papers dir
     md_files = glob.glob(os.path.join(PAPERS_DIR, '**/*.md'), recursive=True)
-    
+
     # Filter out PROGRESS.md if any
     md_files = [f for f in md_files if 'PROGRESS.md' not in f and 'todos' not in f]
 
     for md_path in md_files:
         with open(md_path, 'r') as f:
             content = f.read()
-        
+
         # Simple front matter parser
         title = ""
         category = ""
@@ -42,10 +44,10 @@ def sync():
                 title = line.split(':', 1)[1].strip().strip('"')
             if line.startswith('category:'):
                 category = line.split(':', 1)[1].strip().strip('"')
-        
+
         folder = os.path.dirname(md_path)
         note_file = os.path.basename(md_path)
-        
+
         idx = folder_map.get(folder)
         if idx is None:
             # Try matching by title (vague match)
@@ -53,9 +55,9 @@ def sync():
                 if t in title or title in t:
                     idx = title_map[t]
                     break
-        
+
         status = 'done' if not is_stub(content) else 'pending'
-        
+
         if idx is not None:
             # Update existing
             papers_in_json[idx]['status'] = status
@@ -79,6 +81,7 @@ def sync():
     # Save
     with open(PROGRESS_FILE, 'w') as f:
         json.dump(progress, f, indent=2, ensure_ascii=False)
+
 
 if __name__ == '__main__':
     sync()

--- a/tests/test_prepare_pages.py
+++ b/tests/test_prepare_pages.py
@@ -1,39 +1,46 @@
-import pytest
-import sys
 import os
+import sys
 
 # Add the project root to sys.path to import from scripts
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scripts.prepare_pages import normalize_name
+from scripts.prepare_pages import normalize_name  # noqa: E402
+
 
 def test_normalize_name_basic():
     """Test basic lowercase conversion."""
     assert normalize_name("Hello World") == "hello world"
 
+
 def test_normalize_name_lowercase():
     """Test that all characters are lowercased."""
     assert normalize_name("PYTHON") == "python"
+
 
 def test_normalize_name_special_chars():
     """Test removal of special characters."""
     assert normalize_name("Paper Title: Subtitle!") == "paper title subtitle"
 
+
 def test_normalize_name_extra_spaces():
     """Test collapsing multiple spaces and stripping."""
     assert normalize_name("  extra   spaces  ") == "extra spaces"
+
 
 def test_normalize_name_alphanumeric():
     """Test that alphanumeric characters are preserved and others removed."""
     assert normalize_name("Agent-007") == "agent007"
 
+
 def test_normalize_name_empty_after_cleaning():
     """Test strings that become empty after cleaning."""
     assert normalize_name("!!!") == ""
 
+
 def test_normalize_name_numbers():
     """Test strings with numbers."""
     assert normalize_name("123 test 456") == "123 test 456"
+
 
 def test_normalize_name_mixed():
     """Test complex mixed input."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> ⚠️ **本 PR 已被 #54 取代**，不要合并此 PR。
>
> 原本拆分的 5 个 PR（#49 / #50 / #51 / #52 / #53）单独合并会互相 merge conflict，已合并到单一 PR **#54** —— 全部 cherry-pick + 解冲突 + 本地 lint/test/build 通过。
>
> 请关闭本 PR 并审 #54。

---

# 原内容

## 背景

代码质量审计（PR1/5）。本 PR 是 5 个独立改进 PR 中的第 1 个，专注于"零行为变化"的配置清理与编辑器一致性。

## 改动

- **`_config.yml`**：删除重复的 `syntax_highlighter: rouge`（第 11/12 行同名键，YAML 容忍但属噪音）。
- **`.editorconfig`**（新增）：统一 UTF-8、LF、最终空行；Python 4 空格、其它 2 空格；Markdown 保留 trailing whitespace（不破坏强制换行）。
- **`scripts/sync_progress.py`**：清理 6 处 W293（行内空白）、补 E302/E305 函数前后空行。
- **`tests/test_prepare_pages.py`**：移除未使用的 `pytest` import；为 `sys.path.append` 后的 import 加 `# noqa: E402`，并补 PEP 8 空行。

## 验证

- `pytest tests/ -v` → 8 passed
- `pyflakes scripts/ tests/` → 无输出
- `pycodestyle --max-line-length=120 scripts/ tests/` → 无输出
- `python3 -c "import yaml; yaml.safe_load(open('_config.yml').read())"` → kramdown 配置仍然正确

## 风险

极低 —— 纯清理，无脚本逻辑变化、无生成内容差异。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7edb7452-2b25-4ddb-bfb5-8afe3352375a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7edb7452-2b25-4ddb-bfb5-8afe3352375a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

