### PR TITLE
[SUPERSEDED by #54] chore(deps): 接入 Dependabot + 固定 Mermaid 版本 + 加 CDN SRI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  # Track third-party GitHub Actions for CVE patches and major-version bumps.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-minor:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Track Jekyll / jekyll-seo-tag and other RubyGems used by GitHub Pages.
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(gems)"
+    labels:
+      - "dependencies"
+      - "ruby"
+    groups:
+      bundler-minor:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Track Python dev dependencies (pytest / ruff) once requirements-dev.txt
+  # exists. Dependabot tolerates a missing manifest gracefully.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(pip)"
+    labels:
+      - "dependencies"
+      - "python"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,12 +6,23 @@
   <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>">
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
-  <!-- KaTeX -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
-  <!-- Mermaid -->
-  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <!-- KaTeX (pinned + SRI) -->
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+        integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV"
+        crossorigin="anonymous">
+  <script defer
+          src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+          integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8"
+          crossorigin="anonymous"></script>
+  <script defer
+          src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+          integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05"
+          crossorigin="anonymous"></script>
+  <!-- Mermaid (pinned + SRI) -->
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"
+          integrity="sha384-rbtjAdnIQE/aQJGEgXrVUlMibdfTSa4PQju4HDhN3sR2PmaKFzhEafuePsl9H/9I"
+          crossorigin="anonymous"></script>
   <script>
     function initMermaid(theme) {
       if (typeof mermaid === 'undefined') return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> ⚠️ **本 PR 已被 #54 取代**，不要合并此 PR。
>
> 原本拆分的 5 个 PR（#49 / #50 / #51 / #52 / #53）单独合并会互相 merge conflict，已合并到单一 PR **#54** —— 全部 cherry-pick + 解冲突 + 本地 lint/test/build 通过。
>
> 请关闭本 PR 并审 #54。

---

# 原内容

## 背景

代码质量审计 PR4/5。补齐"依赖健康度"和"CDN 资源完整性"。

## 改动

### `.github/dependabot.yml`（新）

三套生态每周一同时检查：

| 生态 | 跟踪对象 | commit prefix | label |
|---|---|---|---|
| `github-actions` | `actions/checkout`、`jekyll-build-pages` 等 | `chore(actions)` | `dependencies` / `github-actions` |
| `bundler` | `jekyll`、`jekyll-seo-tag` | `chore(gems)` | `dependencies` / `ruby` |
| `pip` | `pytest`、`ruff`（PR3 引入的 `requirements-dev.txt`） | `chore(pip)` | `dependencies` / `python` |

minor / patch 升级合并成一个 PR（grouped），减少噪音；major 单独提 PR 以便人工审。

### `_layouts/default.html`

**1. 固定 Mermaid 版本**：原本是 `mermaid/dist/mermaid.min.js`（=jsdelivr `latest`），任何时候 jsdelivr 升 major 都可能直接破坏所有 mermaid 图渲染。改为固定 `mermaid@11.4.1`。

**2. 加 SRI（Subresource Integrity）**：给 KaTeX 的 css / js / auto-render.js，以及 Mermaid 11.4.1，全部加上 sha384 integrity + crossorigin="anonymous"。如果 CDN 被入侵或被错误覆盖，浏览器会拒绝执行被篡改的脚本。

哈希计算方式：

```bash
curl -sL https://cdn.jsdelivr.net/npm/<pkg>@<ver>/dist/<file> \
  | openssl dgst -sha384 -binary | openssl base64 -A
```

四个新增 integrity 都是从 jsdelivr 现网资源即时计算得到。

## 验证

- `git diff _layouts/default.html` — 看到 4 条 SRI 对应原 4 条 CDN 引用。
- 之后 GitHub Pages 重新部署时，浏览器加载页面应无 CSP/SRI 错误（KaTeX 公式仍渲染、Mermaid 图仍渲染）。

## 风险

- 低 / 中。SRI 的风险是：未来想升级 KaTeX/Mermaid 版本时**必须同步更新 integrity 哈希**，否则 CDN 上拿到的新文件会被浏览器拒绝。建议把这个流程写进 `CONTRIBUTING.md`（后续可做）。
- Dependabot 第一次启用后会瞬间开几条 PR（github-actions 当前固定在 `@v4` / `@v5`，jekyll 也有 4.4.x 等），需要人工 review 一波。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7edb7452-2b25-4ddb-bfb5-8afe3352375a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7edb7452-2b25-4ddb-bfb5-8afe3352375a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

