### PR TITLE
security: 收紧 mermaid + 修复 KaTeX innerHTML 反转 XSS + 加 CSP

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--
+    CSP (defence-in-depth). Static site, no fetch/XHR — only KaTeX & mermaid
+    are loaded from jsdelivr. ``'unsafe-inline'`` is unfortunately required by
+    the inline <script>/<style> blocks below and by mermaid's generated SVG
+    style attrs; tighten further by externalising scripts in the future.
+  -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; font-src 'self' https://cdn.jsdelivr.net data:; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'none'">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>">
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
@@ -30,7 +38,10 @@
         startOnLoad: false,
         theme: theme === 'dark' ? 'dark' : 'default',
         flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
-        securityLevel: 'loose',
+        // 'strict' runs labels through DOMPurify (blocks <script>, on*= handlers, javascript: URLs)
+        // while still permitting <br/> and basic formatting our diagrams need.
+        // Do NOT use 'loose' — it lets a malicious notebook plant XSS via labels or click directives.
+        securityLevel: 'strict',
       };
       mermaid.initialize(config);
       window.roadmapMermaidConfigured = true;
@@ -279,27 +290,30 @@
     function initKaTeX() {
       if (typeof renderMathInElement === 'undefined') return false;
 
-      // Fix HTML entities inside math before rendering
-      // Kramdown converts > to &gt; and < to &lt; inside table cells etc.
-      document.querySelectorAll('td, th, li, p, span, strong, em, b, i, h1, h2, h3, h4, h5, h6').forEach(function(el) {
-        var html = el.innerHTML;
-        // Only process if there's a math delimiter that suggests math content
-        if (html.indexOf('$') === -1 && html.indexOf('\\(') === -1 && html.indexOf('\\[') === -1) return;
-
-        // ⚡ Bolt Optimization: Early return if there are no HTML entities to replace, preventing expensive regex execution.
-        if (html.indexOf('&gt;') === -1 && html.indexOf('&lt;') === -1 && html.indexOf('&amp;') === -1) return;
-
-        // Replace HTML entities back inside math delimiters (only if they are inside math blocks)
-        var mathRegex = /(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\]|\$[\s\S]*?\$|\\\([\s\S]*?\\\))/g;
-        var newHtml = html.replace(mathRegex, function(match) {
+      // Fix HTML entities inside math delimiters before KaTeX scans the DOM.
+      //
+      // SECURITY: the previous version did `el.innerHTML = ...` after
+      // unescaping &lt;/&gt;/&amp;, which turned `$<img onerror=...>$` in a
+      // notebook into a real <img> element when the page rendered (stored
+      // XSS, exploitable by anyone whose markdown reaches main).
+      //
+      // Walk text nodes only and mutate ``nodeValue`` in place. ``nodeValue``
+      // is plain string data — assigning to it never re-parses HTML, so even
+      // if the unescape introduces ``<`` characters they remain literal text.
+      var mathRegex = /(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\]|\$[\s\S]*?\$|\\\([\s\S]*?\\\))/g;
+      var walker = document.createTreeWalker(
+        document.body, NodeFilter.SHOW_TEXT, null
+      );
+      var textNode;
+      while ((textNode = walker.nextNode())) {
+        var v = textNode.nodeValue;
+        if (!v || (v.indexOf('$') === -1 && v.indexOf('\\(') === -1 && v.indexOf('\\[') === -1)) continue;
+        if (v.indexOf('&gt;') === -1 && v.indexOf('&lt;') === -1 && v.indexOf('&amp;') === -1) continue;
+        var fixed = v.replace(mathRegex, function (match) {
           return match.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
         });
-
-        // ⚡ Bolt Optimization: Only mutate DOM if string actually changed to prevent layout thrashing
-        if (newHtml !== html) {
-          el.innerHTML = newHtml;
-        }
-      });
+        if (fixed !== v) textNode.nodeValue = fixed;
+      }
 
       renderMathInElement(document.body, {
         delimiters: [


### PR DESCRIPTION
## 总结

来自一次站点静态安全审计的 3 处加固，全部命中 `_layouts/default.html`，**不动任何论文笔记内容**。

## 改动

| # | 位置 | 修改 | 影响 |
|---|---|---|---|
| 1 | `_layouts/default.html:44` | mermaid `securityLevel: 'loose'` → **`'strict'`** | 封堵 `click NodeName "javascript:..."` 与节点标签内的 `<script>`/`onerror` |
| 2 | `_layouts/default.html:295-316` | KaTeX 实体反转改用 `TreeWalker` 遍历 text node，删掉危险的 `el.innerHTML = ...` 写回 | 修复任何能合 PR 的人都能投毒的存储型 XSS |
| 3 | `_layouts/default.html:6-13` | 加 `<meta http-equiv="Content-Security-Policy">` + `<meta name="referrer">` | 防御纵深 + 防 paper URL 泄漏给第三方 |

## PoC（修复前可触发）

**KaTeX 路径**（任何笔记里写一行就能弹）：

```markdown
$ <img src=x onerror=alert(1)> $
```

kramdown 编码后是 `$&lt;img...&gt;$` → 旧 JS 在 `$...$` 内反转 entity → `el.innerHTML =` 写回 → 浏览器重新解析为真 `<img>` 元素 → `onerror` 触发。

**mermaid 路径**：

```
flowchart TB
  A["<img src=x onerror=alert(document.cookie)>"]
  click A "javascript:alert('1')"
```

`securityLevel: 'loose'` 直接放行；`'strict'` 让 mermaid 把 label 走 DOMPurify，自动剥掉事件处理器。

## CSP 详情

```
default-src 'self';
script-src  'self' https://cdn.jsdelivr.net 'unsafe-inline';
style-src   'self' https://cdn.jsdelivr.net 'unsafe-inline';
font-src    'self' https://cdn.jsdelivr.net data:;
img-src     'self' data: https:;
connect-src 'self';
frame-ancestors 'none';   # 防点击劫持
base-uri    'self';
object-src  'none';
form-action 'none';
```

`'unsafe-inline'` 暂保留，因为页面有多处 inline `<script>`（语言切换、KaTeX 初始化、mermaid 路线图等）。后续把它们抽到外部 `.js` 文件后可以收紧。

## Test plan

- [x] `python scripts/prepare_pages.py` 输出与 main 一致（59 篇 / 14 类）
- [x] `pytest tests/` 18/18 通过
- [ ] 部署后访问任一论文页，确认：
  - mermaid 流程图（路线图、4 算法对比、单图）正常渲染
  - KaTeX 数学公式正常渲染（如 PHC、PPO 笔记里的公式）
  - DevTools Console 无 CSP 违规报错
- [ ] 部署后访问主页，确认搜索、语言切换、主题切换都正常

## 后续（可选，未在本 PR 范围）

- `data-search="{{ paper.title | xml_escape }}"` 等 Liquid 属性输出统一加 `xml_escape`
- `assets/js/paper.js` 的 nav HTML 拼接改 `createElement` + `textContent`
- inline `<script>` 抽外部文件后，CSP 去 `'unsafe-inline'`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUKj5vqLfRa5N78v1i8PqJ)_