### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in Mermaid diagram processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Found a `target="_blank"` link pointing to GitHub in `_includes/header.html` without the `rel="noopener noreferrer"` attribute.
 **Learning:** This is a classic "Reverse Tabnabbing" vulnerability where the newly opened tab can gain access to the `window.opener` object and potentially redirect the original page to a malicious site.
 **Prevention:** Always add `rel="noopener noreferrer"` to external links that open in a new tab via `target="_blank"`.
+## 2025-05-09 - [DOM-based XSS in Mermaid Rendering]
+**Vulnerability:** Found a DOM-based XSS vulnerability in `_layouts/default.html` where Mermaid diagram content stored in `data-original-code` was restored using `el.innerHTML = el.getAttribute('data-original-code')`.
+**Learning:** If a markdown file contains a malicious Mermaid block (e.g., `<img src=x onerror=alert(1)>`), the script will assign the unescaped payload directly to `innerHTML`, triggering XSS.
+**Prevention:** Always use `textContent` when retrieving or assigning raw strings or code definitions to prevent them from being parsed and executed as HTML.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,13 +49,13 @@
       // 1. Re-render paper notebook diagrams if they have original code
       document.querySelectorAll('.mermaid[data-original-code]:not(#roadmap-mermaid)').forEach(function(el) {
         el.removeAttribute('data-processed');
-        el.innerHTML = el.getAttribute('data-original-code');
+        el.textContent = el.getAttribute('data-original-code');
       });
 
       // 2. For any other mermaid blocks that might not have original code yet
       document.querySelectorAll('.mermaid:not([data-original-code]):not(#roadmap-mermaid)').forEach(function(el) {
         if (el.textContent.trim().length > 0) {
-          el.setAttribute('data-original-code', el.innerHTML);
+          el.setAttribute('data-original-code', el.textContent);
         }
       });
 


### PR DESCRIPTION
This PR resolves a DOM-based Cross-Site Scripting (XSS) vulnerability.

**🚨 Severity**: HIGH
**💡 Vulnerability**: The `_layouts/default.html` template previously read the `data-original-code` attribute containing Mermaid diagram definitions and assigned it back to `el.innerHTML`. If a user injected a payload like `<img src="x" onerror="alert(1)">` inside a mermaid block in their markdown file, it would be executed when restoring the view.
**🎯 Impact**: If exploited, this could allow arbitrary JavaScript execution in the browser of anyone viewing the markdown page, which is particularly severe if the repository accepts external contributions or renders user-supplied markdown.
**🔧 Fix**: Replaced `el.innerHTML` with `el.textContent` for both reading and writing the `data-original-code` attribute. `textContent` safely handles the content as raw text, preventing execution while properly providing the graph definition to Mermaid.
**✅ Verification**: Ran Jekyll build and verified tests pass. An XSS payload in a markdown mermaid block will now safely render as raw string text instead of executing. Added a learning log entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7822240274325769870](https://jules.google.com/task/7822240274325769870) started by @ImChong*