### PR TITLE
docs(Meta): 添加 Cursor Cloud 开发环境说明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,33 @@ docs(Meta): 添加 agents 协作说明
 chore(Progress): 更新论文阅读进度
 ```
 
+## Cursor Cloud specific instructions
+
+### Services overview
+
+This is a Jekyll 4.3 static site with Python preprocessing scripts. Two runtimes are needed:
+
+| Component | Purpose | Commands |
+|-----------|---------|----------|
+| Python scripts | Preprocess Markdown → add YAML front matter, generate `_data/papers.json` | `python3 scripts/prepare_pages.py` |
+| Jekyll | Build & serve the static site | `bundle exec jekyll serve --host 0.0.0.0 --port 4000` |
+
+### Running locally
+
+1. **Preprocess**: `python3 scripts/prepare_pages.py` (must run before Jekyll build whenever paper `.md` files change).
+2. **Serve**: `bundle exec jekyll serve --host 0.0.0.0 --port 4000` — site is at `http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/`.
+3. Jekyll auto-rebuilds on file changes (LiveReload not configured; refresh browser manually).
+
+### Lint & Test
+
+- Lint: `ruff check scripts/ tests/`
+- Test: `pytest -v`
+- Both are in `PATH` at `~/.local/bin` (user-installed via pip).
+
+### Gotchas
+
+- `python` is not symlinked on this VM — always use `python3`.
+- `bundle install` must run with `sudo` (gems install to `/var/lib/gems/`); `bundle exec jekyll ...` does NOT need sudo.
+- There is no `Gemfile.lock` committed; Bundler resolves versions fresh on each install.
+- The `baseurl` in `_config.yml` is `/Humanoid_Robot_Learning_Paper_Notebooks` — local URLs always include this prefix.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add Cursor Cloud-specific development instructions to `AGENTS.md` so future cloud agents can quickly start the Jekyll dev server, run lint/tests, and understand environment gotchas.

### Changes
- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:
  - Services overview (Python preprocessing + Jekyll)
  - Local run commands
  - Lint & test commands
  - Environment gotchas (python3 vs python, sudo for bundle install, baseurl prefix, no Gemfile.lock)

### Evidence of working environment

[jekyll_site_demo.mp4](https://cursor.com/agents/bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjekyll_site_demo.mp4)

Homepage with paper listings and categories:
[Homepage with paper listings](https://cursor.com/agents/bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_papers_listing.webp)

Search/filter working (PPO query):
[Search results for PPO](https://cursor.com/agents/bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_filter_ppo.webp)

Paper detail page:
[Paper detail page](https://cursor.com/agents/bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpaper_detail_page.webp)

Chinese language toggle:
[Homepage in Chinese mode](https://cursor.com/agents/bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_chinese_mode.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d4a95c7-62af-4cf2-a2b6-2f1a46d4ac57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

