### PR TITLE
fix(CI): 修复 Pages 部署 sanitize 因 _site 权限失败

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,10 @@ jobs:
           source: ./
           destination: ./_site
 
+      # jekyll-build-pages runs in Docker as root; host steps cannot rewrite _site without this.
+      - name: Fix _site ownership for follow-up steps
+        run: sudo chown -R "$(id -un)":"$(id -gn)" _site
+
       - name: Sanitize paper page HTML (stored XSS mitigation)
         run: python3 scripts/sanitize_paper_html.py _site
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

`Deploy to GitHub Pages` 在 **Sanitize paper page HTML** 步骤失败：`PermissionError` 无法写入 `_site/.../*.html`。

原因：`actions/jekyll-build-pages` 在 Docker 内以 **root** 生成 `_site`，而 sanitize 在宿主机上以 **runner** 用户运行，无法覆盖 root 拥有的文件。

## 修改

在 Jekyll 构建之后、sanitize 之前增加一步：`sudo chown -R "$(id -un)":"$(id -gn)" _site`，使后续步骤与 artifact 上传能以当前用户访问/改写 `_site`。

## 验证

- 与 [失败 run](https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks/actions) 日志中的报错路径一致；合入后应能通过同一工作流。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-330657ef-b168-409c-8049-ef7e48686a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-330657ef-b168-409c-8049-ef7e48686a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

