### PR TITLE
style(Layout): 主栏宽度与 imchong.github.io 对齐（960px）

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -75,7 +75,7 @@ body {
 }
 
 .header-inner {
-  max-width: 900px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 8px 24px;
   min-height: 56px;
@@ -128,9 +128,9 @@ body {
 
 /* ===== Container ===== */
 .container {
-  max-width: 860px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 2rem 1.5rem;
+  padding: 2rem 24px;
 }
 
 /* Paper pages: shift right to make room for left TOC */
@@ -865,7 +865,7 @@ body {
 }
 
 .footer-inner {
-  max-width: 900px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 0 24px;
   text-align: center;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将站内主内容区与页头、页脚的横向 `max-width` 统一为与 [imchong.github.io](https://imchong.github.io/index.html) 相同的 **960px**，并把 `.container` 的水平内边距从 `1.5rem` 改为 **24px**，与参考站点 `.container` / `.header-inner` 的左右留白一致。

## 变更

- `assets/css/style.css`：`header-inner`、`container`、`footer-inner` 的 `max-width` 由 900/860/900px 调整为 960px；`.container` 使用 `padding: 2rem 24px`（保留纵向节奏，横向与参考站对齐）。

## 验证

- `pip install -r requirements-dev.txt` 后：`python3 -m ruff check scripts/ tests/`、`python3 -m pytest -v`（27 项）均通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bbb948d-6c8d-41b7-b48a-d10e828296c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bbb948d-6c8d-41b7-b48a-d10e828296c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

