### PR TITLE
docs(论文笔记): 动作重定向模块新增 NMR 与 ReActor

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -137,6 +137,22 @@
         "dir": "Retargeting_Matters__General_Motion_Retargeting_for_Humanoid_Motion_Tracking",
         "arxiv": "2510.02252",
         "zhname": "Retargeting Matters：面向人形运动跟踪的通用动作重定向"
+      },
+      {
+        "title": "Make Tracking Easy: Neural Motion Retargeting for Humanoid Whole-body Control",
+        "path": "papers/02_Motion_Retargeting/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control.md",
+        "url": "/papers/02_Motion_Retargeting/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control.html",
+        "dir": "Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control",
+        "arxiv": "2603.22201v3",
+        "zhname": "让跟踪变简单：面向人形全身控制的神经动作重定向（NMR）"
+      },
+      {
+        "title": "ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting",
+        "path": "papers/02_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting.md",
+        "url": "/papers/02_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting.html",
+        "dir": "ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting",
+        "arxiv": "2605.06593v1",
+        "zhname": "ReActor：面向物理可行动作重定向的强化学习"
       }
     ],
     "subtitle": "Bridging human motion data and humanoid policies — geometric IK, learned retargeting, and the engineering choices that determine downstream policy quality",

--- a/papers/02_Motion_Retargeting/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control.md
+++ b/papers/02_Motion_Retargeting/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control.md
@@ -1,0 +1,160 @@
+---
+layout: paper
+title: "Make Tracking Easy: Neural Motion Retargeting for Humanoid Whole-body Control"
+zhname: "让跟踪变简单：面向人形全身控制的神经动作重定向（NMR）"
+category: "Motion Retargeting"
+paper_order: 2
+---
+
+# Make Tracking Easy: Neural Motion Retargeting for Humanoid Whole-body Control
+**把重定向从「每帧非凸优化」改成「可学习的分布映射」，再用物理仿真把监督信号洗干净**
+
+> 📅 阅读日期: 2026-05-13
+> 🏷️ 板块: Motion Retargeting
+> ℹ️ 笔记已对照 [arXiv HTML 2603.22201v3](https://arxiv.org/html/2603.22201v3) 全文结构整理；定量表格与实现细节以论文原文为准。
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|------|------|
+| **arXiv** | [2603.22201v3](https://arxiv.org/abs/2603.22201) |
+| **HTML 全文** | [2603.22201v3 (HTML)](https://arxiv.org/html/2603.22201v3) |
+| **PDF** | [arXiv PDF](https://arxiv.org/pdf/2603.22201v3.pdf) |
+| **发布时间** | 2026 年 3 月（arXiv） |
+| **硬件平台** | Unitree G1（全身动态技能实验） |
+
+**作者**: Qingrui Zhao, Kaiyue Yang, Xiyu Wang, Shiqi Zhao, Yi Lu, Xinfang Zhang, Qiu Shen, Xiao-Xiao Long*, Xun Cao*（南京大学等）
+
+**一行定位**：在「人体 SMPL 序列 → 人形关节轨迹」这一环节，用 **NMR（Neural Motion Retargeting）** 直接学习时序映射；用 **CEPR（Clustered-Expert Physics Refinement）** 先批量生成「物理上站得住脚」的人机配对数据，解决监督信号里混着 IK 局部最优噪声的鸡生蛋问题。
+
+---
+
+## 🎯 一句话总结
+
+论文先用 Hessian 论证传统几何 / 优化式重定向（含 GMR 这类强基线）在 **SE(3) 对数映射 + 前向运动学曲率** 下会出现 **负曲率方向**，因而对初始化敏感、易产生关节跳变与自穿；随后把重定向改写成 **从人体运动分布到机器人可行流形上的监督学习**，配合 **聚类 + 多专家 RL 物理精修** 得到约 **3 万条** 高质量配对序列，再训练 **CNN 编码 + 全连接自注意力 Transformer（非自回归）** 的网络，在 G1 上显著抑制关节不连续与自碰撞，并加速下游全身控制策略收敛。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 | 一句话 |
+|------|------|--------|
+| **NMR** | Neural Motion Retargeting | 学习式、时序感知的 SMPL→机器人映射 |
+| **CEPR** | Clustered-Expert Physics Refinement | 聚类后分簇训练 RL 专家，用仿真 rollout 生成物理一致监督 |
+| **GMR** | General Motion Retargeting | 论文中作为运动学重定向与过滤的前级（Araujo et al., 2025） |
+| **TMR** | Text–Motion Retrieval 类表征 | 用于把动作编码到可与文本对齐的潜空间再做 K-Means |
+| **PPO** | Proximal Policy Optimization | 各簇专家跟踪策略的训练算法 |
+| **6D rotation** | 连续旋转表示 | 网络里根姿态用 6D 表示以降低不连续 |
+
+---
+
+## ❓ 论文在回应哪两个「老问题」？
+
+1. **优化式重定向的非凸与局部最优**：逐帧 IK / 微分优化在实践里会留下关节速度尖峰、自穿透、脚滑等瑕疵；这些瑕疵不会 magically 被下游 tracking 消化，反而逼迫策略学补偿动作。
+2. **监督学习缺干净数据**：若直接用 GMR 输出当标签，会 **继承同样的失败模式**；作者因此把「好标签」定义成 **在物理仿真里能被 RL 专家稳定复现的轨迹**，而不是单次优化器的 argmin。
+
+---
+
+## 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    subgraph DATA["CEPR：从 SMPL 到物理一致配对"]
+        S1["原始 SMPL 库"] --> S2["物理感知筛选<br/>（急动度 / CoM 支撑 / 脚接触）"]
+        S2 --> S3["GMR 运动学重定向"]
+        S3 --> S4{"硬阈值过滤<br/>关节速度 / 自碰比例 / 脚漂浮"}
+        S4 --> S5["TMR 潜表征 + K-Means 聚类"]
+        S5 --> S6["每簇并行训练 PPO 跟踪专家"]
+        S6 --> S7["专家 rollout 记录机器人状态<br/>与 SMPL 对齐成对"]
+    end
+
+    subgraph NET["NMR 网络与两阶段训练"]
+        K1["大规模运动学数据"] --> T1["阶段1：L1 预训练<br/>CNN + 全连接自注意力 Transformer"]
+        S7 --> T2["约 3 万条物理配对"]
+        T1 --> T3["阶段2：在 CEPR 数据上微调<br/>把输出拉向可行流形"]
+        T2 --> T3
+    end
+
+    subgraph DOWN["下游"]
+        T3 --> D1["参考轨迹质量提升"]
+        D1 --> D2["全身控制 / tracking 策略更快收敛"]
+    end
+
+    style DATA fill:#e8f4fd,stroke:#1f78b4
+    style NET fill:#fdebd0,stroke:#e67e22
+    style DOWN fill:#e8f8e8,stroke:#27ae60
+</div>
+
+---
+
+## 🔧 方法详解
+
+### 1. 非凸性动机（III-A）
+
+论文在简化 surrogate 代价上写出 Hessian 的 **Gauss–Newton 正定项 + 曲率修正项**；说明除雅可比项外，**对数映射与运动学递归组合** 可产生 **负方向曲率**，从而解释「为何几何重定向会卡局部最优」——这不是实现小毛病，而是结构问题。读者若做工程排障，可把这一段当成 **给 IK 调参失败找理论借口的说明书**。
+
+### 2. CEPR 三阶段数据管线（III-B）
+
+| 阶段 | 目的 | 要点 |
+|------|------|------|
+| **Step 1** | 语义与粗物理合理 | 过滤明显不适合机器人的片段（大 jerk、CoM 出支撑、脚接触不足） |
+| **Step 2** | 运动学候选 + 质检 | GMR 出初值；再用关节速度尖峰、MuJoCo 自碰比例、脚平均离地高度等规则剔除坏段 |
+| **Step 3** | 物理「精修」真标签 | 先聚类缓解「单策略拟合全库」的分布冲突；每簇训一个高维观测的 tracking expert；收敛后在参考上 rollout，得到 **(SMPL 序列, 仿真一致机器人轨迹)** |
+
+**聚类动机**：全文强调「一条 PPO 吃尽所有动作」会遇到 **distributional conflict**；折中方案是按 **语义相近** 的动作簇分别训专家，算力上比「每条序列一个策略」可行。
+
+### 3. 运动表示与网络（III-C）
+
+- 人体侧采用接近 MotionMillion 的字段：**根平面速度、根 6D 朝向、局部关节位置与速度**。
+- 机器人侧在同样信息上 **追加关节 DoF** \(q\)。
+- 网络：**1D ResNet 编码 → LLaMA 风格的 Transformer 块（此处用双向自注意力，利用全序列上下文）→ 上采样 + 1D 卷积解码**，整体 **非自回归**，一次前向预测整段对齐序列。
+- 损失：对预测机器人表示 \(\hat{m}_{\text{bot}}\) 与目标做 **L1**。
+
+### 4. 「先大后小」两阶段训练（III-D）
+
+- **阶段 1（运动学预训练）**：数据量大、覆盖面广，学会 **embodiment 映射的主干**。
+- **阶段 2（CEPR 微调）**：数据量小一个量级左右，但每条都经过 **RL+物理引擎** 筛选，负责把分布 **拉向动态可行集**。
+- 消融逻辑：只做其一会出现 **缺物理** 或 **缺泛化** 的经典 trade-off，论文用「NMR w/o RL 微调」等实验支撑这一点。
+
+---
+
+## 📊 实验侧读者该抓什么？
+
+- **artifact 指标**：关节跳变、自碰撞、关节限位违反相对强基线（含 GMR）是否系统下降。
+- **下游效率**：用 NMR 轨迹作为参考时，全身控制 / tracking 训练是否 **更快收敛、终端误差更低**。
+- **任务多样性**：武术、舞蹈等高动态片段上的定性视频对比，对应论文强调的「绕开几何陷阱」。
+
+---
+
+## 🤔 自测问答
+
+**Q1：NMR 还需要在线跑 GMR 吗？**  
+A：训练管线里 GMR 主要承担 **廉价大规模初值**；推理时网络一旦部署，理想情况是 **端到端从 SMPL 特征直出机器人轨迹**，具体工程是否保留 GMR 作 warm-start 属于系统实现选择，论文重心在 **学习式替代逐帧优化**。
+
+**Q2：CEPR 和 PHC / 大规模 tracking 数据建设有何异同？**  
+A：精神相近：都用 **物理仿真 + RL** 把「看起来对」变成「能站得住」。差异在于本文把这条管线 **明确服务神经重定向的监督构造**，并引入 **聚类专家** 降低单策略多模态冲突。
+
+**Q3：最该小心的工程假设是什么？**  
+A：**仿真域 gap**：专家标签再干净也仍是 MuJoCo（或同类）动力学下的真理；上真机仍需结合硬件限幅、延迟与接触模型差异做验证。
+
+---
+
+## 🔗 相关笔记与外链
+
+- 同板块几何强基线：[Retargeting Matters (GMR)](https://arxiv.org/abs/2510.02252) — 仓库笔记路径 `papers/02_Motion_Retargeting/Retargeting_Matters__...`
+- 本文 arXiv HTML：[2603.22201v3](https://arxiv.org/html/2603.22201v3)
+
+---
+
+## 📚 引用（BibTeX 备忘）
+
+```bibtex
+@article{zhao2026make,
+  title={Make Tracking Easy: Neural Motion Retargeting for Humanoid Whole-body Control},
+  author={Zhao, Qingrui and Yang, Kaiyue and Wang, Xiyu and others},
+  journal={arXiv preprint arXiv:2603.22201},
+  year={2026}
+}
+```

--- a/papers/02_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting.md
+++ b/papers/02_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting.md
@@ -1,0 +1,163 @@
+---
+layout: paper
+title: "ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting"
+zhname: "ReActor：面向物理可行动作重定向的强化学习"
+category: "Motion Retargeting"
+paper_order: 3
+---
+
+# ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting
+**双层优化：上层调「跨本体映射参数」，下层用 RL 在物理仿真里把参考轨迹「跑成」可跟踪的样子**
+
+> 📅 阅读日期: 2026-05-13
+> 🏷️ 板块: Motion Retargeting
+> ℹ️ 笔记已对照 [arXiv HTML 2605.06593v1](https://arxiv.org/html/2605.06593v1) 与 arXiv 元数据（SIGGRAPH 2026 / TOG）整理；实现与定理细节以原文为准。
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|------|------|
+| **arXiv** | [2605.06593v1](https://arxiv.org/abs/2605.06593) |
+| **HTML 全文** | [2605.06593v1 (HTML)](https://arxiv.org/html/2605.06593v1) |
+| **PDF** | [arXiv PDF](https://arxiv.org/pdf/2605.06593v1.pdf) |
+| **会议 / 期刊** | **SIGGRAPH 2026**（arXiv `comment` 标注）；ACM TOG 正式出版信息见论文页 |
+| **发布时间** | 2026 年 5 月（arXiv） |
+
+**作者**: David Müller, Agon Serifi, Sammy Christen, Ruben Grandia, Espen Knoop, Moritz Bächer
+
+**一行定位**：把「生成可模仿参考」与「学会跟踪它」放进 **同一个物理仿真回路**：**上层**优化少量、可解释的重定向参数 \(\mathbf{p}\)，**下层**用 RL 学 \(\pi_\phi(a|o,g)\) 跟踪由 \(\mathbf{p}\) 诱导的参考 \(\mathbf{g}_t\)；用 **TTSA 式双时间尺度更新** 与 **对上层梯度的结构化近似**，避免在每个内层 RL 收敛后再求隐式 Hessian 那种不现实开销。
+
+---
+
+## 🎯 一句话总结
+
+针对传统几何重定向需要 **手工接触模板 / 大量调参**、且仍产生 **脚滑、自碰、动力学不可行** 等问题，ReActor 提出 **物理感知、RL 内嵌的双层框架**：用户只给 **稀疏语义刚体对应** 与名义姿态对齐，系统自动搜索一组 **有界偏移参数** 把源运动 \(\mathbf{m}_t\) 映到参数化参考 \(\mathbf{g}_t(\mathbf{p})\)；下层策略在仿真里跟踪 \(\mathbf{g}_t\)，上层最小化 \(\mathbf{g}\) 与仿真 rollout 状态 \(\mathbf{s}_t\) 的误差。论文在 **两台人形 + 四足** 上展示跨大差异本体的重定向，并分析近似梯度与泛化行为。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 | 备注 |
+|------|------|------|
+| **TTSA** | Two-Timescale Stochastic Approximation | 上层慢、下层快（相对）联合更新 |
+| **RFC** | Residual Force Control | 根上施辅助力矩帮助跨数据集泛化；论文对 wrench 施惩罚与死区 |
+| **RSI** | Reference State Initialization | 经典 motion imitation 技巧；本文因本体不同需改初始化 |
+| **AMASS** | 大规模人体动作库 | 实验数据来源之一 |
+
+---
+
+## ❓ 和「DeepMimic 式模仿」差在哪？
+
+- **DeepMimic**：给定一条（多半已手工修好）参考，RL 学跟踪。
+- **ReActor**：参考本身 **尚未** 与目标机器人对齐；**同时**学「怎么改参考」与「怎么跟改完的参考」。  
+换言之，它补的是 **embodiment gap 的上游**，而不是只优化下游 tracking 增益。
+
+---
+
+## 🧭 双层优化结构（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    subgraph UPPER["上层：重定向参数 p"]
+        P0["用户：稀疏刚体语义对应 + 名义姿态"] --> P1["全局尺度 s + nominal 变换<br/>（自动从输入抽取）"]
+        P1 --> P2["有界可学习偏移<br/>p_pos, p_ori, p_z"]
+        P2 --> G["参数化参考轨迹 g_t(p)"]
+    end
+
+    subgraph LOWER["下层：RL 跟踪"]
+        G --> RL["策略 pi_phi(a|o,g_t)"]
+        RL --> SIM["物理仿真 + 接触动力学"]
+        SIM --> S["状态 rollout s_t"]
+    end
+
+    S --> L["上层损失 L = E[l(g_t - s_t)]"]
+    L -->|"TTSA + 简化梯度 d_p L"| P2
+
+    subgraph OUT["输出"]
+        S --> O1["artifact 较少的参考运动"]
+        O1 --> O2["可直接用于下游模仿 / tracking 训练"]
+    end
+
+    style UPPER fill:#e8f4fd,stroke:#1f78b4
+    style LOWER fill:#fdebd0,stroke:#e67e22
+    style OUT fill:#e8f8e8,stroke:#27ae60
+</div>
+
+---
+
+## 🔧 方法详解
+
+### 1. 双层问题写法（Sec. 3）
+
+外层：\(\min_{\mathbf{p}\in\mathcal{P}} \mathcal{L}(\mathbf{p}, \phi^\*(\mathbf{p}))\)，约束 \(\phi^\*(\mathbf{p}) = \arg\max_\phi \mathcal{R}(\mathbf{p},\phi)\)。  
+内层：标准 **最大化回报** 的 RL；外层把 **仿真轨迹与参考的失配** 当监督。直觉上，\(\mathbf{p}\) 把「人」那边的帧 **抬到** 机器人能跟上的流形附近，\(\phi\) 负责在 **非光滑接触** 下真的跑起来。
+
+### 2. 上层梯度为何能「算得动」（Sec. 4）
+
+完全等内层收敛再对 \(\mathbf{p}\) 求导会爆炸慢。作者采用 **单循环 bilevel**，并在总导数
+
+\[
+\mathrm{d}_{\mathbf{p}} \ell(\mathbf{g}_t - \mathbf{s}^\*_t)
+  = \partial_{\mathbf{g}_t}\ell\,\mathrm{d}_{\mathbf{p}}\mathbf{g}_t
+  + \partial_{\mathbf{s}^\*_t}\ell\,\mathrm{d}_{\mathbf{p}}\mathbf{s}^\*_t
+\]
+
+里，利用 **对称损失** \(\partial_{\mathbf{s}}\ell = -\partial_{\mathbf{g}}\ell\) 与 **「最优轨迹对参考的响应可标量近似」** \(\mathrm{d}_{\mathbf{p}}\mathbf{s}^\* \approx \alpha \,\mathrm{d}_{\mathbf{p}}\mathbf{g}\) 的假设，把敏感项收成 **\((1-\alpha)\,\partial_{\mathbf{g}}\ell\,\mathrm{d}_{\mathbf{p}}\mathbf{g}\)** 的实用估计，再用当前策略 rollout 的样本做蒙特卡洛近似。读者可把 \(\alpha\) 理解成 **「机器人有多听话地跟着 g 走」** 的黑盒灵敏度旋钮。
+
+### 3. 参数化 \(\mathbf{g}_t\)（Sec. 5）
+
+- 从名义 T-pose 对齐开始：**根高度比** 给出全局尺度 \(s = h_{\text{target}}/h_{\text{source}}\)。
+- 对每个用户指定的刚体对，在源局部坐标里存 **常数 nominal 偏移** \(\mathbf{x}^b_{\text{nom}}, \mathbf{R}^b_{\text{nom}}\)，把缩放后的源骨架与目标帧对齐。
+- 优化变量：**小范数约束下的** \(\mathbf{p}^b_{\text{pos}}, \mathbf{p}^b_{\text{ori}}\) 以及 **每条运动的可学习竖直平移** \(p_z\)（处理 AMASS 类数据里残余的穿地 / 漂浮）。
+- 位置、线速度、角速度项用 **平方误差**；旋转用 **测地线 Log 映射范数**；对欠驱动关节可只惩罚 swing/twist 子分量。
+
+### 4. 下层 RL（Sec. 6 摘要）
+
+- **动作**：关节 PD 目标 + **根残差力矩（RFC）**，并对 wrench 做 **惩罚 + 连续死区**，鼓励在不需要时预测精确零外力。
+- **观测**：根高度、投影重力、根线角速度、关节状态、动作历史，外加 **retargeting phase 变量** \(\psi_t\)：用于在 episode 开头先把机器人 **摆到可跟踪姿态**，再逐步打开跟踪奖励（避免一上来就巨大误差）。
+- **初始化**：因本体不同，不能 RSI 到同构关节；改为 **源根状态 + 名义关节附近高斯扰动**，让策略自己学会对齐。
+
+---
+
+## 📊 实验阅读抓手
+
+1. **与几何 / 学习基线比**：脚滑、自碰、关节突变等 **artifact 指标** 是否稳定下降。  
+2. **下游 tracking**：用 ReActor 清洗后的参考训练控制器，样本效率与最终误差。  
+3. **跨形态**：四足等 **与人差异极大** 的本体，验证「稀疏对应 + 自动寻参」是否仍 work。  
+4. **消融**：去掉 bilevel 或近似梯度假设后，外层是否不稳定或陷入差解。
+
+---
+
+## 🤔 自测问答
+
+**Q1：RFC 会不会「作弊」把物理问题糊过去？**  
+A：论文明确区分 **retargeting vs motion imitation**：此处允许根辅助力是为了 **在形态差异极大时仍能跨 AMASS 学到通用跟踪器**，并通过 **强惩罚 + 死区** 逼策略在可行时关掉外力；下游若追求完全物理真实，可把 RFC 逐步收紧或换硬跟踪设定做第二阶段。
+
+**Q2：我要提供多少人工？**  
+A：**语义刚体对 + 根对 + 名义姿态**；不需要手写整条接触时间表——这与许多 IK 管线「先猜接触再优化」形成对比。
+
+**Q3：主要风险点？**  
+A：**假设 \(\mathrm{d}_{\mathbf{p}}\mathbf{s}^\* \approx \alpha \mathrm{d}_{\mathbf{p}}\mathbf{g}\)** 是实用近似而非严格定理；在强多模态接触任务上，外层可能仍需调 \(\eta\) 与损失权重 \(w_x, w_R, \ldots\) 的相对比例。
+
+---
+
+## 🔗 相关笔记与外链
+
+- 几何强基线（同板块）：`Retargeting_Matters__...`（GMR）
+- 神经分布映射视角：`Make_Tracking_Easy__...`（NMR，arXiv 2603.22201）
+- 本文 HTML：[2605.06593v1](https://arxiv.org/html/2605.06593v1)
+
+---
+
+## 📚 引用（BibTeX 备忘）
+
+```bibtex
+@article{muller2026reactor,
+  title={ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting},
+  author={M{\"u}ller, David and Serifi, Agon and Christen, Sammy and Grandia, Ruben and Knoop, Espen and B{\"a}cher, Moritz},
+  journal={arXiv preprint arXiv:2605.06593},
+  year={2026}
+}
+```

--- a/papers/02_Motion_Retargeting/Retargeting_Matters__General_Motion_Retargeting_for_Humanoid_Motion_Tracking/Retargeting_Matters__General_Motion_Retargeting_for_Humanoid_Motion_Tracking.md
+++ b/papers/02_Motion_Retargeting/Retargeting_Matters__General_Motion_Retargeting_for_Humanoid_Motion_Tracking/Retargeting_Matters__General_Motion_Retargeting_for_Humanoid_Motion_Tracking.md
@@ -3,6 +3,7 @@ layout: paper
 title: "Retargeting Matters: General Motion Retargeting for Humanoid Motion Tracking"
 zhname: "Retargeting Matters：面向人形运动跟踪的通用动作重定向"
 category: "Motion Retargeting"
+paper_order: 1
 ---
 
 # Retargeting Matters: General Motion Retargeting for Humanoid Motion Tracking


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 在 **动作重定向**（`papers/02_Motion_Retargeting/`）下新增两篇论文笔记，并运行 `python3 scripts/prepare_pages.py` 更新 `_data/papers.json`。

## 新增笔记

1. **Make Tracking Easy: Neural Motion Retargeting for Humanoid Whole-body Control**（[arXiv 2603.22201v3](https://arxiv.org/html/2603.22201v3)）：NMR + CEPR 数据管线、两阶段训练与 Hessian 非凸动机；含 **mermaid** 总览图。
2. **ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting**（[arXiv 2605.06593v1](https://arxiv.org/html/2605.06593v1)）：双层优化、上层梯度近似、参数化参考与下层 RL；含 **mermaid** 结构图。

## 其他

- 为已有 **Retargeting Matters (GMR)** 笔记增加 `paper_order: 1`，与新笔记的 `paper_order: 2/3` 一起固定板块内顺序为 GMR → NMR → ReActor。

## 验证

- `python3 scripts/prepare_pages.py`
- `ruff check scripts/ tests/`、`pytest -v`（本地已安装 `requirements-dev.txt` / `requirements-site.txt` 相关依赖后通过）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce5db55c-98d9-4509-9067-da57e100ae2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce5db55c-98d9-4509-9067-da57e100ae2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

