### PR TITLE
fix(样式): 暗色模式下优化 Mermaid 分区流程图对比度

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -631,6 +631,55 @@ body {
   background: #1e1e1e;
 }
 
+/*
+ * Paper Mermaid notes zone subgraphs with `style SUB fill:#pastel,stroke:#…`.
+ * Mermaid emits that fill as an inline `style="fill:#… !important"`, so normal
+ * CSS cannot recolor the cluster rect. Apply an SVG filter instead to darken the
+ * pastel panel; dark-theme cluster titles stay #F9FFFE and become legible.
+ */
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#e8f4fd"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#E8F4FD"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#e8f4fd"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#E8F4FD"] {
+  filter: brightness(0.42) saturate(1.08) contrast(1.06);
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#fdebd0"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#FDEBD0"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#fdebd0"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#FDEBD0"] {
+  filter: brightness(0.44) saturate(1.05) contrast(1.05);
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#e8f8e8"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#E8F8E8"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#e8f8e8"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#E8F8E8"] {
+  filter: brightness(0.42) saturate(1.06) contrast(1.06);
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#fceae8"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#FCEAE8"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#fceae8"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#FCEAE8"] {
+  filter: brightness(0.46) saturate(1.05) contrast(1.05);
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#fce4ec"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#FCE4EC"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#fce4ec"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#FCE4EC"] {
+  filter: brightness(0.44) saturate(1.06) contrast(1.05);
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#f4ecf7"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#F4ECF7"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#f4ecf7"],
+[data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#F4ECF7"] {
+  filter: brightness(0.44) saturate(1.05) contrast(1.05);
+}
+
+
 /* ===== Breadcrumb ===== */
 .breadcrumb {
   font-family: 'Arial', sans-serif;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

论文笔记里用 Mermaid `style … fill:#pastel` 给 subgraph 分区上色时，Mermaid 11 会把 `fill` 写成**带 `!important` 的内联样式**，暗色主题下 subgraph 标题仍按「深色底」配色（如 `#F9FFFE`），叠在浅色分区底上几乎看不清。

## 做法

在 `[data-theme="dark"] .paper-body .mermaid` 内，对站点里反复使用的几种 pastel 分区色（`#e8f4fd` / `#fdebd0` / `#e8f8e8` / `#fceae8` / `#fce4ec` / `#f4ecf7`）匹配 `g.cluster` 下第一层背景 `rect`（`style*=` 或 `fill=`），用 **`filter: brightness(…) saturate(…) contrast(…)`** 压暗面板。滤镜不依赖覆盖内联 `fill`，且只作用于分区背景矩形，不影响节点框与连线。

## 影响范围

- 直接修复 [Make Tracking Easy / NMR](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/02_Motion_Retargeting/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control/Make_Tracking_Easy__Neural_Motion_Retargeting_for_Humanoid_Whole-body_Control.html) 等使用相同色板的流程图。
- 其他论文里相同 hex 的分区图一并受益，无需逐篇改 mermaid 源码。

## 效果图（暗色）

以下为与站点 `assets/css/style.css` 相同规则、Mermaid `theme: dark` 与论文同款分区色（蓝 / 橙 / 绿）在 headless Chrome 中的截图：子图标题与节点文字在压暗后的分区底上对比度正常。

![暗色模式下 Mermaid 三色 subgraph 流程图（应用 brightness 滤镜后）](https://cursor.com/artifacts/c/art-f0296ce0-1a31-441d-9326-ec6644f7f2e9)

## 测试

当前环境未安装 Jekyll / ruff / pytest，未跑站点构建与 Python 测试；变更仅限 `assets/css/style.css`。截图通过 `puppeteer-core` 对本地静态页渲染生成。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-924c4991-a532-47c7-aa9b-60c5ff5bd385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-924c4991-a532-47c7-aa9b-60c5ff5bd385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

