### PR TITLE
fix(样式): Mermaid pastel 子图标题在暗色模式加衬底

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,10 @@ This is a Jekyll 4.3 static site with Python preprocessing scripts. Two runtimes
 - There is no `Gemfile.lock` committed; Bundler resolves versions fresh on each install.
 - The `baseurl` in `_config.yml` is `/Humanoid_Robot_Learning_Paper_Notebooks` — local URLs always include this prefix.
 
+### Pull Request：附带页面渲染验证截图
+
+推送工作分支并**创建或更新 GitHub PR 后**，在 **PR 描述中附上「页面渲染验证成功」的截图**，便于审阅者在未本地起站的情况下确认样式或交互是否符合预期。
+
+- **截图内容**：优先截取本次改动直接影响的区域（例如 `#paper-body` 内 Mermaid、暗色主题切换后、窄视口移动端等），并在正文中用一两句话说明对应页面路径或验证方式。
+- **验证方式**（任选其一即可）：本地执行 `python3 scripts/prepare_pages.py` 与 `bundle exec jekyll serve` 后用浏览器截图；环境无完整 Jekyll 时，可用 **headless Chrome**（如 `puppeteer-core`）加载临时 HTML fixture、内联或引用本次改动的 `assets/css/style.css` 相关规则后截图；已安装 **Chrome DevTools MCP** 时，可在真实浏览器中打开本地站点并截图。
+- **嵌入 PR**：使用 Cursor Cloud 的 PR 管理能力时，在说明里使用 `<img alt="…" src="/opt/cursor/artifacts/screenshots/某文件.png" />` 引用本地截图路径，由工具侧上传并重写为可访问 URL；亦可手动将图片粘贴到 GitHub PR 描述。

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -635,7 +635,12 @@ body {
  * Paper Mermaid notes zone subgraphs with `style SUB fill:#pastel,stroke:#…`.
  * Mermaid emits that fill as an inline `style="fill:#… !important"`, so normal
  * CSS cannot recolor the cluster rect. Apply an SVG filter instead to darken the
- * pastel panel; dark-theme cluster titles stay #F9FFFE and become legible.
+ * pastel panel.
+ *
+ * Subgraph titles render in foreignObject with a transparent wrapper; Mermaid’s
+ * dark theme still uses near-white title text (#F9FFFE), which can sit directly
+ * on the pastel fill (especially when the rect filter composites oddly on
+ * WebKit). Add a dark translucent pill behind the label text for readability.
  */
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#e8f4fd"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#E8F4FD"],
@@ -677,6 +682,36 @@ body {
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#f4ecf7"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#F4ECF7"] {
   filter: brightness(0.44) saturate(1.05) contrast(1.05);
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f4fd"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F4FD"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f4fd"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F4FD"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fdebd0"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FDEBD0"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fdebd0"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FDEBD0"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f8e8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F8E8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f8e8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F8E8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fceae8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCEAE8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fceae8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCEAE8"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fce4ec"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCE4EC"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fce4ec"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCE4EC"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#f4ecf7"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#F4ECF7"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#f4ecf7"]) .cluster-label foreignObject > div,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#F4ECF7"]) .cluster-label foreignObject > div {
+  background-color: rgba(18, 22, 28, 0.92) !important;
+  border-radius: 6px;
+  padding: 2px 8px !important;
+  box-sizing: border-box;
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

上一版已在暗色主题下对 pastel 分区背景 `rect` 使用 `brightness` 滤镜，但在 **ReActor** 等页面上，子图标题（如「上层：重定向参数 p」）仍可能看不清：Mermaid 把标题放在 **`foreignObject` 内透明背景的 `div`** 里，暗色主题仍使用近白色字（`#F9FFFE`）；在部分 WebKit（尤其移动端）上，标题区域与浅色底的合成不稳定，容易出现「白字叠浅底」。

## 做法

在保留原有 `rect` 滤镜的前提下，对使用站点六种常用 pastel 的 `g.cluster`（通过 `:has(> rect[style*=#…])` / `fill` 匹配），为 **`.cluster-label foreignObject > div`** 增加 **深色半透明圆角衬底**（`rgba(18, 22, 28, 0.92)`），使标题始终在深色底上绘制，与分区底色脱钩。

## 影响范围

- [ReActor 双层结构流程图](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/02_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting/ReActor__Reinforcement_Learning_for_Physics-Aware_Motion_Retargeting.html) 等使用相同 pastel hex 的 subgraph 标题。
- 与已合并的滤镜规则共用同一套色表，不修改各篇 `.md` 中的 Mermaid 源码。

## 页面渲染验证

以下截图为 headless Chrome（`puppeteer-core`）、视口约 **390×900**、Mermaid `theme: dark`，内联样式与 `assets/css/style.css` 中 pastel 分区的 **brightness 滤镜 + 子图标题衬底** 规则一致；图为简化的 ReActor 风格三色 subgraph，用于确认「上层：重定向参数 p」等标题在衬底上可读。

![暗色模式下 ReActor 风格 Mermaid 子图标题衬底与分区滤镜验证截图](https://cursor.com/artifacts/c/art-562a55dd-f740-4819-83d5-a6bee0f6bc74)

## 协作说明

本 PR 同时更新 `AGENTS.md`，在「Cursor Cloud specific instructions」下增加 **Pull Request：附带页面渲染验证截图** 小节，约定后续推送 PR 时应在描述中附带类似渲染验证截图及可选验证方式。

## 测试

- 未跑 Jekyll 构建；变更涉及 `assets/css/style.css` 与 `AGENTS.md`。
- 上述截图由本地 fixture 生成，与线上 ReActor 页使用相同 pastel hex 与站点 CSS 选择器。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-924c4991-a532-47c7-aa9b-60c5ff5bd385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-924c4991-a532-47c7-aa9b-60c5ff5bd385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

