### PR TITLE
fix(样式): Mermaid pastel 子图标题改为深色字（无衬底）

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -634,49 +634,172 @@ body {
 /*
  * Paper Mermaid notes zone subgraphs with `style SUB fill:#pastel,stroke:#…`.
  * Mermaid emits that fill as an inline `style="fill:#… !important"`, so normal
- * CSS cannot recolor the cluster rect. Apply an SVG filter instead to darken the
- * pastel panel; dark-theme cluster titles stay #F9FFFE and become legible.
+ * CSS cannot recolor the cluster rect. Darken the pastel panel slightly with a
+ * filter, and override subgraph **title** colour (foreignObject / optional SVG
+ * text): Mermaid’s dark theme uses near-white #F9FFFE on those fills — switch to
+ * deep, hue-matched text colours instead of adding a background pill.
  */
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#e8f4fd"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#E8F4FD"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#e8f4fd"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#E8F4FD"] {
-  filter: brightness(0.42) saturate(1.08) contrast(1.06);
+  filter: brightness(0.66) saturate(1.06) contrast(1.04);
 }
 
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#fdebd0"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#FDEBD0"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#fdebd0"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#FDEBD0"] {
-  filter: brightness(0.44) saturate(1.05) contrast(1.05);
+  filter: brightness(0.68) saturate(1.04) contrast(1.04);
 }
 
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#e8f8e8"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#E8F8E8"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#e8f8e8"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#E8F8E8"] {
-  filter: brightness(0.42) saturate(1.06) contrast(1.06);
+  filter: brightness(0.66) saturate(1.05) contrast(1.04);
 }
 
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#fceae8"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#FCEAE8"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#fceae8"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#FCEAE8"] {
-  filter: brightness(0.46) saturate(1.05) contrast(1.05);
+  filter: brightness(0.7) saturate(1.04) contrast(1.04);
 }
 
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#fce4ec"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#FCE4EC"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#fce4ec"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#FCE4EC"] {
-  filter: brightness(0.44) saturate(1.06) contrast(1.05);
+  filter: brightness(0.68) saturate(1.05) contrast(1.04);
 }
 
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#f4ecf7"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[style*="#F4ECF7"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#f4ecf7"],
 [data-theme="dark"] .paper-body .mermaid svg g.cluster > rect[fill="#F4ECF7"] {
-  filter: brightness(0.44) saturate(1.05) contrast(1.05);
+  filter: brightness(0.68) saturate(1.04) contrast(1.04);
+}
+
+/* Subgraph titles only — deep text on tinted cluster header (no background chip). */
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f4fd"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F4FD"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f4fd"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F4FD"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f4fd"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F4FD"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f4fd"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F4FD"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f4fd"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F4FD"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f4fd"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F4FD"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f4fd"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F4FD"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f4fd"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F4FD"]) .cluster-label tspan {
+  color: #05293f !important;
+  fill: #05293f !important;
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fdebd0"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FDEBD0"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fdebd0"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FDEBD0"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fdebd0"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FDEBD0"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fdebd0"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FDEBD0"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fdebd0"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FDEBD0"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fdebd0"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FDEBD0"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fdebd0"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FDEBD0"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fdebd0"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FDEBD0"]) .cluster-label tspan {
+  color: #2f1c08 !important;
+  fill: #2f1c08 !important;
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f8e8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F8E8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f8e8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F8E8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f8e8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F8E8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f8e8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F8E8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f8e8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F8E8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f8e8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F8E8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#e8f8e8"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#E8F8E8"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#e8f8e8"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#E8F8E8"]) .cluster-label tspan {
+  color: #082814 !important;
+  fill: #082814 !important;
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fceae8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCEAE8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fceae8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCEAE8"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fceae8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCEAE8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fceae8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCEAE8"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fceae8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCEAE8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fceae8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCEAE8"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fceae8"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCEAE8"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fceae8"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCEAE8"]) .cluster-label tspan {
+  color: #3c1410 !important;
+  fill: #3c1410 !important;
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fce4ec"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCE4EC"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fce4ec"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCE4EC"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fce4ec"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCE4EC"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fce4ec"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCE4EC"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fce4ec"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCE4EC"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fce4ec"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCE4EC"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#fce4ec"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#FCE4EC"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#fce4ec"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#FCE4EC"]) .cluster-label tspan {
+  color: #361426 !important;
+  fill: #361426 !important;
+}
+
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#f4ecf7"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#F4ECF7"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#f4ecf7"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#F4ECF7"]) .cluster-label span,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#f4ecf7"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#F4ECF7"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#f4ecf7"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#F4ECF7"]) .cluster-label p,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#f4ecf7"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#F4ECF7"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#f4ecf7"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#F4ECF7"]) .cluster-label text,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#f4ecf7"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[style*="#F4ECF7"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#f4ecf7"]) .cluster-label tspan,
+[data-theme="dark"] .paper-body .mermaid svg g.cluster:has(> rect[fill="#F4ECF7"]) .cluster-label tspan {
+  color: #221834 !important;
+  fill: #221834 !important;
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

用户希望 **ReActor** 等页面上「上层：重定向参数 p」一类 **Mermaid subgraph 标题**不要再用背景块衬托，仅靠 **字色** 提升在 pastel 分区上的可读性。

## 做法

- 删除以 **`foreignObject > div` 半透明衬底** 承载标题的做法（`main` 上若曾合入衬底版本则本 PR 改为纯字色方案；当前实现为覆盖 Mermaid 暗色主题默认的近白 `#F9FFFE`）。
- 对六种站点常用 pastel 分区，用 `:has(> rect[…])` 匹配 `g.cluster`，为 **`.cluster-label` 内的 `span` / `p` / `text` / `tspan`** 设置与色相一致的 **深色 `color` 与 `fill`**（`!important` 以压过 SVG 内嵌 `#my-svg .cluster-label` 规则）。
- 将分区背景 `rect` 的 **brightness 滤镜略减轻**（约 0.66～0.70），使顶栏区域仍偏浅、与深色标题对比足够，避免「深字叠深底」。

## 页面渲染验证

### 暗色模式

headless Chrome、`theme: dark`、与 `assets/css/style.css` 中 `[data-theme="dark"]` 下 pastel / cluster 规则一致；子图标题无衬底，仅靠深色字与略轻的 brightness 滤镜。

![暗色 pastel 子图标题改为深色字且无衬底](https://cursor.com/artifacts/c/art-0da387e8-9773-4e01-bbbb-273de49232f7)

### 白天模式

相关选择器均带有 **`[data-theme="dark"]` 前缀**，白天模式不会命中，分区与标题保持 Mermaid 默认浅色主题。下图为 `data-theme="light"`、`theme: default`、与上文相同的 ReActor 风格三色 subgraph fixture，用于确认浅色外观不受影响。

![白天模式 pastel subgraph 默认渲染（无暗色主题 CSS 覆盖）](https://cursor.com/artifacts/c/art-3e8743ce-81b7-47d6-94f1-14414fbff84f)

## 测试

未跑 Jekyll；变更仅限 `assets/css/style.css`。暗色与白天截图均由本地 fixture（`file://` + Mermaid 11.4.1 CDN）生成。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-924c4991-a532-47c7-aa9b-60c5ff5bd385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-924c4991-a532-47c7-aa9b-60c5ff5bd385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

