### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Attribute Injection in Jekyll Templates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** Found a DOM-based XSS vulnerability in `_layouts/default.html` where Mermaid dynamically generated SVG content was directly assigned to `mermaidRoadmap.innerHTML` and a cache object.
 **Learning:** Even though Mermaid has a `securityLevel: 'strict'` configuration which runs labels through DOMPurify, it is safer to run the *entire* generated SVG string through `DOMPurify.sanitize()` prior to setting `innerHTML`. This provides an additional layer of defense against XSS that could be introduced by bypasses in Mermaid's internal sanitization or maliciously crafted code that escapes label boundaries.
 **Prevention:** Always use `DOMPurify.sanitize()` on generated HTML or SVG strings from third-party libraries before assigning them to `innerHTML`, even if the library claims to perform its own sanitization.
+
+## 2025-05-18 - HTML Attribute Injection in Jekyll Templates
+**Vulnerability:** Found a vulnerability in `index.html` where dynamically generated file URLs (like `paper.url` and `page.url`) were injected into `href` attributes without HTML escaping (e.g., `href="{{ site.baseurl }}{{ paper.url }}"`).
+**Learning:** If a paper's file path contains quote characters (`"` or `'`), injecting it unescaped into an HTML attribute allows an attacker to break out of the attribute context and inject arbitrary HTML attributes or events, leading to Cross-Site Scripting (XSS).
+**Prevention:** Always append the `| escape` filter when injecting dynamic content, including URLs and paths generated from filenames, into HTML attributes in Jekyll templates.

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ title: "Home"
         <ul class="paper-list">
           {% for paper in cat_data.papers %}
           <li data-search="{{ paper.title | escape }} {{ paper.zhname | escape }} {{ paper.arxiv | escape }}">
-            <a href="{{ site.baseurl }}{{ paper.url }}" class="paper-card">
+            <a href="{{ site.baseurl }}{{ paper.url | escape }}" class="paper-card">
               <span class="paper-title" data-en="{{ paper.title | escape }}" data-zh="{{ paper.zhname | escape }}">{{ paper.title | escape }}</span>
             </a>
           </li>
@@ -123,7 +123,7 @@ title: "Home"
           <ul class="paper-list">
             {% for paper in subcat.papers %}
             <li data-search="{{ paper.title | escape }} {{ paper.zhname | escape }} {{ paper.arxiv | escape }}">
-              <a href="{{ site.baseurl }}{{ paper.url }}" class="paper-card">
+              <a href="{{ site.baseurl }}{{ paper.url | escape }}" class="paper-card">
                 <span class="paper-title" data-en="{{ paper.title | escape }}" data-zh="{{ paper.zhname | escape }}">{{ paper.title | escape }}</span>
               </a>
             </li>
@@ -138,7 +138,7 @@ title: "Home"
       <ul class="paper-list">
         {% for paper in cat_data.papers %}
         <li data-search="{{ paper.title | escape }} {{ paper.zhname | escape }} {{ paper.arxiv | escape }}">
-          <a href="{{ site.baseurl }}{{ paper.url }}" class="paper-card">
+          <a href="{{ site.baseurl }}{{ paper.url | escape }}" class="paper-card">
             <span class="paper-title" data-en="{{ paper.title | escape }}" data-zh="{{ paper.zhname | escape }}">{{ paper.title | escape }}</span>
           </a>
         </li>
@@ -167,7 +167,7 @@ title: "Home"
         {% assign current_cat = cat %}
       {% endif %}
       <li data-search="{{ page.title | escape }}">
-        <a href="{{ page.url | relative_url }}" class="paper-card">
+        <a href="{{ page.url | relative_url | escape }}" class="paper-card">
           <span class="paper-title">{% if page.title %}{{ page.title | escape }}{% else %}{{ parts[3] | replace: "_", " " | escape }}{% endif %}</span>
         </a>
       </li>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: 在 `index.html` 中，动态生成的论文 URL（如 `paper.url`）被直接插入到 `href` 属性中，未使用 HTML 转义（`| escape`）。如果文件路径中包含双引号（`"`），攻击者可能会破坏属性上下文，注入恶意的 HTML 属性或事件，导致 XSS。
🎯 Impact: 可能导致存储型 XSS 漏洞。
🔧 Fix: 在 Jekyll 模板中为涉及动态路径的 URL 添加 `| escape` 过滤器，如 `href="{{ site.baseurl }}{{ paper.url | escape }}"`。这能确保双引号和其他特殊字符被正确地 HTML 编码。
✅ Verification: 运行 `PYTHONPATH=. pytest tests/` 并使用 `bundle exec jekyll build` 验证构建成功且无新错误。检查了 `.jules/sentinel.md` 是否已补充安全学习记录。

---
*PR created automatically by Jules for task [16994248888776102641](https://jules.google.com/task/16994248888776102641) started by @ImChong*