### PR TITLE
fix(Progress): 校正 daily_summary 的 next_summary_index

### DIFF
--- a/progress.json
+++ b/progress.json
@@ -39,7 +39,7 @@
     "last_summary_index": 350,
     "last_summary_date": "2026-05-18",
     "last_summary_title": "EgoActor: Grounding Task Planning into Spatial-aware Egocentric Actions for Humanoid Robots via Visual-Language Models",
-    "next_summary_index": 351,
+    "next_summary_index": 368,
     "log": [
       {
         "date": "2026-04-24",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

`progress.json` 中 `daily_summary.module_rotation` 在 08_Navigation 最后一篇（索引 350）完成后，`next_module` 已正确为 `09_State_Estimation`，但 `next_summary_index` 被写成 `last_summary_index + 1`（351），对应的是 08 模块内的下一篇（FocusNav），与轮转目标不一致。

已改为 **368**，与 `papers/PROGRESS.md` 中 State Estimation 小节首篇（AutoOdom）的全局编号一致，避免自动化任务误选论文。

## 验收

无 GitHub Pages 可见 UI 变更，免截图。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ce3c890-fe3d-4b83-be20-516cb13a5eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ce3c890-fe3d-4b83-be20-516cb13a5eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

