### PR TITLE
docs(SONIC): 流程图改为「主线竖直 + 中段双列」布局

### DIFF
--- a/papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.md
+++ b/papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.md
@@ -101,7 +101,7 @@ SONIC 的论点是：**只要把 motion tracking 当作 foundational task 放大
 
 ## 🧭 整体框架（mermaid）
 
-<div class="mermaid" style="max-width:520px;margin:0 auto;">
+<div class="mermaid" style="max-width:640px;margin:0 auto;">
 flowchart TB
     subgraph DATA["📚 规模化 MoCap 监督"]
         direction TB
@@ -122,7 +122,7 @@ flowchart TB
         direction TB
         T1["VR 全身 (PICO)"]
         T2["VR 三点 (头/双手)"]
-        T3["视频 / 文本 / 音乐 (GENMO)"]
+        T3["视频 / 文本 / 音乐<br/>(GENMO)"]
         T4["VLA: GR00T N1.5"]
         ENC["Hybrid Encoder"]
         T1 ~~~ T2 ~~~ T3 ~~~ T4 ~~~ ENC
@@ -155,7 +155,8 @@ flowchart TB
 
     DATA --> SCALE
     SCALE --> TOKEN
-    TOKEN --> PLAN
+    SCALE --> PLAN
+    TOKEN --> POLICY
     PLAN --> POLICY
     POLICY --> DEPLOY
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

承接 #112：上一轮把 SONIC 笔记的流程图从 `flowchart LR` 改成竖直布局，但为了把字撑大，把 `TOKEN`（universal token 编码器）与 `PLAN`（运动规划器）串成了**串行**（`SCALE→TOKEN→PLAN→POLICY`）。这丢掉了论文里「universal token 编码器和实时运动规划器是**两条并行输入**，统一进入跟踪策略」的语义。

issue 反馈：**不必硬塞成一列，两列也可以**——只要整体仍是竖直阅读方向、节点文字别太小。

页面：[SONIC 笔记 - 整体框架](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.html)。

## 改动

本 PR 只动了 `papers/03_High_Impact_Selection/SONIC_*/SONIC_*.md` 一个文件的 mermaid 代码块，把整体排布改成「主线竖直 + 中段双列」：

```
DATA
  ↓
SCALE
  ↓     ↓
TOKEN  PLAN
  ↓     ↓
   POLICY
     ↓
   DEPLOY
```

主流程边写成：

```
DATA --> SCALE
SCALE --> TOKEN
SCALE --> PLAN
TOKEN --> POLICY
PLAN  --> POLICY
POLICY --> DEPLOY
```

`TOKEN` 与 `PLAN` 自然落在 SCALE 与 POLICY 之间的同一 rank，被 mermaid Dagre 排成左右两列、再一起汇入 `POLICY`，恢复了原文「两路并行输入」的结构；上下游（`DATA→SCALE` / `POLICY→DEPLOY`）仍然是单列纵向。

其他细节：

- TOKEN 内部仍用 `direction TB` + `~~~` 不可见边把 `T1…T4 / ENC` 串成单列纵向，保证 TOKEN 这一列本身不会被 4 路 fan-in 撑宽；`T3` 的 `视频 / 文本 / 音乐` 加回 `<br/>` 换行，让节点更窄。
- 桌面端宽度上限从 `max-width:520px` 放宽到 `max-width:640px`，给中段双列留出足够横向空间，避免被压窄。

## 渲染验收

本地 `python3 scripts/prepare_pages.py && bundle exec jekyll build` 后，用 headless Chrome 直接抓 `.mermaid svg` 元素：

**移动端 390 宽**

![SONIC 框架流程图 - 移动端 390 宽：主线竖直 + 中段 TOKEN | PLAN 双列](https://cursor.com/artifacts/c/art-74f52dc9-d838-4bd8-9165-53bdfd0bf696)

**桌面端 1200 宽**

![SONIC 框架流程图 - 桌面端 1200 宽：主线竖直 + 中段 TOKEN | PLAN 双列](https://cursor.com/artifacts/c/art-410eee30-d353-4c80-a946-3bf787242c05)

两个宽度下都呈「窄列纵向走、TOKEN/PLAN 中段并排」的形态，中文标签清晰可读，且 TOKEN/PLAN 的并行输入语义被保留。

## 影响范围

- 仅修改一个论文笔记 Markdown 文件，未触碰 `_layouts/` / `_includes/` / `assets/css/` 等全局资产，也未改动任何 Python / 测试代码（无 lint / pytest 需要重跑）。
- `max-width: 640px` 是 inline style，只作用在这一个 `<div>` 上，其他论文页里的 mermaid 不受影响。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-585c5e75-8f77-4ed2-bea0-7e1878a57a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-585c5e75-8f77-4ed2-bea0-7e1878a57a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

