### PR TITLE
fix(css): 窄屏论文表格横向滚动与列宽优化

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1438,6 +1438,11 @@ html[data-lang-mode="zh"] .footer-text-zh {
     width: 100%;
     max-width: 100%;
     min-width: 0;
+    /* Wide Markdown tables: let columns size to content and scroll horizontally
+       instead of forcing width:100% + overflow-wrap:anywhere (which squeezes
+       later columns to one character per line on narrow viewports). */
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .paper-body h1,
@@ -1461,21 +1466,27 @@ html[data-lang-mode="zh"] .footer-text-zh {
   }
 
   .paper-body table {
-    width: 100%;
+    width: max-content;
     min-width: 100%;
-    max-width: 100%;
+    max-width: none;
     table-layout: auto;
   }
 
   .paper-body th,
   .paper-body td {
-    overflow-wrap: anywhere;
-    word-break: break-word;
+    overflow-wrap: break-word;
+    word-break: normal;
+  }
+
+  /* Inline code in tables (e.g. hidden_dims arrays): keep on one line so
+     columns stay readable; horizontal scroll on .paper-body handles overflow. */
+  .paper-body th code,
+  .paper-body td code {
+    white-space: nowrap;
   }
 
   /* Key–value style tables (e.g. 基本信息): do not let column 1 shrink to
-     per-glyph breaks; the blanket overflow-wrap:anywhere above makes short
-     labels min-content to ~1ch wide on narrow viewports. */
+     awkward wraps; short labels stay on one line when there is room. */
   .paper-body th:first-child,
   .paper-body td:first-child {
     white-space: nowrap;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

SONIC 等论文在 **≤1200px** 视口下，Markdown 表格曾被强制 `width: 100%`，且单元格使用 `overflow-wrap: anywhere`，与「首列 `nowrap`」叠加后，后几列被压成极窄竖条（单字换行），例如「高层结构：3 路 encoder × FSQ × 2 个 decoder」一节的架构表。

## 改动

- 窄屏下将 `.paper-body` 设为 `overflow-x: auto`，表格恢复 `width: max-content; min-width: 100%`，列宽按内容分配，超出时在正文区域横向滑动阅读。
- 表格单元格改用 `overflow-wrap: break-word` + `word-break: normal`，去掉 `anywhere` 的逐字断裂。
- 表内 `` `code` `` 使用 `white-space: nowrap`，使 `hidden_dims` 等数组保持单行（由横向滚动承载溢出）。

## 验收

本地 Jekyll 构建后，使用 Playwright 在深色主题下对该节 **整张 `<table>`** 做元素级截图（避免 390px 视口只框到前两列）；列包含「子模块 / 角色 / 隐层结构 / 激活 / 训练用·部署用」，排版正常。

![修复后：SONIC 高层结构整表（深色，元素截图）](https://cursor.com/artifacts/c/art-f6e9aa1e-8955-4e6f-a00e-b2248aa146f4)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e970e72e-4d3e-4cc7-998a-508cda607d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e970e72e-4d3e-4cc7-998a-508cda607d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

