### PR TITLE
🛡️ Sentinel: Add rel="noopener noreferrer" to external links in markdown

### DIFF
--- a/scripts/sanitize_paper_html.py
+++ b/scripts/sanitize_paper_html.py
@@ -114,6 +114,7 @@ def sanitize_paper_body_fragment(html_fragment: str) -> str:
         clean_content_tags=_CLEAN_CONTENT_TAGS,
         strip_comments=True,
         generic_attribute_prefixes=frozenset({"aria-", "data-"}),
+        link_rel="noopener noreferrer",
     )
 
 

--- a/tests/test_sanitize_paper_html.py
+++ b/tests/test_sanitize_paper_html.py
@@ -43,6 +43,12 @@ def test_sanitize_paper_body_fragment_blocks_vectors(snippet: str, forbidden: st
     assert forbidden.lower() not in clean.lower()
 
 
+def test_sanitize_paper_body_fragment_adds_noopener_noreferrer() -> None:
+    dirty = '<a href="https://example.com" target="_blank">external</a>'
+    clean = sanitize_paper_body_fragment(dirty)
+    assert 'rel="noopener noreferrer"' in clean
+
+
 def test_main_rewrites_built_paper_file(tmp_path: Path) -> None:
     site_root = tmp_path / "_site"
     paper = site_root / "papers" / "01_Cat" / "Note" / "Note.html"


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: Found that external links injected into paper content could contain `target="_blank"` without enforcing `rel="noopener noreferrer"`. This could allow a malicious target site to gain access to the original page's `window.opener` object, a vulnerability known as Reverse Tabnabbing.

🎯 **Impact**: If a user includes a link to a malicious site in their markdown using `target="_blank"`, that malicious site could potentially redirect the original tab to a phishing page.

🔧 **Fix**: Updated `scripts/sanitize_paper_html.py` to pass `link_rel="noopener noreferrer"` to the `nh3.clean` call. The `nh3` library will automatically inject this `rel` attribute to relevant link tags during HTML sanitization. Also added a unit test to verify this behavior.

✅ **Verification**: Run `PYTHONPATH=. pytest tests/test_sanitize_paper_html.py` to confirm that the `rel="noopener noreferrer"` is appended.

---
*PR created automatically by Jules for task [12169871831561876693](https://jules.google.com/task/12169871831561876693) started by @ImChong*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to HTML sanitization behavior plus a unit test; main impact is that links may gain/override `rel` attributes when cleaned.
> 
> **Overview**
> Ensures sanitized paper HTML links get `rel="noopener noreferrer"` injected during `nh3.clean` to mitigate reverse-tabnabbing when `target="_blank"` is present.
> 
> Adds a unit test covering the new `rel` attribute behavior in `sanitize_paper_body_fragment`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b71d8bb2cdb93855375f23dabdacd53b099400b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->