### PR TITLE
fix(prepare_pages): 高影响力精选论文卡片按 H 编号排序

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,21 +31,39 @@ This is a Jekyll 4.3 static site with Python preprocessing scripts. Two runtimes
 | Component | Purpose | Commands |
 |-----------|---------|----------|
 | Python scripts | Preprocess Markdown → add YAML front matter, generate `_data/papers.json` | `python3 scripts/prepare_pages.py` |
-| Python (post-build) | Sanitize `#paper-body` in built HTML (mitigates stored XSS from raw HTML in notes) | `pip install -r requirements-site.txt` then `python3 scripts/sanitize_paper_html.py _site` (runs in Deploy workflow after Jekyll) |
+| Python (post-build) | Sanitize `#paper-body` in built HTML (mitigates stored XSS from raw HTML in notes) | `pip3 install -r requirements-site.txt` then `python3 scripts/sanitize_paper_html.py _site` (runs in Deploy workflow after Jekyll) |
 | Jekyll | Build & serve the static site | `bundle exec jekyll serve --host 0.0.0.0 --port 4000` |
 
 ### Running locally
 
+0. **若命令不存在则先安装（勿跳过）**  
+   - **Ruby / Bundler / Jekyll**（Debian / Ubuntu 示例，装好后仍需在仓库根目录执行 `sudo bundle install`）：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ruby-full ruby-bundler build-essential zlib1g-dev
+cd /path/to/repo && sudo bundle install
+```
+
+   - **Python 质检（ruff、pytest）**：若 `ruff` / `pytest` 不在 `PATH` 中：
+
+```bash
+pip3 install -r requirements-dev.txt
+# 可选：export PATH="$HOME/.local/bin:$PATH"
+```
+
+   - **站点 HTML 消毒脚本依赖**：`pip3 install -r requirements-site.txt`（与 Deploy 流程一致）。
+
 1. **Preprocess**: `python3 scripts/prepare_pages.py` (must run before Jekyll build whenever paper `.md` files change).
 2. **Serve**: `bundle exec jekyll serve --host 0.0.0.0 --port 4000` — site is at `http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/`.
 3. Jekyll auto-rebuilds on file changes (LiveReload not configured; refresh browser manually).
-4. **Optional (match production HTML)**: After `bundle exec jekyll build`, run `python3 scripts/sanitize_paper_html.py _site` (install deps once with `pip install -r requirements-site.txt`). GitHub Pages deploy runs this automatically; `jekyll serve` alone does not.
+4. **Optional (match production HTML)**: After `bundle exec jekyll build`, run `python3 scripts/sanitize_paper_html.py _site` (install deps once with `pip3 install -r requirements-site.txt`). GitHub Pages deploy runs this automatically; `jekyll serve` alone does not.
 
 ### Lint & Test
 
 - Lint: `ruff check scripts/ tests/`
 - Test: `pytest -v`
-- Both are in `PATH` at `~/.local/bin` (user-installed via pip).
+- 若未找到命令，先执行 `pip3 install -r requirements-dev.txt`；可执行文件通常在 `~/.local/bin`，必要时加入 `PATH`。
 
 ### Gotchas
 

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -178,28 +178,12 @@
             "zhname": "人形机器人表现力全身控制"
           },
           {
-            "title": "SONIC: Supersizing Motion Tracking for Natural Humanoid Whole-Body Control",
-            "path": "papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.md",
-            "url": "/papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.html",
-            "dir": "SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control",
-            "arxiv": "2511.07820",
-            "zhname": "SONIC：用规模化运动跟踪打造自然的人形全身控制器"
-          },
-          {
-            "title": "HugWBC: A Unified and General Humanoid Whole-Body Controller for Versatile Locomotion",
-            "path": "papers/03_High_Impact_Selection/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller.md",
-            "url": "/papers/03_High_Impact_Selection/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller.html",
-            "dir": "HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller",
-            "arxiv": "2502.03206",
-            "zhname": "HugWBC：面向多步态人形的统一通用全身控制器"
-          },
-          {
-            "title": "UH-1: Learning from Massive Human Videos for Universal Humanoid Pose Control",
-            "path": "papers/03_High_Impact_Selection/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control.md",
-            "url": "/papers/03_High_Impact_Selection/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control.html",
-            "dir": "UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control",
-            "arxiv": "2412.14172",
-            "zhname": "UH-1：从海量互联网人类视频中学习通用人形姿态控制"
+            "title": "HOVER: Versatile Neural Whole-Body Controller for Humanoid Robots",
+            "path": "papers/03_High_Impact_Selection/HOVER_Versatile_Neural_Whole-Body_Controller/HOVER_Versatile_Neural_Whole-Body_Controller.md",
+            "url": "/papers/03_High_Impact_Selection/HOVER_Versatile_Neural_Whole-Body_Controller/HOVER_Versatile_Neural_Whole-Body_Controller.html",
+            "dir": "HOVER_Versatile_Neural_Whole-Body_Controller",
+            "arxiv": "2410.21229",
+            "zhname": "HOVER：面向人形机器人的多模态通用神经全身控制器"
           },
           {
             "title": "ExBody2: Advanced Expressive Humanoid Whole-Body Control",
@@ -210,12 +194,28 @@
             "zhname": "ExBody2：进阶的表达性人形全身控制"
           },
           {
-            "title": "HOVER: Versatile Neural Whole-Body Controller for Humanoid Robots",
-            "path": "papers/03_High_Impact_Selection/HOVER_Versatile_Neural_Whole-Body_Controller/HOVER_Versatile_Neural_Whole-Body_Controller.md",
-            "url": "/papers/03_High_Impact_Selection/HOVER_Versatile_Neural_Whole-Body_Controller/HOVER_Versatile_Neural_Whole-Body_Controller.html",
-            "dir": "HOVER_Versatile_Neural_Whole-Body_Controller",
-            "arxiv": "2410.21229",
-            "zhname": "HOVER：面向人形机器人的多模态通用神经全身控制器"
+            "title": "HugWBC: A Unified and General Humanoid Whole-Body Controller for Versatile Locomotion",
+            "path": "papers/03_High_Impact_Selection/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller.md",
+            "url": "/papers/03_High_Impact_Selection/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller/HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller.html",
+            "dir": "HugWBC_A_Unified_and_General_Humanoid_Whole-Body_Controller",
+            "arxiv": "2502.03206",
+            "zhname": "HugWBC：面向多步态人形的统一通用全身控制器"
+          },
+          {
+            "title": "SONIC: Supersizing Motion Tracking for Natural Humanoid Whole-Body Control",
+            "path": "papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.md",
+            "url": "/papers/03_High_Impact_Selection/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control/SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control.html",
+            "dir": "SONIC_Supersizing_Motion_Tracking_for_Natural_Humanoid_Control",
+            "arxiv": "2511.07820",
+            "zhname": "SONIC：用规模化运动跟踪打造自然的人形全身控制器"
+          },
+          {
+            "title": "UH-1: Learning from Massive Human Videos for Universal Humanoid Pose Control",
+            "path": "papers/03_High_Impact_Selection/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control.md",
+            "url": "/papers/03_High_Impact_Selection/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control/UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control.html",
+            "dir": "UH-1_Learning_from_Massive_Human_Videos_for_Universal_Humanoid_Pose_Control",
+            "arxiv": "2412.14172",
+            "zhname": "UH-1：从海量互联网人类视频中学习通用人形姿态控制"
           }
         ],
         "zhname": "全身控制核心"
@@ -224,20 +224,20 @@
         "name": "Teleoperation & Imitation Learning",
         "papers": [
           {
-            "title": "HOMIE: Humanoid Loco-Manipulation with Isomorphic Exoskeleton Cockpit",
-            "path": "papers/03_High_Impact_Selection/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit.md",
-            "url": "/papers/03_High_Impact_Selection/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit.html",
-            "dir": "HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit",
-            "arxiv": "2502.13013",
-            "zhname": "HOMIE：同构外骨骼驾驶舱式人形遥操作系统"
-          },
-          {
             "title": "OmniH2O: Universal and Dexterous Human-to-Humanoid Whole-Body Teleoperation and Learning",
             "path": "papers/03_High_Impact_Selection/OmniH2O_Universal_Whole-Body_Teleoperation/OmniH2O_Universal_Whole-Body_Teleoperation.md",
             "url": "/papers/03_High_Impact_Selection/OmniH2O_Universal_Whole-Body_Teleoperation/OmniH2O_Universal_Whole-Body_Teleoperation.html",
             "dir": "OmniH2O_Universal_Whole-Body_Teleoperation",
             "arxiv": "2406.08858",
             "zhname": "OmniH2O：通用灵巧的人到人形整体遥操与学习"
+          },
+          {
+            "title": "HOMIE: Humanoid Loco-Manipulation with Isomorphic Exoskeleton Cockpit",
+            "path": "papers/03_High_Impact_Selection/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit.md",
+            "url": "/papers/03_High_Impact_Selection/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit/HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit.html",
+            "dir": "HOMIE_Humanoid_Loco-Manipulation_with_Isomorphic_Exoskeleton_Cockpit",
+            "arxiv": "2502.13013",
+            "zhname": "HOMIE：同构外骨骼驾驶舱式人形遥操作系统"
           },
           {
             "title": "iDP3: Generalizable Humanoid Manipulation with Improved 3D Diffusion Policies",
@@ -253,14 +253,6 @@
       {
         "name": "Locomotion Classics",
         "papers": [
-          {
-            "title": "Learning Sim-to-Real Humanoid Locomotion in 15 Minutes",
-            "path": "papers/03_High_Impact_Selection/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes.md",
-            "url": "/papers/03_High_Impact_Selection/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes.html",
-            "dir": "Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes",
-            "arxiv": "2512.01996",
-            "zhname": "15 分钟人形 sim-to-real：FastSAC / FastTD3 大规模并行配方（Amazon FAR）"
-          },
           {
             "title": "Real-World Humanoid Locomotion with Reinforcement Learning",
             "path": "papers/03_High_Impact_Selection/Real-World_Humanoid_Locomotion_with_RL/Real-World_Humanoid_Locomotion_with_RL.md",
@@ -286,6 +278,14 @@
             "zhname": "人形跑酷：无动作先验的端到端视觉全身控制（Unitree H1）"
           },
           {
+            "title": "Learning Sim-to-Real Humanoid Locomotion in 15 Minutes",
+            "path": "papers/03_High_Impact_Selection/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes.md",
+            "url": "/papers/03_High_Impact_Selection/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes/Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes.html",
+            "dir": "Learning_Sim-to-Real_Humanoid_Locomotion_in_15_Minutes",
+            "arxiv": "2512.01996",
+            "zhname": "15 分钟人形 sim-to-real：FastSAC / FastTD3 大规模并行配方（Amazon FAR）"
+          },
+          {
             "title": "Learning Quadrupedal Locomotion over Challenging Terrain",
             "path": "papers/03_High_Impact_Selection/Learning_Quadrupedal_Locomotion_over_Challenging_Terrain/Learning_Quadrupedal_Locomotion_over_Challenging_Terrain.md",
             "url": "/papers/03_High_Impact_Selection/Learning_Quadrupedal_Locomotion_over_Challenging_Terrain/Learning_Quadrupedal_Locomotion_over_Challenging_Terrain.html",
@@ -298,6 +298,22 @@
       {
         "name": "Sim-to-Real & Foundation Model",
         "papers": [
+          {
+            "title": "Learning Agile and Dynamic Motor Skills for Legged Robots",
+            "path": "papers/03_High_Impact_Selection/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots.md",
+            "url": "/papers/03_High_Impact_Selection/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots.html",
+            "dir": "Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots",
+            "arxiv": "1901.08652",
+            "zhname": "ANYmal 敏捷运动技能学习（sim-to-real RL 奠基作）"
+          },
+          {
+            "title": "ASAP: Aligning Simulation and Real-World Physics for Learning Agile Humanoid Whole-Body Skills",
+            "path": "papers/03_High_Impact_Selection/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills.md",
+            "url": "/papers/03_High_Impact_Selection/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills.html",
+            "dir": "ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills",
+            "arxiv": "2502.01143",
+            "zhname": "ASAP：用残差动作模型对齐仿真与真机动力学的人形敏捷全身技能"
+          },
           {
             "title": "GR00T N1: An Open Foundation Model for Generalist Humanoid Robots",
             "path": "papers/03_High_Impact_Selection/GR00T_N1_Humanoid_Foundation_Model/GR00T_N1_Humanoid_Foundation_Model.md",
@@ -313,22 +329,6 @@
             "dir": "Behavior_Foundation_Model_for_Humanoid_Robots",
             "arxiv": "2509.13780",
             "zhname": "BFM：面向人形全身控制的行为基础模型"
-          },
-          {
-            "title": "ASAP: Aligning Simulation and Real-World Physics for Learning Agile Humanoid Whole-Body Skills",
-            "path": "papers/03_High_Impact_Selection/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills.md",
-            "url": "/papers/03_High_Impact_Selection/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills/ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills.html",
-            "dir": "ASAP_Aligning_Simulation_and_Real-World_Physics_for_Agile_Humanoid_Skills",
-            "arxiv": "2502.01143",
-            "zhname": "ASAP：用残差动作模型对齐仿真与真机动力学的人形敏捷全身技能"
-          },
-          {
-            "title": "Learning Agile and Dynamic Motor Skills for Legged Robots",
-            "path": "papers/03_High_Impact_Selection/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots.md",
-            "url": "/papers/03_High_Impact_Selection/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots/Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots.html",
-            "dir": "Learning_Agile_and_Dynamic_Motor_Skills_for_Legged_Robots",
-            "arxiv": "1901.08652",
-            "zhname": "ANYmal 敏捷运动技能学习（sim-to-real RL 奠基作）"
           }
         ],
         "zhname": "仿真到现实与基座模型"
@@ -337,12 +337,12 @@
         "name": "Simulation Platform & Tools",
         "papers": [
           {
-            "title": "ProtoMotions3: An Open-source Framework for Humanoid Simulation and Control",
-            "path": "papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.md",
-            "url": "/papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.html",
-            "dir": "ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control",
-            "arxiv": "2409.14393",
-            "zhname": "ProtoMotions3：面向人形仿真与控制的开源框架"
+            "title": "Humanoid-Gym: Reinforcement Learning for Humanoid Robot with Zero-Shot Sim2Real Transfer",
+            "path": "papers/03_High_Impact_Selection/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer.md",
+            "url": "/papers/03_High_Impact_Selection/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer.html",
+            "dir": "Humanoid-Gym_Zero-Shot_Sim2Real_Transfer",
+            "arxiv": "2404.05695",
+            "zhname": "Humanoid-Gym：面向人形机器人零样本 Sim2Real 的 RL 框架"
           },
           {
             "title": "BEHAVIOR Robot Suite: Streamlining Real-World Whole-Body Manipulation for Everyday Household Activities",
@@ -353,12 +353,12 @@
             "zhname": "BEHAVIOR Robot Suite：面向日常家务的实机全身操作框架"
           },
           {
-            "title": "Humanoid-Gym: Reinforcement Learning for Humanoid Robot with Zero-Shot Sim2Real Transfer",
-            "path": "papers/03_High_Impact_Selection/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer.md",
-            "url": "/papers/03_High_Impact_Selection/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer.html",
-            "dir": "Humanoid-Gym_Zero-Shot_Sim2Real_Transfer",
-            "arxiv": "2404.05695",
-            "zhname": "Humanoid-Gym：面向人形机器人零样本 Sim2Real 的 RL 框架"
+            "title": "ProtoMotions3: An Open-source Framework for Humanoid Simulation and Control",
+            "path": "papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.md",
+            "url": "/papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.html",
+            "dir": "ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control",
+            "arxiv": "2409.14393",
+            "zhname": "ProtoMotions3：面向人形仿真与控制的开源框架"
           },
           {
             "title": "Isaac Lab: Unified GPU Simulation Platform for Robot Learning",

--- a/scripts/prepare_pages.py
+++ b/scripts/prepare_pages.py
@@ -133,6 +133,97 @@ def parse_progress_order():
     return order
 
 
+_H_INDEX_RE = re.compile(r'^H(\d+)$', re.IGNORECASE)
+_ARXIV_IN_MARKDOWN_CELL_RE = re.compile(
+    r'(?:arxiv\.org/(?:abs|html|pdf)/|arxiv:)(\d{4}\.\d{4,5}(?:v\d+)?)',
+    re.IGNORECASE,
+)
+
+
+def parse_high_impact_h_order():
+    """Parse PROGRESS.md rows whose first column is ``H1``…``H23``.
+
+    Returns two dicts used only for ``03_High_Impact_Selection``:
+
+    * ``by_name``: :func:`normalize_name` of the linked title → H index (int)
+    * ``by_arxiv``: arXiv id without version suffix → H index (int)
+
+    ArXiv keys are normalized to lowercase and stripped of a trailing ``vN``.
+    """
+    if not os.path.exists(PROGRESS_PATH):
+        return {}, {}
+
+    with open(PROGRESS_PATH, encoding='utf-8') as f:
+        content = f.read()
+
+    by_name = {}
+    by_arxiv = {}
+
+    for line in content.split('\n'):
+        line = line.strip()
+        if not line.startswith('|'):
+            continue
+        cols = [c.strip() for c in line.split('|')]
+        cols = [c for c in cols if c]
+        if len(cols) < 2:
+            continue
+        if cols[0] in ('#', '---', '----', '-----') or re.match(r'^-+$', cols[0]):
+            continue
+
+        tag_m = _H_INDEX_RE.match(cols[0])
+        if not tag_m:
+            continue
+
+        h_num = int(tag_m.group(1))
+        paper_col = cols[1]
+
+        for ax_m in _ARXIV_IN_MARKDOWN_CELL_RE.finditer(paper_col):
+            ax = re.sub(r'v\d+$', '', ax_m.group(1).lower())
+            by_arxiv[ax] = h_num
+
+        paper_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', paper_col)
+        paper_text = re.sub(r'[*_`\[\]]', '', paper_text)
+        paper_text = paper_text.strip()
+        if not paper_text:
+            continue
+
+        normalized = normalize_name(paper_text)
+        if normalized and len(normalized) > 3:
+            by_name[normalized] = h_num
+
+    return by_name, by_arxiv
+
+
+def match_high_impact_h_order(paper_title, paper_dir, arxiv_id, by_name, by_arxiv):
+    """Resolve H# reading order for high-impact notes; ``None`` if unknown."""
+    if arxiv_id:
+        ax_key = arxiv_id.lower()
+        if ax_key in by_arxiv:
+            return by_arxiv[ax_key]
+        if re.search(r'v\d+$', ax_key):
+            ax_key = re.sub(r'v\d+$', '', ax_key)
+            if ax_key in by_arxiv:
+                return by_arxiv[ax_key]
+
+    norm_title = normalize_name(paper_title)
+    if norm_title and norm_title in by_name:
+        return by_name[norm_title]
+
+    norm_dir = normalize_name(paper_dir.replace('_', ' '))
+    if norm_dir and norm_dir in by_name:
+        return by_name[norm_dir]
+
+    for key, h_num in by_name.items():
+        if norm_title and (norm_title in key or key in norm_title):
+            return h_num
+
+    for key, h_num in by_name.items():
+        if norm_dir and (norm_dir in key or key in norm_dir):
+            return h_num
+
+    return None
+
+
 def match_paper_order(paper_title, paper_dir, progress_order):
     """Find the README order index for a paper. Lower = earlier in README."""
     # ⚡ Bolt Optimization: O(1) fast-path for exact matches before O(N) fuzzy search
@@ -173,6 +264,7 @@ def check_stub(fpath, content):
 def process_papers():
     """Walk through papers directory and add front matter."""
     progress_order = parse_progress_order()
+    hi_by_name, hi_by_arxiv = parse_high_impact_h_order()
     index_data = {}
 
     # Load existing papers.json to preserve metadata (subtitle, subcategories, zhname)
@@ -242,16 +334,29 @@ def process_papers():
                 rel_path = os.path.relpath(fpath, BASE_DIR)
                 url_path = '/' + rel_path.rsplit('.md', 1)[0] + '.html'
 
-                order_idx = match_paper_order(title, paper_dir, progress_order)
-
                 # ⚡ Bolt Optimization: Extract front matter explicitly with O(1) parsing
                 # instead of running multiple multi-line regexes over the whole file
                 frontmatter_meta = parse_frontmatter(content)
 
-                # Front-matter `paper_order: <n>` overrides PROGRESS.md matching.
-                # Used to put papers in README's recommended learning-path order
-                # even when their titles don't match the awesome-list table rows.
-                if 'paper_order' in frontmatter_meta:
+                arxiv_for_order = extract_arxiv(content)
+
+                order_idx = match_paper_order(title, paper_dir, progress_order)
+
+                if category_dir == '03_High_Impact_Selection':
+                    h_idx = match_high_impact_h_order(
+                        title, paper_dir, arxiv_for_order, hi_by_name, hi_by_arxiv
+                    )
+                    if h_idx is not None:
+                        order_idx = h_idx
+                    elif 'paper_order' in frontmatter_meta:
+                        try:
+                            order_idx = int(frontmatter_meta['paper_order'])
+                        except ValueError:
+                            pass
+                elif 'paper_order' in frontmatter_meta:
+                    # Front-matter `paper_order: <n>` overrides PROGRESS.md matching.
+                    # Used to put papers in README's recommended learning-path order
+                    # even when their titles don't match the awesome-list table rows.
                     try:
                         order_idx = int(frontmatter_meta['paper_order'])
                     except ValueError:
@@ -273,7 +378,7 @@ def process_papers():
 
                 # Extract arXiv ID, preserving existing metadata when the note
                 # uses a format the parser does not recognize.
-                arxiv = extract_arxiv(content) or existing_meta_for_paper.get('arxiv')
+                arxiv = arxiv_for_order or existing_meta_for_paper.get('arxiv')
                 if arxiv:
                     paper_entry['arxiv'] = arxiv
 
@@ -286,7 +391,7 @@ def process_papers():
 
                 papers.append(paper_entry)
 
-        # Sort by README order
+        # Sort: global categories by PROGRESS row order; High Impact uses H# from PROGRESS when matched
         papers.sort(key=lambda p: p['_order'])
         # Load existing category meta (subtitle, subcategories) from current papers.json
         existing_meta = existing_papers_json.get(category_dir, {})

--- a/tests/test_prepare_pages.py
+++ b/tests/test_prepare_pages.py
@@ -1,5 +1,6 @@
 """Tests for the pure helpers in ``scripts.prepare_pages``."""
 
+from scripts import prepare_pages
 from scripts.prepare_pages import extract_arxiv, normalize_name
 
 
@@ -58,3 +59,34 @@ def test_extract_arxiv_abs_url_all_caps_host():
 def test_extract_arxiv_no_mention_returns_none():
     """No arxiv token anywhere → no ID (cheap path)."""
     assert extract_arxiv("Only doi:10.1000/182 and no preprint link.") is None
+
+
+def test_parse_high_impact_h_order_reads_h_rows(tmp_path, monkeypatch):
+    """``Hn`` first-column rows map titles and arXiv IDs to integer order."""
+    progress = tmp_path / "PROGRESS.md"
+    progress.write_text(
+        "| # | 论文 | 来源 |\n"
+        "|---|------|------|\n"
+        "| H1 | [Short Paper Name](https://arxiv.org/abs/1111.11111) | x |\n"
+        "| H2 | [Other](https://arxiv.org/abs/2222.22222v2) | y |\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(prepare_pages, "PROGRESS_PATH", str(progress))
+    by_name, by_arxiv = prepare_pages.parse_high_impact_h_order()
+    assert by_arxiv["1111.11111"] == 1
+    assert by_arxiv["2222.22222"] == 2
+    assert by_name[normalize_name("Short Paper Name")] == 1
+
+
+def test_match_high_impact_h_order_prefers_arxiv():
+    """When title text drifts from PROGRESS, arXiv still pins the H index."""
+    by_name = {normalize_name("Progress Title Only"): 5}
+    by_arxiv = {"3333.33333": 7}
+    got = prepare_pages.match_high_impact_h_order(
+        "Different Title on Disk",
+        "Some_Dir",
+        "3333.33333",
+        by_name,
+        by_arxiv,
+    )
+    assert got == 7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

主页「高影响力精选」各子分类下的论文卡片顺序此前受全局 `PROGRESS.md` 行序与部分笔记 `paper_order` 影响，与 `PROGRESS` 中高影响力表的 **H1–H23 编号** 不一致。

本 PR 在 `scripts/prepare_pages.py` 中单独解析 `H\d+` 表行，并**优先用 arXiv ID**（其次标题模糊匹配）将笔记映射到对应 H 序号，仅作用于 `03_High_Impact_Selection`；无 H 条目的笔记仍走原有 `paper_order` / 全局表顺序。已重新运行脚本更新 `_data/papers.json`。

## 环境与文档

- 已在 Ubuntu 类环境通过 `apt` 安装 `ruby-full`、`ruby-bundler`、`build-essential`、`zlib1g-dev`，并执行 `sudo bundle install`；本地已验证 `python3 scripts/prepare_pages.py` 与 `bundle exec jekyll build` 通过。
- `AGENTS.md` 已补充：**若缺少 Ruby / ruff / pytest，须先按文档安装，勿跳过**（含 `pip3 install -r requirements-dev.txt` 等）。

## 验收

下列截图由当前 `_data/papers.json` 生成静态列表（与 Jekyll 首页该区块渲染顺序一致），视口约 390px 宽。

![修复后：高影响力精选各子类论文顺序（按 H 编号）](https://cursor.com/artifacts/c/art-bf0ede09-5391-4ae8-845b-4f28d0e3170c)

## 测试

- `python3 -m ruff check scripts/prepare_pages.py tests/test_prepare_pages.py`
- `python3 -m pytest -q tests/test_prepare_pages.py tests/test_prepare_pages_golden.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee2f186d-b8d8-497d-b2b6-7b68a717d4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee2f186d-b8d8-497d-b2b6-7b68a717d4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

