### PR TITLE
feat(UI): Mermaid 流程图点击放大与拖拽平移

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,6 +35,7 @@
   <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"
           integrity="sha384-rbtjAdnIQE/aQJGEgXrVUlMibdfTSa4PQju4HDhN3sR2PmaKFzhEafuePsl9H/9I"
           crossorigin="anonymous"></script>
+  <script src="{{ '/assets/js/mermaid-zoom.js' | relative_url }}" defer></script>
   <script>
     function initMermaid(theme) {
       if (typeof mermaid === 'undefined') return;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -627,6 +627,108 @@ body {
   margin: 0 auto;
 }
 
+.mermaid:has(svg) {
+  cursor: zoom-in;
+}
+
+/* ===== Mermaid lightbox (click to enlarge, drag to pan) ===== */
+body.mermaid-lightbox-open {
+  overflow: hidden;
+}
+
+.mermaid-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 10050;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.mermaid-lightbox[hidden] {
+  display: none !important;
+}
+
+.mermaid-lightbox__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.62);
+}
+
+.mermaid-lightbox__panel {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(96vw, 1200px);
+  height: min(92vh, 900px);
+  margin: auto;
+  padding: 0.75rem 1rem 1rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.mermaid-lightbox__close {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.55rem;
+  z-index: 2;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mermaid-lightbox__close:hover {
+  background: var(--bg-secondary);
+  color: var(--text);
+}
+
+.mermaid-lightbox__hint {
+  margin: 0 0 0.5rem;
+  padding-right: 2rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.mermaid-lightbox__viewport {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  touch-action: none;
+  cursor: grab;
+  user-select: none;
+}
+
+.mermaid-lightbox__viewport.is-dragging {
+  cursor: grabbing;
+}
+
+.mermaid-lightbox__stage {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+.mermaid-lightbox__stage .mermaid-lightbox__svg {
+  display: block;
+  max-width: none !important;
+  height: auto !important;
+}
+
 [data-theme="dark"] .mermaid {
   background: #1e1e1e;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -726,7 +726,6 @@ body.mermaid-lightbox-open {
 .mermaid-lightbox__stage .mermaid-lightbox__svg {
   display: block;
   max-width: none !important;
-  height: auto !important;
 }
 
 [data-theme="dark"] .mermaid {

--- a/assets/js/mermaid-zoom.js
+++ b/assets/js/mermaid-zoom.js
@@ -1,0 +1,226 @@
+/**
+ * Click any rendered Mermaid diagram to open a fullscreen lightbox.
+ * Pan with left mouse button (or touch drag); close with Esc, backdrop, or ×.
+ */
+(function () {
+  'use strict';
+
+  var lightbox = null;
+  var viewport = null;
+  var stage = null;
+  var state = {
+    scale: 1,
+    x: 0,
+    y: 0,
+    dragging: false,
+    pointerId: null,
+    lastClientX: 0,
+    lastClientY: 0,
+  };
+
+  function ensureLightbox() {
+    if (lightbox) return lightbox;
+
+    lightbox = document.createElement('div');
+    lightbox.className = 'mermaid-lightbox';
+    lightbox.setAttribute('role', 'dialog');
+    lightbox.setAttribute('aria-modal', 'true');
+    lightbox.setAttribute('aria-label', 'Mermaid diagram viewer');
+    lightbox.hidden = true;
+
+    var backdrop = document.createElement('div');
+    backdrop.className = 'mermaid-lightbox__backdrop';
+    backdrop.setAttribute('data-mermaid-lightbox-close', '');
+
+    var panel = document.createElement('div');
+    panel.className = 'mermaid-lightbox__panel';
+
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'mermaid-lightbox__close';
+    closeBtn.setAttribute('data-mermaid-lightbox-close', '');
+    closeBtn.setAttribute('aria-label', '关闭');
+    closeBtn.textContent = '×';
+
+    var hint = document.createElement('p');
+    hint.className = 'mermaid-lightbox__hint';
+    hint.textContent = '拖拽平移 · Esc 关闭';
+
+    viewport = document.createElement('div');
+    viewport.className = 'mermaid-lightbox__viewport';
+
+    stage = document.createElement('div');
+    stage.className = 'mermaid-lightbox__stage';
+    viewport.appendChild(stage);
+
+    panel.appendChild(closeBtn);
+    panel.appendChild(hint);
+    panel.appendChild(viewport);
+    lightbox.appendChild(backdrop);
+    lightbox.appendChild(panel);
+    document.body.appendChild(lightbox);
+
+    closeBtn.addEventListener('click', close);
+    backdrop.addEventListener('click', close);
+
+    lightbox.addEventListener('click', function (e) {
+      if (e.target === lightbox) close();
+    });
+
+    panel.addEventListener('click', function (e) {
+      e.stopPropagation();
+    });
+
+    viewport.addEventListener('pointerdown', onPointerDown);
+    viewport.addEventListener('pointermove', onPointerMove);
+    viewport.addEventListener('pointerup', onPointerUp);
+    viewport.addEventListener('pointercancel', onPointerUp);
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return lightbox;
+  }
+
+  function applyTransform() {
+    if (!stage) return;
+    stage.style.transform =
+      'translate(calc(-50% + ' +
+      state.x +
+      'px), calc(-50% + ' +
+      state.y +
+      'px)) scale(' +
+      state.scale +
+      ')';
+  }
+
+  function measureSvg(svg) {
+    var viewBox = svg.viewBox && svg.viewBox.baseVal;
+    if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
+      return { width: viewBox.width, height: viewBox.height };
+    }
+    var rect = svg.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      return { width: rect.width, height: rect.height };
+    }
+    var w = parseFloat(svg.getAttribute('width'));
+    var h = parseFloat(svg.getAttribute('height'));
+    if (w > 0 && h > 0) return { width: w, height: h };
+    return { width: 800, height: 600 };
+  }
+
+  function fitToViewport(svg) {
+    var size = measureSvg(svg);
+    var pad = 48;
+    var vw = Math.max(viewport.clientWidth - pad, 200);
+    var vh = Math.max(viewport.clientHeight - pad, 200);
+    var fit = Math.min(vw / size.width, vh / size.height);
+    state.scale = Math.min(Math.max(fit, 0.25), 3);
+    state.x = 0;
+    state.y = 0;
+    applyTransform();
+  }
+
+  function open(sourceEl) {
+    var svg = sourceEl.querySelector('svg');
+    if (!svg) return;
+
+    ensureLightbox();
+    stage.innerHTML = '';
+    var clone = svg.cloneNode(true);
+    clone.style.maxWidth = 'none';
+    clone.style.width = 'auto';
+    clone.style.height = 'auto';
+    clone.classList.add('mermaid-lightbox__svg');
+    stage.appendChild(clone);
+
+    state.dragging = false;
+    state.pointerId = null;
+    lightbox.hidden = false;
+    lightbox.classList.add('is-open');
+    document.body.classList.add('mermaid-lightbox-open');
+
+    requestAnimationFrame(function () {
+      fitToViewport(clone);
+    });
+  }
+
+  function close() {
+    if (!lightbox || lightbox.hidden) return;
+    lightbox.hidden = true;
+    lightbox.classList.remove('is-open');
+    document.body.classList.remove('mermaid-lightbox-open');
+    state.dragging = false;
+    state.pointerId = null;
+    if (viewport) viewport.classList.remove('is-dragging');
+    if (stage) stage.innerHTML = '';
+  }
+
+  function onKeyDown(e) {
+    if (e.key === 'Escape' && lightbox && !lightbox.hidden) {
+      e.preventDefault();
+      close();
+    }
+  }
+
+  function onPointerDown(e) {
+    if (!lightbox || lightbox.hidden) return;
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
+    state.dragging = true;
+    state.pointerId = e.pointerId;
+    state.lastClientX = e.clientX;
+    state.lastClientY = e.clientY;
+    viewport.classList.add('is-dragging');
+    viewport.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }
+
+  function onPointerMove(e) {
+    if (!state.dragging || e.pointerId !== state.pointerId) return;
+    var dx = e.clientX - state.lastClientX;
+    var dy = e.clientY - state.lastClientY;
+    state.lastClientX = e.clientX;
+    state.lastClientY = e.clientY;
+    state.x += dx;
+    state.y += dy;
+    applyTransform();
+    e.preventDefault();
+  }
+
+  function onPointerUp(e) {
+    if (!state.dragging || e.pointerId !== state.pointerId) return;
+    state.dragging = false;
+    state.pointerId = null;
+    viewport.classList.remove('is-dragging');
+    try {
+      viewport.releasePointerCapture(e.pointerId);
+    } catch (err) {
+      /* ignore */
+    }
+  }
+
+  function findMermaidTarget(target) {
+    if (!target || !target.closest) return null;
+    var el = target.closest('.mermaid');
+    if (!el || !el.querySelector('svg')) return null;
+    return el;
+  }
+
+  document.addEventListener(
+    'click',
+    function (e) {
+      if (lightbox && !lightbox.hidden) return;
+      var mermaid = findMermaidTarget(e.target);
+      if (!mermaid) return;
+      e.preventDefault();
+      open(mermaid);
+    },
+    true
+  );
+
+  new MutationObserver(function () {
+    if (lightbox && !lightbox.hidden) close();
+  }).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+})();

--- a/assets/js/mermaid-zoom.js
+++ b/assets/js/mermaid-zoom.js
@@ -108,6 +108,20 @@
     return { width: 800, height: 600 };
   }
 
+  /** Mermaid often sets width="100%" + max-width; that collapses to 0×0 outside .mermaid. */
+  function cloneSvgForLightbox(svg) {
+    var clone = svg.cloneNode(true);
+    var size = measureSvg(svg);
+    clone.removeAttribute('width');
+    clone.removeAttribute('height');
+    clone.style.cssText = '';
+    clone.style.width = size.width + 'px';
+    clone.style.height = size.height + 'px';
+    clone.style.maxWidth = 'none';
+    clone.classList.add('mermaid-lightbox__svg');
+    return clone;
+  }
+
   function fitToViewport(svg) {
     var size = measureSvg(svg);
     var pad = 48;
@@ -126,11 +140,7 @@
 
     ensureLightbox();
     stage.innerHTML = '';
-    var clone = svg.cloneNode(true);
-    clone.style.maxWidth = 'none';
-    clone.style.width = 'auto';
-    clone.style.height = 'auto';
-    clone.classList.add('mermaid-lightbox__svg');
+    var clone = cloneSvgForLightbox(svg);
     stage.appendChild(clone);
 
     state.dragging = false;
@@ -140,7 +150,9 @@
     document.body.classList.add('mermaid-lightbox-open');
 
     requestAnimationFrame(function () {
-      fitToViewport(clone);
+      requestAnimationFrame(function () {
+        fitToViewport(clone);
+      });
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

为站点内所有已渲染的 Mermaid 流程图（含首页路线图与论文页）增加全屏灯箱查看：

- 点击 `.mermaid` 区域即可放大查看
- 放大后可在视口内按住鼠标左键（或触摸）拖拽平移
- 支持 Esc、点击遮罩或右上角 × 关闭
- 切换明暗主题时自动关闭灯箱

## 修复（灯箱空白）

Mermaid 渲染的 SVG 常带 `width="100%"` 与 `max-width` 约束；克隆到灯箱后若再设 `width/height: auto`，在脱离原容器时尺寸会塌缩为 **0×0**，表现为空白。现改为按 `viewBox` 写入明确像素宽高后再缩放适配视口。

## 浏览器验收（修复后）

PPO 论文页本地 Jekyll（1280×900）：

[Mermaid 灯箱：点击放大（修复后可见流程图）](https://cursor.com/agents/bc-e478d345-a9aa-4385-bbaf-d9f65f980fd0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmermaid-lightbox-open.png)

[Mermaid 灯箱：拖拽平移后](https://cursor.com/agents/bc-e478d345-a9aa-4385-bbaf-d9f65f980fd0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmermaid-lightbox-panned.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e478d345-a9aa-4385-bbaf-d9f65f980fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e478d345-a9aa-4385-bbaf-d9f65f980fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

