### PR TITLE
fix(DeepMimic): 修复移动端代码块被压扁导致页面显示异常

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@
           crossorigin="anonymous"></script>
   <!-- DOMPurify (pinned + SRI) -->
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js"
-          integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+          integrity="sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu"
           crossorigin="anonymous"></script>
   <!-- Mermaid (pinned + SRI) -->
   <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1568,11 +1568,13 @@ html[data-lang-mode="zh"] .footer-text-zh {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    contain: strict;
+    /* inline-size only: ``contain: strict`` collapses block height (~1 line) on
+       mobile and clips Python/bash samples inside DeepMimic-style notes. */
+    contain: inline-size;
   }
 
   .paper-body .table-wrapper {
-    contain: strict;
+    contain: inline-size;
   }
 
   /* Rouge wrapper must clip wide .code-block scroll overflow so it cannot

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -236,6 +236,7 @@
         codeEl.classList.contains('language-mermaid') ||
         codeEl.classList.contains('mermaid') ||
         text.startsWith('graph ') ||
+        text.startsWith('flowchart ') ||
         text.startsWith('sequenceDiagram') ||
         text.startsWith('gantt') ||
         text.startsWith('classDiagram');

--- a/tests/test_mobile_contain_css.py
+++ b/tests/test_mobile_contain_css.py
@@ -1,0 +1,36 @@
+"""Regression: mobile ``contain: strict`` on tables/code must not collapse height."""
+
+from pathlib import Path
+
+STYLE = Path(__file__).resolve().parents[1] / "assets" / "css" / "style.css"
+
+
+def _mobile_paper_body_block() -> str:
+    text = STYLE.read_text(encoding="utf-8")
+    marker = ".paper-body .table-wrapper"
+    table_idx = text.find(marker)
+    assert table_idx != -1, "table-wrapper mobile rules missing"
+    start = text.rfind("@media (max-width: 1200px)", 0, table_idx)
+    assert start != -1, "mobile paper-body block missing"
+    return text[start:]
+
+
+def _assert_uses_inline_size_only(snippet: str) -> None:
+    """Property lines only — ignore comments that mention ``strict``."""
+    for line in snippet.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("/*") or stripped.startswith("*"):
+            continue
+        assert "contain: strict" not in stripped
+
+
+def test_mobile_table_wrapper_not_contain_strict():
+    block = _mobile_paper_body_block()
+    idx = block.index(".paper-body .table-wrapper")
+    _assert_uses_inline_size_only(block[idx : idx + 200])
+
+
+def test_mobile_code_block_not_contain_strict():
+    block = _mobile_paper_body_block()
+    idx = block.index(".paper-body .code-block")
+    _assert_uses_inline_size_only(block[idx : idx + 320])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题（与截图一致）

在 iPhone 等窄屏（约 390px）下，DeepMimic 页 **「📋 基本信息」「📌 英文缩写速查」等 Markdown 表格整块空白**，只剩标题与分隔线；代码块同样几乎只剩一行。

根因：移动端为消除主栏右侧空白，对 `.paper-body .table-wrapper` / `.code-block` 使用了 **`contain: strict`**。在 size containment 下，容器 **`clientHeight` 被算成 0**（`scrollHeight` 仍有数百 px），Safari/Chrome 移动端上内容不可见。

生产页复现（修复前）：

- 基本信息 `.table-wrapper`：`clientHeight: 0`，`scrollHeight: 321`
- 英文缩写表：`clientHeight: 0`，`scrollHeight: 601`

## 修复

将上述容器的 `contain` 从 `strict` 改为 **`inline-size`**（仍限制横向撑破版心，不压扁块级高度）。

另：修正 DOMPurify CDN 的 SRI；`paper.js` 识别 `flowchart ` 前缀的 Mermaid。

## 验收（390×844）

修复后基本信息表 `clientHeight: 321`，可见 arXiv / 作者 / GitHub 等行。

[修复后：基本信息表（390×844）](https://cursor.com/agents/bc-c0a0de19-285b-495a-807e-200752e626bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdeepmimic-basic-info-mobile-390.png)

[修复后：MimicKit 代码块（390×844）](https://cursor.com/agents/bc-c0a0de19-285b-495a-807e-200752e626bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdeepmimic-mobile-after.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0a0de19-285b-495a-807e-200752e626bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0a0de19-285b-495a-807e-200752e626bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

