### PR TITLE
fix(UI): 代码块整体横向滚动，修复逐行单独滑动

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1553,21 +1553,13 @@ html[data-lang-mode="zh"] .footer-text-zh {
     overflow-x: clip;
   }
 
-  .paper-body .code-row {
-    min-width: 0;
-    max-width: 100%;
-  }
-
-  .paper-body .code-cell {
-    min-width: 0;
-    overflow-x: auto;
-    max-width: calc(100% - 3rem);
-  }
-
+  /* Scroll the whole .code-block (all lines together), not each .code-cell. */
   .paper-body .code-block {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     /* inline-size only: ``contain: strict`` collapses block height (~1 line) on
        mobile and clips Python/bash samples inside DeepMimic-style notes. */
     contain: inline-size;

--- a/tests/test_mobile_contain_css.py
+++ b/tests/test_mobile_contain_css.py
@@ -34,3 +34,12 @@ def test_mobile_code_block_not_contain_strict():
     block = _mobile_paper_body_block()
     idx = block.index(".paper-body .code-block")
     _assert_uses_inline_size_only(block[idx : idx + 320])
+
+
+def test_mobile_code_scrolls_on_block_not_per_line():
+    """Wide code must scroll inside .code-block, not on each .code-cell row."""
+    block = _mobile_paper_body_block()
+    assert ".paper-body .code-cell" not in block
+    snippet = block[block.index(".paper-body .code-block") :]
+    snippet = snippet[: snippet.index(".paper-body .table-wrapper")]
+    assert "overflow-x: auto" in snippet


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端代码块出现「每一行各自左右滑」的体验，长代码难以对齐阅读。

## 原因

在 `@media (max-width: 1200px)` 中曾把 `overflow-x: auto` 和 `max-width` 设在 `.code-cell` 上，并压缩 `.code-row` 宽度，导致每行成为独立横向滚动容器。

## 修复

- 移除移动端对 `.code-cell` / `.code-row` 的逐行滚动与宽度限制
- 在 `.code-block` 上保留/显式设置 `overflow-x: auto`，整块代码框统一横向滚动
- 新增回归测试，防止再次在 `.code-cell` 上开启横向滚动

## 验收

[修复后：代码块整体横向滚动（390×844）](https://cursor.com/agents/bc-d43347b1-8450-49fb-b0c4-5c871129b892/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcode-block-unified-scroll-390x844.png)

Playwright 校验：` .code-block` 为 `overflow-x: auto`，`.code-cell` 为 `visible`。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d43347b1-8450-49fb-b0c4-5c871129b892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d43347b1-8450-49fb-b0c4-5c871129b892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

