### PR TITLE
fix(UI): 移动端代码块改为换行布局并修复 inline 代码断行

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1423,6 +1423,12 @@ html[data-lang-mode="zh"] .footer-text-zh {
   line-height: 1.5;
   white-space: pre;
   contain: inline-size;
+  /* Grid layout so every row aligns to the same two columns (gutter + cell)
+     and the cell track sizes to the widest line. Without this short rows are
+     narrower than long rows and scrolling looks like ragged per-line drift. */
+  display: grid;
+  grid-template-columns: 3rem auto;
+  grid-auto-flow: row;
 }
 
 [data-theme="dark"] .paper-body .code-block {
@@ -1438,16 +1444,14 @@ html[data-lang-mode="zh"] .footer-text-zh {
 }
 
 .paper-body .code-row {
-  display: flex;
-  align-items: baseline;
-  /* Row never wraps: gutter + code stay on one visual line */
-  flex-wrap: nowrap;
-  min-width: max-content;
+  /* Make the row "transparent" so its two children (.code-ln and .code-cell)
+     become direct grid items of .code-block. This guarantees every row aligns
+     to the same gutter/cell columns regardless of line length. */
+  display: contents;
 }
 
 .paper-body .code-ln {
-  flex: 0 0 3rem;
-  width: 3rem;
+  /* Grid column 1 (3rem) handles the width; gutter just paints inside it. */
   text-align: right;
   padding-right: 0.75rem;
   color: #999;
@@ -1462,7 +1466,8 @@ html[data-lang-mode="zh"] .footer-text-zh {
 }
 
 .paper-body .code-cell {
-  flex: 1;
+  /* Grid column 2 (auto) sizes to the widest cell, so every row visually
+     shares the same right edge while scrolling. */
   padding-right: 1.5rem;
   white-space: pre;
   word-break: normal;
@@ -1553,41 +1558,16 @@ html[data-lang-mode="zh"] .footer-text-zh {
     overflow-x: clip;
   }
 
-  /* Wrap code content on mobile instead of horizontal scrolling. iOS Safari's
-     floating overlay scrollbar otherwise appears at the line a finger last
-     scrolled through, which reads as a "single-line scrollbar" artifact. */
+  /* Scroll the whole .code-block (all lines together), not each .code-cell. */
   .paper-body .code-block {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    overflow-x: hidden;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     /* inline-size only: ``contain: strict`` collapses block height (~1 line) on
        mobile and clips Python/bash samples inside DeepMimic-style notes. */
     contain: inline-size;
-  }
-
-  .paper-body .code-row {
-    /* Allow the row (gutter + cell) to shrink so its cell can wrap. */
-    min-width: 0;
-    /* Gutter aligns with the first wrapped visual line, not the baseline of
-       the last one. */
-    align-items: flex-start;
-  }
-
-  .paper-body .code-cell {
-    /* Wrap long code lines while preserving indentation. */
-    min-width: 0;
-    flex: 1 1 auto;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    word-break: normal;
-  }
-
-  /* Plain <pre> (when JS rebuild hasn't run, or for non-rouge code) wraps too. */
-  .paper-body pre {
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    word-break: normal;
   }
 
   .paper-body .table-wrapper {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1553,16 +1553,41 @@ html[data-lang-mode="zh"] .footer-text-zh {
     overflow-x: clip;
   }
 
-  /* Scroll the whole .code-block (all lines together), not each .code-cell. */
+  /* Wrap code content on mobile instead of horizontal scrolling. iOS Safari's
+     floating overlay scrollbar otherwise appears at the line a finger last
+     scrolled through, which reads as a "single-line scrollbar" artifact. */
   .paper-body .code-block {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow-x: hidden;
     /* inline-size only: ``contain: strict`` collapses block height (~1 line) on
        mobile and clips Python/bash samples inside DeepMimic-style notes. */
     contain: inline-size;
+  }
+
+  .paper-body .code-row {
+    /* Allow the row (gutter + cell) to shrink so its cell can wrap. */
+    min-width: 0;
+    /* Gutter aligns with the first wrapped visual line, not the baseline of
+       the last one. */
+    align-items: flex-start;
+  }
+
+  .paper-body .code-cell {
+    /* Wrap long code lines while preserving indentation. */
+    min-width: 0;
+    flex: 1 1 auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  /* Plain <pre> (when JS rebuild hasn't run, or for non-rouge code) wraps too. */
+  .paper-body pre {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   .paper-body .table-wrapper {
@@ -1577,6 +1602,27 @@ html[data-lang-mode="zh"] .footer-text-zh {
     overflow-x: hidden;
     overflow-x: clip;
     contain: inline-size;
+  }
+
+  /* Inline code (in paragraphs/lists/tables): don't shatter identifiers at every
+     underscore the way the parent's ``word-break: break-word`` would. Break at
+     ``<wbr>`` hints (added by paper.js around / . _ - in long paths) first,
+     and only fall back to mid-token breaks when a single token still overflows. */
+  .paper-body p code,
+  .paper-body li code,
+  .paper-body td code,
+  .paper-body th code,
+  .paper-body h1 code,
+  .paper-body h2 code,
+  .paper-body h3 code,
+  .paper-body h4 code,
+  .paper-body h5 code,
+  .paper-body h6 code,
+  .paper-body blockquote code,
+  .paper-body dt code,
+  .paper-body dd code {
+    word-break: normal;
+    overflow-wrap: anywhere;
   }
 
   .paper-body h1,

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -312,11 +312,73 @@
     }
   }
 
+  // ─── Insert <wbr> in long inline code so paths break at /, then ── ────────
+  // Without these hints the mobile parent's ``word-break: break-word`` shatters
+  // identifiers at arbitrary positions inside a filename. Two-stage hinting:
+  //   1. ``/`` → preferred break (between path segments).
+  //   2. ``.`` and ``_`` and ``-`` → secondary breaks only when a single segment
+  //      between slashes is itself too long to fit.
+  // Anything still longer than the line falls back to ``overflow-wrap: anywhere``
+  // (any-character break) so it cannot overflow the viewport.
+  function applyWbrSplit(code, parts) {
+    while (code.firstChild) code.removeChild(code.firstChild);
+    for (var j = 0; j < parts.length; j++) {
+      if (j > 0) code.appendChild(document.createElement('wbr'));
+      code.appendChild(document.createTextNode(parts[j]));
+    }
+    code.dataset.wbrApplied = '1';
+  }
+
+  function splitLongSegment(seg) {
+    // For a single path segment with no slashes, allow secondary breaks at
+    // ``.``, ``_``, ``-`` boundaries (kept with the next chunk).
+    return seg.split(/(?=[._\-])/);
+  }
+
+  function addInlineCodeBreakHints() {
+    var paperBody = document.getElementById('paper-body');
+    if (!paperBody) return;
+    var codes = paperBody.querySelectorAll('code');
+    for (var i = 0; i < codes.length; i++) {
+      var code = codes[i];
+      // Skip code inside <pre> (block code) and skip if already processed.
+      if (code.closest('pre')) continue;
+      if (code.dataset.wbrApplied === '1') continue;
+      var text = code.textContent;
+      if (!text || text.length < 16) continue;
+      // Only act when the token has no whitespace (paths, identifiers, URLs).
+      if (/\s/.test(text)) continue;
+      // Don't touch code that already contains child elements (syntax-highlighted spans).
+      if (code.firstElementChild) continue;
+
+      // Primary split at ``/`` (kept with the next chunk: ``foo/bar`` →
+      // ``foo`` + ``<wbr>`` + ``/bar``). Path segments stay whole — a 28-char
+      // filename folds to its own line before splitting internally. Only when
+      // a single segment is longer than ~30 characters (true edge case, won't
+      // fit on a mobile line) do we add secondary ``.``/``_``/``-`` breaks so
+      // it can fold without overflowing.
+      var slashParts = text.split(/(?=\/)/);
+      var parts = [];
+      for (var k = 0; k < slashParts.length; k++) {
+        var seg = slashParts[k];
+        if (seg.length > 30) {
+          var sub = splitLongSegment(seg);
+          for (var m = 0; m < sub.length; m++) parts.push(sub[m]);
+        } else {
+          parts.push(seg);
+        }
+      }
+      if (parts.length < 2) continue;
+      applyWbrSplit(code, parts);
+    }
+  }
+
   function init() {
     initPaperNav();
     initTableWrappers();
     initToc();
     rebuildWithLineNumbers();
+    addInlineCodeBreakHints();
   }
 
   if (document.readyState === 'loading') {

--- a/tests/test_mobile_contain_css.py
+++ b/tests/test_mobile_contain_css.py
@@ -36,10 +36,31 @@ def test_mobile_code_block_not_contain_strict():
     _assert_uses_inline_size_only(block[idx : idx + 320])
 
 
-def test_mobile_code_scrolls_on_block_not_per_line():
-    """Wide code must scroll inside .code-block, not on each .code-cell row."""
+def test_mobile_code_wraps_not_per_line_scroll():
+    """Mobile code blocks must wrap (no horizontal scroll). The earlier per-row
+    ``overflow-x: auto`` on ``.code-cell`` caused finger-tracked iOS overlay
+    scrollbars; switching the block to wrap keeps content on screen instead."""
     block = _mobile_paper_body_block()
-    assert ".paper-body .code-cell" not in block
     snippet = block[block.index(".paper-body .code-block") :]
     snippet = snippet[: snippet.index(".paper-body .table-wrapper")]
-    assert "overflow-x: auto" in snippet
+    # Block itself does not scroll horizontally on mobile.
+    assert "overflow-x: hidden" in snippet
+    assert "overflow-x: auto" not in snippet
+    # Cell wraps with pre-wrap + overflow-wrap so long lines fold to the next line.
+    assert "white-space: pre-wrap" in snippet
+    assert "overflow-wrap: anywhere" in snippet
+
+
+def test_mobile_inline_code_does_not_shatter_identifiers():
+    """Inline code inside paragraphs/lists must not inherit the parent's
+    ``word-break: break-word`` (which splits ``foo_bar_baz.py`` between
+    arbitrary underscores). Override to ``word-break: normal`` + ``overflow-wrap:
+    anywhere`` so breaks only happen at <wbr> hints and as a last-resort
+    overflow fallback."""
+    block = _mobile_paper_body_block()
+    # Pull the inline-code rule block (".paper-body p code, ..., .paper-body dd code { ... }").
+    idx = block.index(".paper-body p code")
+    end = block.index("}", idx)
+    snippet = block[idx:end]
+    assert "word-break: normal" in snippet
+    assert "overflow-wrap: anywhere" in snippet

--- a/tests/test_mobile_contain_css.py
+++ b/tests/test_mobile_contain_css.py
@@ -36,19 +36,15 @@ def test_mobile_code_block_not_contain_strict():
     _assert_uses_inline_size_only(block[idx : idx + 320])
 
 
-def test_mobile_code_wraps_not_per_line_scroll():
-    """Mobile code blocks must wrap (no horizontal scroll). The earlier per-row
-    ``overflow-x: auto`` on ``.code-cell`` caused finger-tracked iOS overlay
-    scrollbars; switching the block to wrap keeps content on screen instead."""
+def test_mobile_code_scrolls_on_block_not_per_line():
+    """Wide code must scroll inside .code-block as a whole, not on each
+    .code-cell row. Per-row ``overflow-x: auto`` would let iOS Safari's
+    floating overlay scrollbar track each line individually."""
     block = _mobile_paper_body_block()
+    assert ".paper-body .code-cell" not in block
     snippet = block[block.index(".paper-body .code-block") :]
     snippet = snippet[: snippet.index(".paper-body .table-wrapper")]
-    # Block itself does not scroll horizontally on mobile.
-    assert "overflow-x: hidden" in snippet
-    assert "overflow-x: auto" not in snippet
-    # Cell wraps with pre-wrap + overflow-wrap so long lines fold to the next line.
-    assert "white-space: pre-wrap" in snippet
-    assert "overflow-wrap: anywhere" in snippet
+    assert "overflow-x: auto" in snippet
 
 
 def test_mobile_inline_code_does_not_shatter_identifiers():


### PR DESCRIPTION
之前移动端代码块走 .code-block 整体横向滚动，但 iOS Safari 的浮动滚动条会
出现在手指最后扫过的那一行，看起来像「单行滚动条」(见 issue 截图)。改为
让 .code-cell 用 pre-wrap 换行，整块不再溢出，滚动条彻底消失。

同时长 inline 代码路径 (如 gear_sonic/trl/modules/universal_token_modules.py)
之前会被父级 word-break: break-word 在下划线间断开为
"...universal_token" / "_modules.py"。现在在 paper.js 里给长 inline 代码
按 "/" 边界插入 <wbr>，并把 inline 代码自身的 word-break 还原为 normal +
overflow-wrap: anywhere，断行优先落在路径分隔符上，得到
"gear_sonic/trl/modules" / "/universal_token_modules.py"。