### PR TITLE
fix(UI): 全局滚动条轨道透明，取消默认白色槽背景

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -64,6 +64,35 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* ===== Scrollbars (transparent track — no default white gutter) ===== */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: transparent;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 /* ===== Header ===== */
 .site-header {
   background: var(--header-bg);
@@ -381,12 +410,12 @@ body {
   }
 }
 
-/* TOC scrollbar */
+/* TOC: narrower thumb; track stays transparent via global rules above */
 .toc-sidebar::-webkit-scrollbar {
   width: 3px;
+  height: 3px;
 }
 .toc-sidebar::-webkit-scrollbar-thumb {
-  background: var(--border);
   border-radius: 3px;
 }
 

--- a/tests/test_scrollbar_css.py
+++ b/tests/test_scrollbar_css.py
@@ -1,0 +1,27 @@
+"""Scrollbar track must stay transparent (no default white gutter)."""
+
+from pathlib import Path
+
+STYLE = Path(__file__).resolve().parents[1] / "assets" / "css" / "style.css"
+
+
+def test_global_scrollbar_track_is_transparent():
+    text = STYLE.read_text(encoding="utf-8")
+    assert "scrollbar-color: var(--border) transparent" in text
+    assert "::-webkit-scrollbar-track" in text
+    track_block = text[text.index("::-webkit-scrollbar-track") :]
+    track_block = track_block[: track_block.index("}", track_block.index("{"))]
+    assert "background: transparent" in track_block
+    assert "#fff" not in track_block
+    assert "#ffffff" not in track_block.lower()
+
+
+def test_toc_scrollbar_does_not_set_white_track():
+    text = STYLE.read_text(encoding="utf-8")
+    idx = text.index(".toc-sidebar::-webkit-scrollbar-thumb")
+    end = text.index("/* Sidebar Toggle", idx)
+    block = text[idx:end]
+    assert "scrollbar-track" not in block or "transparent" in block
+    assert "background:" not in block or "var(--border)" in block
+    assert "#fff" not in block
+    assert "#ffffff" not in block.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

浏览器默认滚动条轨道（track）在 WebKit / Chromium 上常为白色，与站点浅色/深色背景、代码块、表格横向滚动区域不协调。

本 PR 在 `assets/css/style.css` 中增加**全局**滚动条样式：

- Firefox：`scrollbar-color: var(--border) transparent`
- WebKit：`::-webkit-scrollbar-track` / `corner` 使用 `transparent`，仅 thumb 使用主题色 `var(--border)`
- 保留 TOC 侧栏较窄的 3px 滚动条宽度，不再单独为 track 设背景

## 验收

DeepMimic 论文页（含 TOC 纵向滚动、代码块/表格横向滚动）：

[修复后：滚动条轨道透明（1280×900）](https://cursor.com/agents/bc-aef293b1-f462-44b1-af29-d857b3bed6ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscrollbar-transparent-track.png)

## 测试

- 新增 `tests/test_scrollbar_css.py` 回归：轨道透明、TOC 规则不含白色 track 背景
- `pytest -v tests/test_scrollbar_css.py` 通过

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aef293b1-f462-44b1-af29-d857b3bed6ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aef293b1-f462-44b1-af29-d857b3bed6ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

