### PR TITLE
fix(UI): 修复 Mermaid 灯箱内流程图文字不可见

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -226,7 +226,12 @@
         var renderId = 'roadmap-mermaid-' + cacheKey.replace(':', '-') + '-' + renderSeq;
         return Promise.resolve(mermaid.render(renderId, graphText)).then(function(result) {
           if (renderSeq !== roadmapRenderSeq || getRoadmapCacheKey(normalizedMode) !== cacheKey) return;
-          var safeSvg = typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(result.svg) : result.svg;
+          var safeSvg =
+            typeof window.sanitizeMermaidSvg === 'function'
+              ? window.sanitizeMermaidSvg(result.svg)
+              : typeof DOMPurify !== 'undefined'
+                ? DOMPurify.sanitize(result.svg)
+                : result.svg;
           roadmapSvgCache[cacheKey] = safeSvg;
           mermaidRoadmap.innerHTML = safeSvg;
           mermaidRoadmap.removeAttribute('data-processed');

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -33,6 +33,19 @@
   window.MERMAID_RENDER_SCALE = MERMAID_RENDER_SCALE;
   window.MERMAID_LIGHTBOX_SCALE = MERMAID_LIGHTBOX_SCALE;
 
+  /**
+   * Mermaid htmlLabels embed text in SVG foreignObject. Default DOMPurify strips
+   * those nodes and leaves empty boxes in the lightbox / roadmap.
+   */
+  window.sanitizeMermaidSvg = function (svgString) {
+    if (!svgString) return '';
+    if (typeof DOMPurify === 'undefined') return svgString;
+    return DOMPurify.sanitize(svgString, {
+      USE_PROFILES: { svg: true, svgFilters: true },
+      ADD_TAGS: ['foreignObject'],
+    });
+  };
+
   window.getMermaidSiteConfig = function (theme) {
     return {
       startOnLoad: false,

--- a/assets/js/mermaid-zoom.js
+++ b/assets/js/mermaid-zoom.js
@@ -238,8 +238,14 @@
   }
 
   function sanitizeMermaidSvg(svgString) {
+    if (typeof window.sanitizeMermaidSvg === 'function') {
+      return window.sanitizeMermaidSvg(svgString);
+    }
     if (typeof DOMPurify !== 'undefined') {
-      return DOMPurify.sanitize(svgString);
+      return DOMPurify.sanitize(svgString, {
+        USE_PROFILES: { svg: true, svgFilters: true },
+        ADD_TAGS: ['foreignObject'],
+      });
     }
     return svgString;
   }

--- a/tests/test_mermaid_config.py
+++ b/tests/test_mermaid_config.py
@@ -26,3 +26,10 @@ def test_lightbox_rerenders_from_source():
     text = ZOOM_JS.read_text(encoding="utf-8")
     assert "buildMermaidLightboxGraph" in text
     assert "mermaid.render" in text
+
+
+def test_sanitize_mermaid_svg_keeps_foreign_object():
+    text = CONFIG_JS.read_text(encoding="utf-8")
+    assert "sanitizeMermaidSvg" in text
+    assert "foreignObject" in text
+    assert "USE_PROFILES" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

点击论文页 Mermaid 流程图打开灯箱后，节点框可见但标签文字全部消失（例如 PPO 页 GAE 示意图）。

## 原因

灯箱高清重绘路径在挂载 SVG 前使用默认 `DOMPurify.sanitize()`。Mermaid 在 `htmlLabels: true` 时把文字放在 SVG `foreignObject` 内，而默认配置会剥离这些节点，只留下空矩形。

## 修复

- 在 `mermaid-config.js` 新增共享函数 `sanitizeMermaidSvg()`，使用 `USE_PROFILES: { svg, svgFilters }` 并保留 `foreignObject`
- 灯箱（`mermaid-zoom.js`）与首页路线图（`default.html`）统一调用该函数

## 验收

PPO 论文页「第 2 步：计算优势（GAE）」流程图，灯箱内可正常显示 `① V(s) 估计` 等节点文字：

[修复后：Mermaid 灯箱显示节点标签](https://cursor.com/agents/bc-4f6b9385-cdbf-4821-8bb7-593320d2202d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmermaid-lightbox-labels-fix.png)

## 测试

- `pytest tests/test_mermaid_config.py -v`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f6b9385-cdbf-4821-8bb7-593320d2202d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f6b9385-cdbf-4821-8bb7-593320d2202d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

