### PR TITLE
fix(UI): 修复移动端标题内括号行内代码错行

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1172,6 +1172,14 @@ body.mermaid-lightbox-open {
 /* Parenthetical function names in headings: keep “（`fn`）” on one line */
 .paper-body .heading-code-phrase {
   white-space: nowrap;
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
+.paper-body .heading-code-phrase code {
+  display: inline;
+  margin: 0;
+  vertical-align: baseline;
 }
 
 .paper-body p {
@@ -1436,12 +1444,13 @@ html[data-lang-mode="zh"] .footer-text-zh {
 /* ===========================
    Rouge Syntax Highlighting — Single Box (table mode)
    =========================== */
-.paper-body .highlighter-rouge {
+/* Block Rouge wrappers only — inline ``code.highlighter-rouge`` in headings must stay inline */
+.paper-body div.highlighter-rouge {
   margin: 1.2rem 0;
 }
 
 /* ===== Code blocks (rouge colors + custom per-line layout) ===== */
-.paper-body .highlighter-rouge {
+.paper-body div.highlighter-rouge {
   margin: 1.2rem 0;
 }
 
@@ -1608,9 +1617,9 @@ html[data-lang-mode="zh"] .footer-text-zh {
     contain: inline-size;
   }
 
-  /* Rouge wrapper must clip wide .code-block scroll overflow so it cannot
-     inflate html/body scrollWidth on mobile. */
-  .paper-body .highlighter-rouge {
+  /* Rouge block wrapper only (``div.highlighter-rouge``). Inline ``code.highlighter-rouge``
+     in headings must not become ``display: block`` or they break onto their own line. */
+  .paper-body div.highlighter-rouge {
     display: block;
     max-width: 100%;
     overflow-x: hidden;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1169,6 +1169,11 @@ body.mermaid-lightbox-open {
   margin-bottom: 0.4rem;
 }
 
+/* Parenthetical function names in headings: keep “（`fn`）” on one line */
+.paper-body .heading-code-phrase {
+  white-space: nowrap;
+}
+
 .paper-body p {
   margin-bottom: 1rem;
 }
@@ -1632,6 +1637,15 @@ html[data-lang-mode="zh"] .footer-text-zh {
   .paper-body dd code {
     word-break: normal;
     overflow-wrap: anywhere;
+  }
+
+  .paper-body h1 code,
+  .paper-body h2 code,
+  .paper-body h3 code,
+  .paper-body h4 code,
+  .paper-body h5 code,
+  .paper-body h6 code {
+    white-space: nowrap;
   }
 
   .paper-body h1,

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -335,8 +335,12 @@
 
         var span = document.createElement('span');
         span.className = 'heading-code-phrase';
-        prev.textContent = prevText.slice(0, openIdx);
-        span.appendChild(document.createTextNode(prevText.slice(openIdx)));
+        // Keep the word before “（” on the same line as the parenthetical (e.g. “策略（fn）”).
+        var colonIdx = prevText.lastIndexOf('：');
+        var wrapStart =
+          colonIdx >= 0 && colonIdx < openIdx ? colonIdx + 1 : openIdx;
+        prev.textContent = prevText.slice(0, wrapStart);
+        span.appendChild(document.createTextNode(prevText.slice(wrapStart)));
         span.appendChild(code);
         span.appendChild(document.createTextNode(closeChar));
         if (nextText.length > 1) {

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -312,6 +312,43 @@
     }
   }
 
+  // ─── Keep “（`fn`）” in headings on one line (mobile word-break splits otherwise) ─
+  function wrapHeadingInlineCodePhrases() {
+    var body = document.getElementById('paper-body');
+    if (!body) return;
+    body.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(function (h) {
+      var codes = h.querySelectorAll(':scope > code');
+      for (var i = 0; i < codes.length; i++) {
+        var code = codes[i];
+        if (code.closest('.heading-code-phrase')) continue;
+        var prev = code.previousSibling;
+        var next = code.nextSibling;
+        if (!prev || prev.nodeType !== Node.TEXT_NODE) continue;
+        if (!next || next.nodeType !== Node.TEXT_NODE) continue;
+        var prevText = prev.textContent;
+        var nextText = next.textContent;
+        var openIdx = Math.max(prevText.lastIndexOf('（'), prevText.lastIndexOf('('));
+        if (openIdx === -1) continue;
+        var openChar = prevText.charAt(openIdx);
+        var closeChar = openChar === '（' ? '）' : ')';
+        if (!nextText.startsWith(closeChar)) continue;
+
+        var span = document.createElement('span');
+        span.className = 'heading-code-phrase';
+        prev.textContent = prevText.slice(0, openIdx);
+        span.appendChild(document.createTextNode(prevText.slice(openIdx)));
+        span.appendChild(code);
+        span.appendChild(document.createTextNode(closeChar));
+        if (nextText.length > 1) {
+          next.textContent = nextText.slice(1);
+        } else {
+          h.removeChild(next);
+        }
+        h.insertBefore(span, prev.nextSibling);
+      }
+    });
+  }
+
   // ─── Insert <wbr> in long inline code so paths break at /, then ── ────────
   // Without these hints the mobile parent's ``word-break: break-word`` shatters
   // identifiers at arbitrary positions inside a filename. Two-stage hinting:
@@ -343,6 +380,8 @@
       var code = codes[i];
       // Skip code inside <pre> (block code) and skip if already processed.
       if (code.closest('pre')) continue;
+      if (code.closest('.heading-code-phrase')) continue;
+      if (code.closest('h1, h2, h3, h4, h5, h6')) continue;
       if (code.dataset.wbrApplied === '1') continue;
       var text = code.textContent;
       if (!text || text.length < 16) continue;
@@ -378,6 +417,7 @@
     initTableWrappers();
     initToc();
     rebuildWithLineNumbers();
+    wrapHeadingInlineCodePhrases();
     addInlineCodeBreakHints();
   }
 

--- a/tests/test_heading_code_phrase.py
+++ b/tests/test_heading_code_phrase.py
@@ -20,3 +20,23 @@ def test_wrap_heading_inline_code_phrases_in_paper_js():
     assert "function wrapHeadingInlineCodePhrases()" in text
     assert "heading-code-phrase" in text
     assert "wrapHeadingInlineCodePhrases();" in text
+
+
+def test_mobile_rouge_block_rule_does_not_target_inline_code():
+    """``display: block`` on ``.highlighter-rouge`` must not apply to ``code`` in headings."""
+    block = _mobile_paper_body_block()
+    idx = block.index("Rouge block wrapper only")
+    snippet = block[idx : idx + 320]
+    assert ".paper-body div.highlighter-rouge" in snippet
+    assert "display: block" in snippet
+    assert ".paper-body .highlighter-rouge {" not in block
+
+
+def _mobile_paper_body_block() -> str:
+    text = STYLE.read_text(encoding="utf-8")
+    marker = ".paper-body .table-wrapper"
+    table_idx = text.find(marker, text.find("@media (max-width: 1200px)"))
+    assert table_idx != -1
+    start = text.rfind("@media (max-width: 1200px)", 0, table_idx)
+    assert start != -1
+    return text[start:]

--- a/tests/test_heading_code_phrase.py
+++ b/tests/test_heading_code_phrase.py
@@ -1,0 +1,22 @@
+"""Regression: headings with parenthetical inline code must not break across lines."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STYLE = ROOT / "assets" / "css" / "style.css"
+PAPER_JS = ROOT / "assets" / "js" / "paper.js"
+
+
+def test_heading_code_phrase_css():
+    text = STYLE.read_text(encoding="utf-8")
+    assert ".paper-body .heading-code-phrase" in text
+    idx = text.index(".paper-body .heading-code-phrase")
+    block = text[idx : idx + 120]
+    assert "white-space: nowrap" in block
+
+
+def test_wrap_heading_inline_code_phrases_in_paper_js():
+    text = PAPER_JS.read_text(encoding="utf-8")
+    assert "function wrapHeadingInlineCodePhrases()" in text
+    assert "heading-code-phrase" in text
+    assert "wrapHeadingInlineCodePhrases();" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端标题 `### 2. 核心：加权回归更新策略（`_compute_actor_loss`）` 被拆成三行：`（`、函数名、`)` 各占一行。

## 根因（补充）

上一版只包了 `.heading-code-phrase` 仍不够：**移动端** `.paper-body .highlighter-rouge { display: block; }` 本意是给代码块外层 `div` 用的，但 Jekyll/Rouge 给标题行内 code 也加了 `highlighter-rouge` class，导致 `<code>` 变成块级元素独占一行——这是截图里仍错行的真正原因。

## 修复

1. 移动端 Rouge 规则改为 **仅** `div.highlighter-rouge`（不再命中 `code.highlighter-rouge`）。
2. `.heading-code-phrase code` 强制 `display: inline`。
3. JS 将冒号后的「加权回归更新策略（fn）」整段包入 nowrap span。

## 验收（390×844，暗色）

[修复后：第二行完整显示 加权回归更新策略（_compute_actor_loss）](https://cursor.com/agents/bc-ff267cf6-cdb7-492c-9684-4ff812c9ca4e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fawr-heading-inline-code-390x844.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff267cf6-cdb7-492c-9684-4ff812c9ca4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff267cf6-cdb7-492c-9684-4ff812c9ca4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

