### PR TITLE
docs(Simulation Benchmark): 添加 MolmoSpaces 230k 室内场景多模拟器开源生态笔记（2026-05-20 轨 B）

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -898,6 +898,14 @@
         "dir": "Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots",
         "arxiv": "2603.06181",
         "zhname": "迈向动作图灵测试：评估人形机器人的「类人度」"
+      },
+      {
+        "title": "MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation",
+        "path": "papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md",
+        "url": "/papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.html",
+        "dir": "MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation",
+        "arxiv": "2602.11337",
+        "zhname": "MolmoSpaces：230k+ 室内场景 × 130k+ 物体 × 42M 抓取的全开源具身 AI 评测生态"
       }
     ],
     "zhname": "仿真基准"

--- a/papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md
+++ b/papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md
@@ -1,0 +1,222 @@
+---
+layout: paper
+paper_order: 4
+title: "MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation"
+zhname: "MolmoSpaces：230k+ 室内场景 × 130k+ 物体 × 42M 抓取的全开源具身 AI 评测生态"
+category: "Simulation Benchmark"
+---
+
+# MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation
+**Ai2 把场景、物体、抓取、机器人、模拟器接口、基准任务一口气全部开源，给「在仿真里训通用 VLA」这件事第一次配齐弹药**
+
+> 📅 阅读日期: 2026-05-20
+> 🏷️ 板块: 11 Simulation Benchmark · 大规模室内仿真 / 抓取标注 / 多模拟器统一接口 / VLA 基准
+> 🔁 推进轨: 模块轮转（10_Sim-to-Real → **11_Simulation_Benchmark**）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| arXiv | [2602.11337](https://arxiv.org/abs/2602.11337) |
+| HTML | [在线阅读 v2](https://arxiv.org/html/2602.11337v2) |
+| PDF | [下载](https://arxiv.org/pdf/2602.11337) |
+| 项目页 | [allenai.org/blog/molmospaces](https://allenai.org/blog/molmospaces) · [论文页](https://allenai.org/papers/molmospaces) |
+| 源码 | [allenai/molmospaces](https://github.com/allenai/molmospaces) |
+| Hugging Face | [papers/2602.11337](https://huggingface.co/papers/2602.11337) |
+| 提交日期 | 2026-02 |
+
+**作者机构**：**Allen Institute for AI (Ai2)** 等
+**配套模型**：[MolmoBot](https://allenai.org/blog/molmobot-robot-manipulation)（同期 Ai2 释出的"完全在仿真里训练"的操作策略）
+
+---
+
+## 🎯 一句话总结
+
+MolmoSpaces 把"做具身 AI 评测要拼数据集、要拼资产、要拼模拟器"这件事一次性解决：开放 **230k+** 室内场景（iTHOR-120 / ProcTHOR-10K / ProcTHOR-Objaverse / Holodeck 四源拼合）、**130k+** 富标注物体（其中 48k 可操作物体附 **42M** 稳定抓取标注），并通过 **simulator-agnostic** 资产格式同时跑通 **MuJoCo / Isaac (Lab & Sim) / ManiSkill** 三大主流仿真器，配套 **MolmoSpaces-Bench**（8 个长程任务）首次报告出**仿真分数与真机成功率 R = 0.96 / ρ = 0.98 的极强 sim-to-real 相关性**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 全称 | 解释 |
+|---|---|---|
+| Ai2 | Allen Institute for AI | 论文出品方 |
+| VLA | Vision-Language-Action model | 视觉-语言-动作通用机器人模型 |
+| ProcTHOR | Procedural THOR | 程序化生成的多房间室内场景生成器 |
+| iTHOR | Interactive THOR | 手工搭建的家庭交互场景 |
+| Holodeck | LLM-driven 3D scene generator | 文本到 3D 室内场景生成系统 |
+| sim-to-real correlation | 仿真分数与真机成功率的统计相关性（R / ρ）|
+
+---
+
+## ❓ 论文要解决什么问题？
+
+当前"在仿真里训通用机器人策略"卡在三件事：
+
+1. **数据规模上不去**：现有家用 / 室内 benchmark（AI2-THOR、RoboCasa、ManiSkill 等）场景数百到几千，**长尾分布严重**，难以训出真正泛化的 VLA；
+2. **资产标准散乱**：抓取标注、关节信息、碰撞模型在不同模拟器之间格式各异，**换个模拟器就要重做一次资产**；
+3. **评测不可比 / 不对真**：很多 benchmark 缺少配对的真机实验，**仿真上涨点不代表真机也涨**，sim-to-real 相关性没人系统量化过。
+
+MolmoSpaces 的回应：**一次性把数据、资产、模拟器适配、任务定义、真机对照实验全部统一并开源**——让"评测一个新策略"变成"换条命令"。
+
+---
+
+## 🔧 方法 / 数据集 / 评测
+
+### 1. 资产生态（"Open Ecosystem"的核心）
+
+| 维度 | 数量 / 内容 |
+|---|---|
+| 室内场景 | **230,000+**（iTHOR-120 手工 + ProcTHOR-10K 程序化 + ProcTHOR-Objaverse 增强 + Holodeck LLM 生成）|
+| 物体资产 | **130,000+** 富标注 |
+| 可操作物体 | **48,000** 附关节 / 物理参数 |
+| 抓取标注 | **42M** 稳定抓取（grasps）|
+| 场景类型 | 家庭 / 办公室 / 教室 / 医院 / 学校 / 博物馆 等 |
+| 资产格式 | **simulator-agnostic**：MuJoCo / Isaac Lab / Isaac Sim / ManiSkill 通用 |
+
+> 💡 与 ProcTHOR 等单一来源 benchmark 的区别：**Holodeck 通过 LLM 生成长尾场景** + **Objaverse 注入大规模 3D 物体**，让分布从"家居样板间"扩展到"博物馆、医院、教室"这类真正长尾的室内空间。
+
+### 2. MolmoSpaces-Bench：8 个任务的统一评测
+
+| 类别 | 任务 |
+|---|---|
+| 导航 | **navigate-to**（找目标） |
+| 静态操作 | **pick**、**open**、**close**、**open-door** |
+| 操作 + 空间推理 | **pick-and-place**、**pick-and-place-next-to**、**pick-and-place-color** |
+
+> 这 8 个任务覆盖**短程操作 / 长程移动操作 / 多房间长程任务**三档难度，相同任务可以在 MuJoCo / Isaac / ManiSkill 三个仿真器下各跑一遍——评估"仿真器无关性"。
+
+### 3. 基线策略 & 关键实验
+
+- **基线类型**：state-of-the-art **VLA 模型** + 经典 **模块化基线**（perception → planner → motion）；
+- **评测结果**：
+  - **sim-to-real 相关性极强**：MolmoSpaces-Bench 分数与真机成功率 **R = 0.96 / Spearman ρ = 0.98**，**pick 任务上 Pearson R² ≈ 0.92**；
+  - **新一代 VLA > 旧 VLA**：代代提升明显，但**对 prompt 改写、初始关节位姿、相机遮挡极敏感**——这是论文重点指出的"VLA 脆性"；
+  - **分布漂移测试**：指令措辞或初始位姿的微小扰动会让早期 VLA 成功率显著下降，新一代模型更鲁棒但仍未饱和。
+
+---
+
+## 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    subgraph SCENES["🏠 场景源（230k+）"]
+        S1["iTHOR-120<br/>(手工家庭)"]
+        S2["ProcTHOR-10K<br/>(程序化多房)"]
+        S3["ProcTHOR-Objaverse<br/>(注入长尾物体)"]
+        S4["Holodeck<br/>(LLM 生成)"]
+    end
+
+    subgraph ASSETS["📦 资产层"]
+        O1["130k+ 物体模型"]
+        O2["48k 可操作物体<br/>(关节 / 物理)"]
+        O3["42M 稳定抓取标注"]
+    end
+
+    subgraph FORMAT["🔌 simulator-agnostic 资产格式"]
+        F["统一 metadata + 物理参数 + URDF/MJCF 桥接"]
+    end
+
+    subgraph SIM["🧪 多模拟器后端"]
+        M1["MuJoCo"]
+        M2["Isaac Lab / Sim"]
+        M3["ManiSkill"]
+    end
+
+    subgraph BENCH["📊 MolmoSpaces-Bench (8 个任务)"]
+        B1["navigate-to"]
+        B2["pick"]
+        B3["pick-and-place / next-to / color"]
+        B4["open / close / open-door"]
+    end
+
+    subgraph EVAL["🎯 评测对象"]
+        E1["VLA 模型"]
+        E2["模块化基线"]
+        E3["真机对照实验"]
+    end
+
+    subgraph OUT["📈 关键发现"]
+        R1["sim-real 相关性<br/>R=0.96, ρ=0.98"]
+        R2["pick 任务 R²≈0.92"]
+        R3["VLA 对 prompt /<br/>初始位姿 / 遮挡敏感"]
+    end
+
+    S1 & S2 & S3 & S4 --> ASSETS
+    ASSETS --> FORMAT
+    FORMAT --> SIM
+    SIM --> BENCH
+    BENCH --> EVAL
+    EVAL --> OUT
+
+    OPEN["📤 全部开源:<br/>资产 + 生成管线 + 基准 + 工具链"]
+    OUT --> OPEN
+
+    style SCENES fill:#e8f4fd,stroke:#1f78b4
+    style ASSETS fill:#fff7e0,stroke:#d4a017
+    style FORMAT fill:#f3e8ff,stroke:#8e44ad
+    style SIM fill:#e8fbe8,stroke:#27ae60
+    style BENCH fill:#fde8e8,stroke:#c0392b
+    style EVAL fill:#fff3e0,stroke:#e67e22
+    style OPEN fill:#e0f7fa,stroke:#0097a7
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **史上最大开源室内具身 AI 数据底座**：230k 场景 × 130k 物体 × 42M 抓取，**全部开放下载**，配合生成管线可继续扩充。
+2. **simulator-agnostic 资产格式**：同一份场景 / 物体 / 抓取标注**直连 MuJoCo / Isaac / ManiSkill 三大主流仿真器**，研究者不再需要"为每个模拟器重做一次资产"。
+3. **MolmoSpaces-Bench**：8 个跨"短程操作 → 长程移动操作 → 多房间任务"的统一基准，覆盖 navigate / pick / place / open-close 全谱。
+4. **首次系统量化 sim-to-real 相关性**：R = 0.96 / ρ = 0.98 / 单任务 R² ≈ 0.92——给"仿真分数能不能预言真机表现"一个有量化依据的回答。
+5. **暴露 VLA 脆性**：实证发现**指令措辞 / 初始关节位姿 / 相机遮挡**对 VLA 成功率影响极大，指出下一阶段 VLA 鲁棒性研究的具体维度。
+6. **完全开放栈**：模型权重（配套 [MolmoBot](https://allenai.org/blog/molmobot-robot-manipulation)）、数据、生成管线、资产、benchmark、工具链**一次性全部公开**——是当前最贴近"具身 AI 的 ImageNet"的开放生态。
+
+---
+
+## 🤖 对人形 / 具身 AI 领域的意义
+
+| 方向 | 含义 |
+|---|---|
+| **VLA 训练** | 130k 物体 + 42M 抓取直接当 pretrain 监督，缓解机器人数据稀缺 |
+| **多模拟器 sim-to-real** | 同份资产跨 MuJoCo / Isaac / ManiSkill 验证一致性，天然形成 dynamics-level DR（与 PolySim 形成互补） |
+| **长程任务 benchmark** | 多房间 / 多目标任务终于有公平标尺 |
+| **真机预测** | R = 0.96 的强相关性，**让"先在仿真里跑分"变成靠谱的真机预筛** |
+| **VLA 鲁棒性研究** | 论文给出的 prompt / 位姿 / 遮挡敏感性，是下一代 VLA 必须解决的 OOD 维度 |
+| **生态外溢** | 资产可直接被 04_WBC / 06_Manipulation / 08_Navigation 复用，是"通用底座" |
+
+---
+
+## 🎤 面试参考
+
+**Q：MolmoSpaces 和已有的 ProcTHOR、RoboCasa、HumanoidBench 比，质的差别在哪？**
+A：(1) **规模量级**：230k 场景 + 42M 抓取——比 RoboCasa（~1k 场景）和 ProcTHOR（10k 场景）都高 1–2 个数量级。(2) **simulator-agnostic 资产格式**：同一份资产能直接喂 MuJoCo / Isaac / ManiSkill，**没有"换模拟器要重做资产"的工程税**。(3) **首次量化 sim-to-real 相关性**（R = 0.96），让仿真基准对真机的预测价值有可信数字背书，这是之前所有具身 benchmark 缺的关键证据。
+
+**Q：为什么 sim-to-real 相关性能做到 R = 0.96？**
+A：核心因素是**资产多样性 + 任务难度匹配**：(1) 230k 场景覆盖家庭/办公/医院/教室等长尾分布，**仿真上能区分的策略差异，真机也保持得住**；(2) 42M 稳定抓取标注让 pick 类任务在仿真里"作弊"空间小；(3) 任务难度梯度合理（短程 → 长程 → 多房间），让分数不至于天花板饱和。但论文也指出这是"在他们设定的真机任务上的相关性"，不代表所有真机场景都能保持。
+
+**Q：论文指出"VLA 对 prompt 改写、初始位姿、相机遮挡敏感"，这对后续工作意味着什么？**
+A：意味着**单纯堆数据 / 模型大小不够**——下一代 VLA 必须在三个 OOD 维度上专门加强：(1) 语言鲁棒性（同义指令应得到同等执行）；(2) 物理鲁棒性（初始关节位姿扰动下仍能完成任务）；(3) 感知鲁棒性（部分遮挡 / 视角偏移）。具体到训练范式，可能要引入 prompt augmentation、初始状态域随机化、相机视角随机化等模块。
+
+**Q：MolmoSpaces 跟 GRUtopia 都是大规模室内仿真，怎么取舍？**
+A：(1) **GRUtopia** 强调**城市级（多建筑、社会化）**、含 NPC、长程语言任务；(2) **MolmoSpaces** 强调**室内规模（230k 场景）+ 资产精细度（42M 抓取）+ 跨模拟器统一**——更偏向"操作 / 抓取 / 短到中程任务"。如果做服务机器人语义任务用 GRUtopia，做通用操作 / VLA pretrain 用 MolmoSpaces。
+
+---
+
+## 🔗 相关阅读
+
+- [GRUtopia (arXiv 2407.10943)](https://arxiv.org/abs/2407.10943)：城市级具身仿真平台（本仓库已有笔记）
+- [HumanoidBench (arXiv 2403.10506)](https://arxiv.org/abs/2403.10506)：人形全身控制基准（本仓库已有笔记）
+- [Towards Motion Turing Test (arXiv 2603.06181)](https://arxiv.org/abs/2603.06181)：类人度评估基准（本仓库已有笔记）
+- [ProcTHOR (NeurIPS 2022)](https://arxiv.org/abs/2206.06994)：程序化生成的室内场景
+- [Objaverse](https://arxiv.org/abs/2212.08051)：开放 3D 物体宇宙，被 MolmoSpaces 用作物体来源
+- [Holodeck (CVPR 2024)](https://arxiv.org/abs/2312.09067)：LLM 驱动的 3D 场景生成
+- [MolmoBot 官方介绍](https://allenai.org/blog/molmobot-robot-manipulation)：本生态配套的"全仿真训练"操作策略
+- [ManiSkill3 (arXiv 2410.00425)](https://arxiv.org/abs/2410.00425)：被 MolmoSpaces 适配的模拟器之一
+- [PolySim (arXiv 2510.01708)](https://arxiv.org/abs/2510.01708)：多模拟器联合训练（10_Sim-to-Real 模块姊妹工作）
+
+---
+
+> 备注：本笔记基于 arXiv 摘要、Ai2 官方博客、Hugging Face 论文页与公开技术报道整理。具体每个任务在 MuJoCo / Isaac / ManiSkill 三模拟器下的成功率数值表、各代 VLA（如 OpenVLA / Pi0 / GR00T 等）的逐任务对比、prompt / 初始位姿扰动下的退化曲线等细节，待论文正式 PDF 完整阅读后回填。

--- a/papers/DAILY_SUMMARY_LOG.md
+++ b/papers/DAILY_SUMMARY_LOG.md
@@ -72,6 +72,7 @@
 | 2026-05-20 | 352 | [STATE-NAV: Stability-Aware Traversability Estimation for Bipedal Navigation on Rough Terrain](08_Navigation/STATE-NAV__Stability-Aware_Traversability_Estimation_for_Bipedal_Navigation_on_Rough_Terrain/STATE-NAV__Stability-Aware_Traversability_Estimation_for_Bipedal_Navigation_on_Rough_Terrain.md) | Navigation / 双足导航 / 可通过性估计 / RRT*+MPC | 截至当前未见公开（以项目主页 [state-nav.github.io/statenav](https://state-nav.github.io/statenav/) 后续更新为准） |
 | 2026-05-20 | 370 | [PINN + UKF: Sensorless Joint Torque Estimation in Humanoid Robots](09_State_Estimation/Physics-Informed_Neural_Networks_with_UKF_for_Sensorless_Joint_Torque_Estimation/Physics-Informed_Neural_Networks_with_UKF_for_Sensorless_Joint_Torque_Estimation.md) | State Estimation / 无传感器力矩估计 / PINN / UKF / 谐波减速器摩擦 | [ami-iit/paper_sorrentino_ral2024_balancing_torque](https://github.com/ami-iit/paper_sorrentino_ral2024_balancing_torque) · [PINN 前作](https://github.com/ami-iit/paper_sorrentino_2024_humanoids_friction_estimation) |
 | 2026-05-20 | 381 | [PolySim: Bridging the Sim-to-Real Gap for Humanoid Control via Multi-Simulator Dynamics Randomization](10_Sim-to-Real/PolySim__Bridging_the_Sim-to-Real_Gap_for_Humanoid_Control_via_Multi-Simulato/PolySim__Bridging_the_Sim-to-Real_Gap_for_Humanoid_Control_via_Multi-Simulato.md) | Sim-to-Real / 多仿真器联合训练 / Dynamics-Level DR / Unitree G1 零样本 | [EmboMaster/PolySim](https://github.com/EmboMaster/PolySim) · [HumanoidVerse](https://github.com/LeCAR-Lab/HumanoidVerse) |
+| 2026-05-20 | 391 | [MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation](11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md) | Simulation Benchmark / 230k 室内场景 / 42M 抓取 / 多模拟器统一接口 / VLA 评测 | [allenai/molmospaces](https://github.com/allenai/molmospaces) · [项目页](https://allenai.org/blog/molmospaces) |
 
 > 备注：2026-04-25 当天首次推进时发现索引 15 (Ψ₀) 已有完整内容，依规则跳到索引 16 (SteadyTray) 完成补写，故同日产生两条记录。
 > 备注：2026-04-26 推进索引 17 (ZeroWBC)，arXiv 与项目主页临时不可访问，笔记基于 awesome-humanoid-robot-learning 列表与项目主页公开文字描述整理；后续待 PDF / 官方仓库释出后补充实验数值。
@@ -199,6 +200,7 @@
 | 352 | STATE-NAV: Stability-Aware Traversability Estimation for Bipedal Navigation on Rough Terrain | 08_Navigation | ✅ 已完成（2026-05-20） |
 | 370 | Physics-Informed Neural Networks with Unscented Kalman Filter for Sensorless Joint Torque Estimation | 09_State_Estimation | ✅ 已完成（2026-05-20） |
 | 381 | PolySim: Bridging the Sim-to-Real Gap for Humanoid Control via Multi-Simulator Dynamics Randomization | 10_Sim-to-Real | ✅ 已完成（2026-05-20） |
-| ? | （明日：11_Simulation_Benchmark 模块首个未完成论文；按 04 → 05 → 06 → 07 → 08 → 09 → 10 → 11 → 12 → 13 → 14 → 04 顺序循环） | 11_Simulation_Benchmark | ⏭️ 下一篇候选 |
+| 391 | MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation | 11_Simulation_Benchmark | ✅ 已完成（2026-05-20） |
+| ? | （明日：12_Hardware_Design 模块首个未完成论文；按 04 → 05 → 06 → 07 → 08 → 09 → 10 → 11 → 12 → 13 → 14 → 04 顺序循环） | 12_Hardware_Design | ⏭️ 下一篇候选 |
 
 > 实际推进时会按当天轮转到的模块在 `papers` 列表中扫描，跳过已有内容的笔记。

--- a/papers/PROGRESS.md
+++ b/papers/PROGRESS.md
@@ -517,7 +517,7 @@
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- | --- | ---- |
 | 389  | [GRUtopia: Dream General Robots in a City at Scale](https://arxiv.org/abs/2407.10943)                                                      | 2407.10 |     | ✅ 完成 |
 | 390  | [Towards Motion Turing Test: Evaluating Human-Likeness in Humanoid Robots](https://arxiv.org/abs/2603.06181) ✅ [笔记](11_Simulation_Benchmark/Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots/Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots.md) | 2026.03 |     | ✅ 已总结 |
-| 391  | [MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation](https://arxiv.org/abs/2602.11337)                        | 2026.02 |     | ⏳ 待读 |
+| 391  | [MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation](https://arxiv.org/abs/2602.11337) ✅ [笔记](11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md) | 2026.02 |     | ✅ 已总结 |
 | 392  | [Benchmarking Humanoid Imitation Learning with Motion Difficulty](https://arxiv.org/abs/2512.07248)                                        | 2025.12 |     | ⏳ 待读 |
 | 393  | [Generative World Modelling for Humanoids: 1X World Model Challenge Technical Report](https://arxiv.org/abs/2510.07092)                    | 2025.10 |     | ⏳ 待读 |
 | 394  | [HumanoidGen: Data Generation for Bimanual Dexterous Manipulation via LLM Reasoning](https://arxiv.org/abs/2507.00833)                     | 2025.07 |     | ⏳ 待读 |

--- a/progress.json
+++ b/progress.json
@@ -41,14 +41,14 @@
         "13_Physics-Based_Animation",
         "14_Human_Motion"
       ],
-      "last_module": "10_Sim-to-Real",
-      "last_index": 381,
-      "last_title": "PolySim: Bridging the Sim-to-Real Gap for Humanoid Control via Multi-Simulator Dynamics Randomization",
-      "next_module": "11_Simulation_Benchmark"
+      "last_module": "11_Simulation_Benchmark",
+      "last_index": 391,
+      "last_title": "MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation",
+      "next_module": "12_Hardware_Design"
     },
-    "last_summary_index": 381,
+    "last_summary_index": 391,
     "last_summary_date": "2026-05-20",
-    "last_summary_title": "PolySim: Bridging the Sim-to-Real Gap for Humanoid Control via Multi-Simulator Dynamics Randomization",
+    "last_summary_title": "MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation",
     "next_summary_index": null,
     "log": [
       {
@@ -542,9 +542,21 @@
         "note_path": "papers/10_Sim-to-Real/PolySim__Bridging_the_Sim-to-Real_Gap_for_Humanoid_Control_via_Multi-Simulato/PolySim__Bridging_the_Sim-to-Real_Gap_for_Humanoid_Control_via_Multi-Simulato.md",
         "track": "module_rotation",
         "source_url": "https://github.com/EmboMaster/PolySim"
+      },
+      {
+        "date": "2026-05-20",
+        "index": 391,
+        "title": "MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation",
+        "module": "11_Simulation_Benchmark",
+        "category": "11_Simulation_Benchmark",
+        "note_path": "papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md",
+        "track": "module_rotation",
+        "arxiv": "2602.11337",
+        "source_repo": "https://github.com/allenai/molmospaces",
+        "project_page": "https://allenai.org/blog/molmospaces"
       }
     ],
-    "last_completed_index": 381,
+    "last_completed_index": 391,
     "next_index": null
   },
   "papers": [


### PR DESCRIPTION
## 📝 概要

新增 **MolmoSpaces** 论文笔记（轨 B · 模块轮转：`10_Sim-to-Real` → **`11_Simulation_Benchmark`**），完成 2026-05-20 当天 11_Simulation_Benchmark 模块的推进任务。

- **论文**：MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation
- **arXiv**：[2602.11337](https://arxiv.org/abs/2602.11337)
- **PDF**：[arXiv PDF](https://arxiv.org/pdf/2602.11337) · **HTML**：[v2 在线阅读](https://arxiv.org/html/2602.11337v2)
- **源码**：[allenai/molmospaces](https://github.com/allenai/molmospaces)
- **项目页**：[Ai2 Blog](https://allenai.org/blog/molmospaces) · [论文页](https://allenai.org/papers/molmospaces)
- **机构**：Allen Institute for AI (Ai2)

## 🎯 笔记亮点

- **一句话总结**：把"做具身 AI 评测要拼数据集、要拼资产、要拼模拟器"一次性解决——开放 230k+ 室内场景、130k+ 物体、42M 抓取标注；同一资产格式直接兼容 MuJoCo / Isaac Lab & Sim / ManiSkill 三大主流仿真器；首次报告 **sim-to-real 相关性 R = 0.96 / ρ = 0.98**。
- **MolmoSpaces-Bench**：8 个统一任务（navigate-to / pick / pick-and-place 系列 / open / close / open-door），覆盖短程操作 → 长程移动操作 → 多房间长程任务三档难度。
- **VLA 脆性发现**：实证指出新一代 VLA 对 **prompt 措辞、初始关节位姿、相机遮挡**敏感，为下一阶段 VLA 鲁棒性研究指明三大 OOD 维度。
- 附 **mermaid 流程图**：可视化"场景源 → 资产层 → simulator-agnostic 格式 → 多模拟器后端 → MolmoSpaces-Bench → 评测发现"全栈生态。

## 🔄 同步更新

- 新建 `papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md`
- `_data/papers.json`：在 11_Simulation_Benchmark 分类下追加 MolmoSpaces 条目
- `papers/PROGRESS.md`：编号 391 标记为 ✅ 已总结
- `progress.json`：追加 log 条目，将 `module_rotation.last_module` 推进到 `11_Simulation_Benchmark`，下一模块 → `12_Hardware_Design`
- `papers/DAILY_SUMMARY_LOG.md`：日志表新增 2026-05-20 / 391 条目，并更新"下一篇候选"指向 12_Hardware_Design

## 🅱️ 轨 B 推进状态

| 项目 | 旧值 | 新值 |
|---|---|---|
| 最近完成模块 | 10_Sim-to-Real | **11_Simulation_Benchmark** |
| 最近完成 index | 381 (PolySim) | **391 (MolmoSpaces)** |
| 下一模块 | 11_Simulation_Benchmark | **12_Hardware_Design** |

## ✅ 验证

- `python3 -c "import json; json.load(open('progress.json')); json.load(open('_data/papers.json'))"` 通过
- 笔记 Front-matter 与 `paper_order: 4` 与同分类既有三条笔记顺序衔接
- arXiv / PDF / HTML / 源码链接均已确认可解析（基于公开搜索 + Ai2 官方博客）


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGp83qvv1UenW1xUdX3ZnQ)_