### PR TITLE
fix(UI): 默认深色主题并消除加载白屏闪烁

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
       <button id="lang-toggle" class="lang-toggle" aria-label="Switch language">
         <span class="lang-label">中文</span>
       </button>
-      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">☀️</button>
     </div>
   </div>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,25 @@
 <!DOCTYPE html>
-<html lang="zh-CN" data-theme="light" data-lang-mode="en">
+<html lang="zh-CN" data-theme="dark" data-lang-mode="en">
 <head>
   <meta charset="UTF-8">
+  <script>
+    /* Apply saved theme before first paint (avoids light flash). */
+    (function () {
+      function getSiteTheme() {
+        try {
+          return localStorage.getItem('theme') === 'light' ? 'light' : 'dark';
+        } catch (e) {
+          return 'dark';
+        }
+      }
+      window.getSiteTheme = getSiteTheme;
+      document.documentElement.setAttribute('data-theme', getSiteTheme());
+    })();
+  </script>
+  <style>
+    html { color-scheme: dark; background-color: #1e1e1e; }
+    html[data-theme="light"] { color-scheme: light; background-color: #ffffff; }
+  </style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!--
     CSP (defence-in-depth). Static site, no fetch/XHR — only KaTeX & mermaid
@@ -369,31 +387,25 @@
       var html = document.documentElement;
 
       function getPreferred() {
-        var saved = localStorage.getItem('theme');
-        if (saved) return saved;
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        return typeof window.getSiteTheme === 'function' ? window.getSiteTheme() : 'dark';
       }
 
       function setTheme(theme) {
         html.setAttribute('data-theme', theme);
         localStorage.setItem('theme', theme);
-        toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+        if (toggle) toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
         
         initMermaid(theme);
       }
 
       setTheme(getPreferred());
 
-      toggle.addEventListener('click', function() {
-        var current = html.getAttribute('data-theme');
-        setTheme(current === 'dark' ? 'light' : 'dark');
-      });
-
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
-        if (!localStorage.getItem('theme')) {
-          setTheme(e.matches ? 'dark' : 'light');
-        }
-      });
+      if (toggle) {
+        toggle.addEventListener('click', function() {
+          var current = html.getAttribute('data-theme');
+          setTheme(current === 'dark' ? 'light' : 'dark');
+        });
+      }
     })();
   </script>
 </body>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,25 +1,5 @@
-/* ===== CSS Variables ===== */
+/* ===== CSS Variables (default / :root = dark) ===== */
 :root,
-[data-theme="light"] {
-  --bg: #ffffff;
-  --bg-secondary: #f8f8f8;
-  --text: #333333;
-  --text-secondary: #666666;
-  --link: #b31b1b;
-  --link-hover: #8b1515;
-  --border: #e0e0e0;
-  --code-bg: #f5f5f5;
-  --code-border: #e0e0e0;
-  --header-bg: #fafafa;
-  --header-border: #ddd;
-  --card-bg: #ffffff;
-  --card-shadow: rgba(0,0,0,0.08);
-  --blockquote-border: #b31b1b;
-  --blockquote-bg: #fdf6f6;
-  --table-stripe: #f9f9f9;
-  --kbd-bg: #eee;
-}
-
 [data-theme="dark"] {
   --bg: #1e1e1e;
   --bg-secondary: #252526;
@@ -38,6 +18,26 @@
   --blockquote-bg: #252526;
   --table-stripe: #2d2d2d;
   --kbd-bg: #333333;
+}
+
+[data-theme="light"] {
+  --bg: #ffffff;
+  --bg-secondary: #f8f8f8;
+  --text: #333333;
+  --text-secondary: #666666;
+  --link: #b31b1b;
+  --link-hover: #8b1515;
+  --border: #e0e0e0;
+  --code-bg: #f5f5f5;
+  --code-border: #e0e0e0;
+  --header-bg: #fafafa;
+  --header-border: #ddd;
+  --card-bg: #ffffff;
+  --card-shadow: rgba(0,0,0,0.08);
+  --blockquote-border: #b31b1b;
+  --blockquote-bg: #fdf6f6;
+  --table-stripe: #f9f9f9;
+  --kbd-bg: #eee;
 }
 
 /* ===== Transitions ===== */

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -303,7 +303,7 @@
     });
 
     if (typeof mermaid !== 'undefined') {
-      var theme = document.documentElement.getAttribute('data-theme') || 'light';
+      var theme = document.documentElement.getAttribute('data-theme') || 'dark';
       if (typeof initMermaid === 'function') {
         initMermaid(theme);
       } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

首屏会先以浅色渲染，待底部主题脚本执行后才切换到深色，出现明显的白屏闪烁。

## 方案

1. **`:root` 默认使用深色 CSS 变量**，样式表解析前不再回落到浅色 token。
2. **在 `<head>` 内增加同步脚本**，在首屏绘制前根据 `localStorage` 设置 `data-theme`。
3. **`<html data-theme="dark">`** 与内联 `background-color` 作为无 JS 时的兜底。
4. **站点默认主题为 `dark`**：仅当用户曾显式选择 `light`（写入 `localStorage`）时使用浅色；已移除跟随系统 `prefers-color-scheme` 的自动切换，避免与站点默认冲突。

用户仍可通过 header 的 ☀️/🌙 按钮切换主题，选择会持久化到 `localStorage`。

## 验收

[修复后：首页默认深色（1280×800）](https://cursor.com/agents/bc-7b06ee39-1eb2-430a-bec2-e7a616dd5b8f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdefault-dark-theme-home.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b06ee39-1eb2-430a-bec2-e7a616dd5b8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b06ee39-1eb2-430a-bec2-e7a616dd5b8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

