### PR TITLE
⚡ Bolt: Prevent layout thrashing with DOM write diff-checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## 2024-05-21 - [Fast String Splitting & DOM Batching]
 **Learning:** In Javascript string processing, character-by-character concatenation (`cur += c`) inside a loop is extremely slow due to continuous memory reallocations. Using index tracking combined with `String.prototype.slice(lastIdx, i)` is nearly an order of magnitude faster. Additionally, when inserting many identical small DOM structures (like code line numbers), constructing a single HTML string and setting it via `innerHTML` is faster than invoking `document.createElement`, `textContent`, and `appendChild` thousands of times, even for seemingly simple nodes.
 **Action:** Always prefer native string slicing over manual character accumulation in JS parsers. Batch large repetitive DOM additions via `innerHTML` strings rather than creating granular elements individually.
+
+## 2025-10-25 - Prevent Layout Thrashing with DOM Write Diff-Checks
+**Learning:** Unconditional assignments to DOM properties like `textContent`, `placeholder`, `aria-label`, and `style.display` in high-frequency loops (such as search filtering or global state toggles like language switches) cause significant layout thrashing. The browser recalculates layout and repaints even if the new string value is exactly identical to the old one.
+**Action:** Always perform strict equality diff-checks (e.g., `if (el.textContent !== newText) { el.textContent = newText; }`) before writing to the DOM, especially within loops that touch multiple elements or run frequently (like debounced search handlers).

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -272,7 +272,7 @@
           // For elements with only data-en/data-zh (no child text nodes), swap textContent
           var useZh = mode === 'zh';
           var text = useZh ? el.getAttribute('data-zh') : el.getAttribute('data-en');
-          if (text !== null) {
+          if (text !== null && el.textContent !== text) {
             el.textContent = text;
           }
         }
@@ -282,7 +282,7 @@
           var el = placeholders[i];
           var useZh = mode === 'zh';
           var text = useZh ? el.getAttribute('data-zh-placeholder') : el.getAttribute('data-en-placeholder');
-          if (text !== null) {
+          if (text !== null && el.placeholder !== text) {
             el.placeholder = text;
           }
         }
@@ -292,7 +292,7 @@
           var el = arias[i];
           var useZh = mode === 'zh';
           var text = useZh ? el.getAttribute('data-zh-aria-label') : el.getAttribute('data-en-aria-label');
-          if (text !== null) {
+          if (text !== null && el.getAttribute('aria-label') !== text) {
             el.setAttribute('aria-label', text);
           }
         }

--- a/index.html
+++ b/index.html
@@ -246,21 +246,25 @@ title: "Home"
           
           subcatCache.items.forEach(function(itemCache) {
             if (itemCache.text.indexOf(query) !== -1) {
-              itemCache.el.style.display = '';
+              if (itemCache.el.style.display !== '') itemCache.el.style.display = '';
               subcatHasMatch = true;
               subcatMatchCount++;
               catHasMatch = true;
               hasAnyMatch = true;
             } else {
-              itemCache.el.style.display = 'none';
+              if (itemCache.el.style.display !== 'none') itemCache.el.style.display = 'none';
             }
           });
           
-          subcatCache.el.style.display = subcatHasMatch || query === '' ? '' : 'none';
+          var targetSubcatDisplay = subcatHasMatch || query === '' ? '' : 'none';
+          if (subcatCache.el.style.display !== targetSubcatDisplay) subcatCache.el.style.display = targetSubcatDisplay;
           if (subcatCache.tocItem) {
-            subcatCache.tocItem.style.display = subcatHasMatch || query === '' ? '' : 'none';
+            if (subcatCache.tocItem.style.display !== targetSubcatDisplay) subcatCache.tocItem.style.display = targetSubcatDisplay;
             var countEl = subcatCache.tocItem.querySelector('.toc-count');
-            if (countEl) countEl.textContent = '(' + subcatMatchCount + ')';
+            if (countEl) {
+              var targetText = '(' + subcatMatchCount + ')';
+              if (countEl.textContent !== targetText) countEl.textContent = targetText;
+            }
           }
           catTotalMatch += subcatMatchCount;
         });
@@ -268,25 +272,30 @@ title: "Home"
         var directMatchCount = 0;
         catCache.directItems.forEach(function(itemCache) {
           if (itemCache.text.indexOf(query) !== -1) {
-            itemCache.el.style.display = '';
+            if (itemCache.el.style.display !== '') itemCache.el.style.display = '';
             catHasMatch = true;
             hasAnyMatch = true;
             directMatchCount++;
           } else {
-            itemCache.el.style.display = 'none';
+            if (itemCache.el.style.display !== 'none') itemCache.el.style.display = 'none';
           }
         });
         catTotalMatch += directMatchCount;
 
-        catCache.el.style.display = catHasMatch || query === '' ? '' : 'none';
+        var targetCatDisplay = catHasMatch || query === '' ? '' : 'none';
+        if (catCache.el.style.display !== targetCatDisplay) catCache.el.style.display = targetCatDisplay;
         if (catCache.tocItem) {
-          catCache.tocItem.style.display = catHasMatch || query === '' ? '' : 'none';
+          if (catCache.tocItem.style.display !== targetCatDisplay) catCache.tocItem.style.display = targetCatDisplay;
           var countEl = catCache.tocItem.querySelector('.toc-count');
-          if (countEl) countEl.textContent = '(' + catTotalMatch + ')';
+          if (countEl) {
+            var targetText = '(' + catTotalMatch + ')';
+            if (countEl.textContent !== targetText) countEl.textContent = targetText;
+          }
         }
       });
 
-      noResults.style.display = hasAnyMatch || query === '' ? 'none' : 'block';
+      var targetNoResultsDisplay = hasAnyMatch || query === '' ? 'none' : 'block';
+      if (noResults.style.display !== targetNoResultsDisplay) noResults.style.display = targetNoResultsDisplay;
     }, 150);
   });
 


### PR DESCRIPTION
在 `index.html` 的搜索过滤和 `_layouts/default.html` 的语言切换逻辑中，增加对 DOM 属性（`textContent`, `style.display`, `placeholder`, `aria-label`）的写入前 diff 检查。这能避免在用户触发大量元素的状态重置时（例如清除搜索词或切换语言），即使状态并未改变仍导致的浏览器布局抖动（Layout Thrashing）和主线程阻塞。同时，在 `.jules/bolt.md` 中记录了这一重要的性能优化发现。

---
*PR created automatically by Jules for task [3996978222933119542](https://jules.google.com/task/3996978222933119542) started by @ImChong*