### PR TITLE
Add SUGAR paper to humanoid control research collection

### DIFF
--- a/papers/PROGRESS.md
+++ b/papers/PROGRESS.md
@@ -261,6 +261,7 @@
 | 185  | [Heracles: Bridging Precise Tracking and Generative Synthesis for General Humanoid Control](https://arxiv.org/abs/2603.27756) | 2026.03 |  | ⏳ 待读 |
 | 186  | [SafeFlow: Real-Time Text-Driven Humanoid Whole-Body Control via Physics-Guided Rectified Flow and Selective Safety Gating](https://arxiv.org/abs/2603.23983) | 2026.03 |  | ⏳ 待读 |
 | 532  | [ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting](https://arxiv.org/abs/2605.06593) | 2026.05 |  | ⏳ 待读 |
+| 533  | [SUGAR: A Scalable Human-Video-Driven Generalizable Humanoid Loco-Manipulation Learning Framework](https://arxiv.org/abs/2605.20373) | 2026.05 | 🌟 | ⏳ 待读 |
 
 
 ### Locomotion（84篇）


### PR DESCRIPTION
## Summary
Added a new paper entry to the research progress tracking document for humanoid control and manipulation learning.

## Changes
- Added paper entry for "SUGAR: A Scalable Human-Video-Driven Generalizable Humanoid Loco-Manipulation Learning Framework" (arxiv 2605.20373)
- Assigned paper ID 533 in the tracking list
- Marked with star (🌟) to indicate relevance/importance
- Set status to "⏳ 待读" (pending reading)
- Placed in the humanoid control section alongside related motion retargeting and control papers

## Details
This paper addresses scalable learning for humanoid robots combining locomotion and manipulation tasks using human video demonstrations, fitting within the existing collection of humanoid control research.

https://claude.ai/code/session_016CvFP4gZuRKWf2scV7kgoq