### PR TITLE
🛡️ Sentinel: [HIGH] Fix fail-open DOM-based XSS when DOMPurify is unavailable

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** Found a vulnerability in `index.html` where dynamically generated file URLs (like `paper.url` and `page.url`) were injected into `href` attributes without HTML escaping (e.g., `href="{{ site.baseurl }}{{ paper.url }}"`).
 **Learning:** If a paper's file path contains quote characters (`"` or `'`), injecting it unescaped into an HTML attribute allows an attacker to break out of the attribute context and inject arbitrary HTML attributes or events, leading to Cross-Site Scripting (XSS).
 **Prevention:** Always append the `| escape` filter when injecting dynamic content, including URLs and paths generated from filenames, into HTML attributes in Jekyll templates.
+
+## 2025-05-20 - [Fail-open XSS in Client-Side Sanitization]
+**Vulnerability:** Found a fail-open XSS vulnerability where client-side JavaScript (in `assets/js/mermaid-config.js`, `assets/js/mermaid-zoom.js`, and `_layouts/default.html`) conditionally used `DOMPurify` to sanitize HTML/SVG, but fell back to returning/using the raw, unsanitized string if `DOMPurify` was not loaded or undefined.
+**Learning:** If a critical security dependency like `DOMPurify` fails to load (e.g., due to network issues, ad blockers, or CDN unavailability), a "fail-open" logic path that uses the raw input completely bypasses the intended security controls. This allows any underlying XSS payload to be executed.
+**Prevention:** Always design security controls to "fail-closed." If a required sanitization library is unavailable, the application should return a safe default (like an empty string) or throw an error, rather than processing potentially malicious data unsanitized.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -249,7 +249,7 @@
               ? window.sanitizeMermaidSvg(result.svg)
               : typeof DOMPurify !== 'undefined'
                 ? DOMPurify.sanitize(result.svg)
-                : result.svg;
+                : '';
           roadmapSvgCache[cacheKey] = safeSvg;
           mermaidRoadmap.innerHTML = safeSvg;
           mermaidRoadmap.removeAttribute('data-processed');

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -39,7 +39,7 @@
    */
   window.sanitizeMermaidSvg = function (svgString) {
     if (!svgString) return '';
-    if (typeof DOMPurify === 'undefined') return svgString;
+    if (typeof DOMPurify === 'undefined') return '';
     return DOMPurify.sanitize(svgString, {
       USE_PROFILES: { svg: true, svgFilters: true },
       ADD_TAGS: ['foreignObject'],

--- a/assets/js/mermaid-zoom.js
+++ b/assets/js/mermaid-zoom.js
@@ -247,7 +247,7 @@
         ADD_TAGS: ['foreignObject'],
       });
     }
-    return svgString;
+    return '';
   }
 
   function mountLightboxSvg(svgString) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Found a fail-open XSS vulnerability where client-side JavaScript conditionally used `DOMPurify` to sanitize Mermaid HTML/SVG. If `DOMPurify` failed to load (e.g., due to network issues, ad blockers, or CDN unavailability), the logic fell back to returning and using the raw, unsanitized string, completely bypassing XSS protection.
🎯 Impact: If `DOMPurify` is blocked or unavailable, an attacker could inject malicious payloads (e.g., `<img src=x onerror=alert(1)>`) via Mermaid definitions in markdown, which would be rendered and executed as DOM-based XSS.
🔧 Fix: Changed the fallback logic to fail securely. If `DOMPurify` is undefined, the code now returns/assigns an empty string (`''`) instead of the raw `svgString` or `result.svg`.
✅ Verification: Ran `pytest` suite and `jekyll build` locally to verify changes and ensure no regressions. Tested that when `DOMPurify` is artificially set to undefined, diagrams do not render instead of executing unsanitized payloads.

---
*PR created automatically by Jules for task [11020496828293883836](https://jules.google.com/task/11020496828293883836) started by @ImChong*