### PR TITLE
fix(UI): 消除 Mermaid 灯箱打开时的尺寸闪烁

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -759,6 +759,11 @@ body.mermaid-lightbox-open {
   will-change: transform;
 }
 
+/* Hidden until fitToViewport — prevents one frame at scale(1). */
+.mermaid-lightbox__stage.is-preparing {
+  visibility: hidden;
+}
+
 .mermaid-lightbox__stage .mermaid-lightbox__svg {
   display: block;
   max-width: none !important;

--- a/assets/js/mermaid-zoom.js
+++ b/assets/js/mermaid-zoom.js
@@ -144,6 +144,25 @@
     applyTransform();
   }
 
+  /** Hide stage until fitToViewport runs — avoids scale(1) flash. */
+  function setStagePreparing(preparing) {
+    if (!stage) return;
+    stage.classList.toggle('is-preparing', !!preparing);
+  }
+
+  function scheduleFitToViewport(svg, done) {
+    function run() {
+      fitToViewport(svg);
+      setStagePreparing(false);
+      if (typeof done === 'function') done();
+    }
+    if (viewport && viewport.clientWidth > 0 && viewport.clientHeight > 0) {
+      run();
+      return;
+    }
+    requestAnimationFrame(run);
+  }
+
   function resetPointerState() {
     pointers.clear();
     pinchSnapshot = null;
@@ -268,14 +287,26 @@
   function openWithSvgClone(sourceEl) {
     var svg = sourceEl.querySelector('svg');
     if (!svg) return false;
+    setStagePreparing(true);
     var clone = cloneSvgForLightbox(svg);
     stage.innerHTML = '';
     stage.appendChild(clone);
-    requestAnimationFrame(function () {
-      requestAnimationFrame(function () {
-        fitToViewport(clone);
-      });
-    });
+    scheduleFitToViewport(clone);
+    return true;
+  }
+
+  function swapLightboxSvg(svgString, sourceEl) {
+    setStagePreparing(true);
+    var mounted = mountLightboxSvg(svgString);
+    if (!mounted) {
+      if (!stage.querySelector('svg')) {
+        openWithSvgClone(sourceEl);
+      } else {
+        setStagePreparing(false);
+      }
+      return false;
+    }
+    scheduleFitToViewport(mounted);
     return true;
   }
 
@@ -289,20 +320,20 @@
     lightbox.classList.add('is-open');
     document.body.classList.add('mermaid-lightbox-open');
 
+    if (!openWithSvgClone(sourceEl)) {
+      setStagePreparing(false);
+      return;
+    }
+
     var sourceCode = sourceEl.getAttribute('data-original-code');
     var canHiResRender =
       sourceCode &&
       typeof mermaid !== 'undefined' &&
       typeof mermaid.render === 'function';
 
-    if (!canHiResRender) {
-      stage.innerHTML = '';
-      openWithSvgClone(sourceEl);
-      return;
-    }
+    if (!canHiResRender) return;
 
     var renderSeq = ++lightboxRenderSeq;
-    stage.innerHTML = '';
     stage.setAttribute('aria-busy', 'true');
 
     var graphText =
@@ -315,21 +346,12 @@
       .then(function (result) {
         if (renderSeq !== lightboxRenderSeq || lightbox.hidden) return;
         stage.removeAttribute('aria-busy');
-        var mounted = mountLightboxSvg(result.svg);
-        if (!mounted) {
-          openWithSvgClone(sourceEl);
-          return;
-        }
-        requestAnimationFrame(function () {
-          requestAnimationFrame(function () {
-            fitToViewport(mounted);
-          });
-        });
+        swapLightboxSvg(result.svg, sourceEl);
       })
       .catch(function () {
         if (renderSeq !== lightboxRenderSeq || lightbox.hidden) return;
         stage.removeAttribute('aria-busy');
-        openWithSvgClone(sourceEl);
+        setStagePreparing(false);
       });
   }
 
@@ -343,6 +365,7 @@
     if (stage) {
       stage.innerHTML = '';
       stage.removeAttribute('aria-busy');
+      stage.classList.remove('is-preparing');
     }
   }
 

--- a/tests/test_mermaid_config.py
+++ b/tests/test_mermaid_config.py
@@ -26,6 +26,14 @@ def test_lightbox_rerenders_from_source():
     text = ZOOM_JS.read_text(encoding="utf-8")
     assert "buildMermaidLightboxGraph" in text
     assert "mermaid.render" in text
+    assert "openWithSvgClone" in text
+    assert "is-preparing" in text
+    assert "scheduleFitToViewport" in text
+
+
+def test_lightbox_hides_stage_until_fit():
+    css = (ROOT / "assets" / "css" / "style.css").read_text(encoding="utf-8")
+    assert ".mermaid-lightbox__stage.is-preparing" in css
 
 
 def test_sanitize_mermaid_svg_keeps_foreign_object():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

点击论文页 Mermaid 图放大时，流程图会先闪一下（空白或错误比例），再显示为灯箱适配大小。

## 原因

1. 高分辨率路径先清空 `stage` 再异步 `mermaid.render`，灯箱已打开但内容为空。
2. SVG 插入后使用双 `requestAnimationFrame` 才 `fitToViewport`，在此之前以 `scale(1)` 显示一帧。

## 修改

- **即时占位**：打开灯箱时先克隆页内 SVG 并立即 `fitToViewport`，用户立刻看到正确比例的图。
- **后台升级**：高分辨率渲染完成后在 `is-preparing` 状态下替换 SVG 并重新适配，避免替换瞬间的尺寸跳变。
- **隐藏未适配帧**：`.mermaid-lightbox__stage.is-preparing { visibility: hidden }`，在 `fitToViewport` 完成前不显示错误缩放。
- 视口尺寸就绪时同步适配，仅布局未就绪时使用单次 `rAF`。

## 验收

ASAP 论文页点击 Mermaid 打开灯箱（1280×900）：

[修复后：Mermaid 灯箱已适配视口（1280×900）](https://cursor.com/agents/bc-dae8d17e-4877-435c-8c99-427921a1a153/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmermaid-lightbox-open.png)

## 测试

- `pytest -v tests/test_mermaid_config.py`
- `ruff check scripts/ tests/`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dae8d17e-4877-435c-8c99-427921a1a153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dae8d17e-4877-435c-8c99-427921a1a153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

