### PR TITLE
⚡ Bolt: Optimize markdown blockquote parsing string splits

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 ## 2026-06-03 - Prevent HTML Re-Parsing and I/O when Sanitization is Clean
 **Learning:** In `scripts/sanitize_paper_html.py`, reading raw HTML into `BeautifulSoup`, extracting `#paper-body`, passing it through `nh3.clean()`, and then unconditionally re-parsing the returned string back into `BeautifulSoup` and writing back to disk is extremely slow for a post-build step. The majority of paper notes contain no malicious payloads, so `nh3` returns the exact same string it received. Unconditionally executing the BeautifulSoup DOM mutation and filesystem write loop creates a massive and completely avoidable O(N) performance bottleneck for static site generation.
 **Action:** When running sanitization scripts like `nh3.clean()` on large HTML strings, always diff-check the input and output strings (`if inner == cleaned`). If they are identical, short-circuit the execution and return early, skipping any expensive re-parsing, DOM tree generation, or disk I/O.
+
+## 2024-05-24 - Short-circuiting expensive string operations
+**Learning:** `content.split("\n")` on large markdown files is very expensive, especially when iterating over hundreds of files.
+**Action:** Use fast substring pre-checks like `if "\n>" not in content:` to short-circuit functions before executing expensive `split` operations.

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -127,6 +127,9 @@ def normalize_paper_meta_blockquotes(content: str) -> tuple[str, bool]:
     are separated by an empty ``>`` continuation line. Without that separator,
     "阅读日期", "板块", and other header callouts collapse onto one line.
     """
+    if "\n>" not in content and not content.startswith(">"):
+        return content, False
+
     lines = content.split("\n")
     h1_idx = next(
         (i for i, line in enumerate(lines) if line.startswith("# ") and not line.startswith("## ")),


### PR DESCRIPTION
Identified and implemented a performance optimization in `scripts/_common.py`. The `normalize_paper_meta_blockquotes` function was needlessly executing an expensive `content.split("\n")` operation on large markdown files, even when the files did not contain any blockquotes. Adding a simple, fast substring pre-check (`if "\n>" not in content`) prevents this expensive memory allocation on the hot path. The codebase tests still pass 100%. Recorded the learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7134910333931843590](https://jules.google.com/task/7134910333931843590) started by @ImChong*