### PR TITLE
fix(UI): 移动端主页侧栏浮窗底部避开漂浮按钮

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -522,12 +522,17 @@ html {
   .toc-sidebar {
     position: fixed;
     top: 0;
+    /* Stop above the floating sidebar toggle (24px + 48px) with breathing room */
+    bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
     left: -280px;
     width: 260px;
-    height: 100%;
+    height: auto;
+    max-height: none;
     background: var(--bg);
     margin: 0;
     padding: 20px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     box-shadow: 2px 0 12px rgba(0,0,0,0.15);
     border-radius: 0 16px 16px 0;
     z-index: 1300;
@@ -574,13 +579,25 @@ html {
 
 @media (max-width: 1200px) {
   .index-layout .toc-sidebar {
+    /* Mirror subpage mobile drawer; desktop float/height must not leak here */
+    float: none;
     position: fixed;
     top: 0;
+    bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
     left: -280px;
     width: 260px;
-    height: 100%;
+    height: auto;
+    max-height: none;
     margin: 0;
+    margin-left: 0;
+    padding: 20px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    background: var(--bg);
+    box-shadow: 2px 0 12px rgba(0,0,0,0.15);
     border-radius: 0 16px 16px 0;
+    z-index: 1300;
+    transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     display: block;
   }
   .index-layout .toc-sidebar.open {

--- a/tests/test_mobile_sidebar_fab_css.py
+++ b/tests/test_mobile_sidebar_fab_css.py
@@ -1,0 +1,33 @@
+"""Mobile TOC drawer must end above the floating sidebar toggle."""
+
+from pathlib import Path
+
+STYLE = Path(__file__).resolve().parents[1] / "assets" / "css" / "style.css"
+
+
+def _mobile_toc_block() -> str:
+    text = STYLE.read_text(encoding="utf-8")
+    marker = "/* Show TOC only on wide screens */"
+    start = text.index(marker)
+    end = text.index("/* Wider container for paper pages", start)
+    return text[start:end]
+
+
+def test_mobile_toc_sidebar_clears_floating_toggle():
+    block = _mobile_toc_block()
+    assert "bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px))" in block
+    assert "height: auto" in block
+    assert "max-height: none" in block
+    assert "overflow-y: auto" in block
+
+
+def test_index_mobile_toc_sidebar_matches_subpage_drawer():
+    text = STYLE.read_text(encoding="utf-8")
+    start = text.index("@media (max-width: 1200px) {\n  .index-layout .toc-sidebar")
+    end = text.index("/* ===== Search Box ===== */", start)
+    block = text[start:end]
+    assert "float: none" in block
+    assert "bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px))" in block
+    assert "height: auto" in block
+    assert "overflow-y: auto" in block
+    assert "background: var(--bg)" in block


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端主页打开左侧分类导航浮窗时，抽屉底部与左下角 `sidebar-toggle` 漂浮按钮区域重叠，末几项分类难以看清；子页面（论文页）的目录抽屉已在底部留出空隙。

## 修改

- 移动端 `.toc-sidebar` 改用 `top` + `bottom` 定位（`bottom: calc(24px + 48px + 28px + safe-area)`），与子页一致的 100px 底部留白，替代 `height: 100%`。
- 补全 `.index-layout .toc-sidebar` 在 `max-width: 1200px` 下的抽屉样式（`float: none`、背景、阴影、`overflow-y: auto` 等），避免桌面端 `float` / `height` 规则泄漏到主页移动端。
- 新增 `tests/test_mobile_sidebar_fab_css.py` 回归测试。

## 验收

390×844 视口打开主页分类导航，浮窗圆角底边止于 FAB 上方，末项「Human Motion」完整可见：

![修复后：主页移动端分类导航浮窗（390×844）](https://cursor.com/artifacts/c/art-f168f4f7-9fc1-4f15-8bc8-f481ab3e3a42)

## 测试

- `pytest tests/test_mobile_sidebar_fab_css.py -v`
- `ruff check tests/test_mobile_sidebar_fab_css.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91e1d3b6-7745-4c2c-b7cc-c40bb60c3850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91e1d3b6-7745-4c2c-b7cc-c40bb60c3850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

