### PR TITLE
fix(PPO): 添加官方/MimicKit 源码链接并修复高亮代码块换行截断

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -8,6 +8,7 @@
         "url": "/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.html",
         "dir": "PPO_Proximal_Policy_Optimization",
         "arxiv": "1707.06347",
+        "has_open_source": true,
         "zhname": "近端策略优化算法 (PPO)"
       },
       {

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -253,6 +253,13 @@
     });
   }
 
+  function normalizeRougeLineBreaks(html) {
+    // Rouge/kramdown often emits "\n</span>" (newline inside the span). Naive
+    // HTML string splitting then breaks tags across rows and clips highlighted
+    // code (e.g. "def" → "de"). Move the newline after the closing tag.
+    return html.replace(/\n(\s*<\/span>)/g, '$1\n');
+  }
+
   function splitByNewline(html) {
     // ⚡ Bolt Optimization: Use native indexOf for fast string scanning instead
     // of character-by-character loops, leading to an order of magnitude faster parsing
@@ -296,7 +303,7 @@
     document.querySelectorAll('div.highlighter-rouge:not(.mermaid-processed)').forEach(function (outer) {
       var code = outer.querySelector('pre code');
       if (!code) return;
-      var html = code.innerHTML;
+      var html = normalizeRougeLineBreaks(code.innerHTML);
       if (html.endsWith('\n')) html = html.slice(0, -1);
       var lines = splitByNewline(html);
 

--- a/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
+++ b/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
@@ -23,6 +23,7 @@ category: "基础路线图"
 | **作者** | John Schulman, Filip Wolski, Prafulla Dhariwal, Alec Radford, Oleg Klimov |
 | **机构** | OpenAI |
 | **发布时间** | 2017年7月20日 |
+| **GitHub** | [openai/baselines (PPO2)](https://github.com/openai/baselines/tree/master/baselines/ppo2)<br>[xbpeng/MimicKit](https://github.com/xbpeng/MimicKit) |
 
 ---
 

--- a/tests/test_code_block_rouge_split.py
+++ b/tests/test_code_block_rouge_split.py
@@ -1,0 +1,86 @@
+"""Regression: Rouge HTML newlines must not split syntax spans across code rows."""
+
+import re
+import subprocess
+from pathlib import Path
+
+ROUGE_NL_BEFORE_CLOSE = re.compile(r"\n(\s*</span>)")
+
+
+def _normalize_rouge_line_breaks(html: str) -> str:
+    return ROUGE_NL_BEFORE_CLOSE.sub(r"\1\n", html)
+
+
+def _split_by_newline(html: str) -> list[str]:
+    lines: list[str] = []
+    last_idx = 0
+    in_tag = False
+    i = 0
+    while i < len(html):
+        if not in_tag:
+            next_tag = html.find("<", i)
+            next_nl = html.find("\n", i)
+            if next_nl != -1 and (next_tag == -1 or next_nl < next_tag):
+                lines.append(html[last_idx:next_nl])
+                last_idx = next_nl + 1
+                i = next_nl + 1
+            elif next_tag != -1:
+                in_tag = True
+                i = next_tag + 1
+            else:
+                break
+        else:
+            next_end = html.find(">", i)
+            if next_end != -1:
+                in_tag = False
+                i = next_end + 1
+            else:
+                break
+    if last_idx < len(html):
+        lines.append(html[last_idx:])
+    return lines
+
+
+def test_rouge_newline_inside_span_does_not_break_tag_across_rows():
+    sample = (
+        '<span class="c1"># mimickit/learning/ppo_model.py\n'
+        '</span><span class="k">class</span> Foo:'
+    )
+    broken = _split_by_newline(sample)
+    assert broken[0].endswith("ppo_model.py")
+    assert broken[0].startswith("<span")
+    assert "</span>" not in broken[0]
+
+    fixed = _normalize_rouge_line_breaks(sample)
+    ok = _split_by_newline(fixed)
+    assert ok[0] == '<span class="c1"># mimickit/learning/ppo_model.py</span>'
+    assert ok[1] == '<span class="k">class</span> Foo:'
+
+
+def test_paper_js_exports_normalize_before_split():
+    """Keep Python mirror in sync with assets/js/paper.js."""
+    paper_js = (Path(__file__).resolve().parents[1] / "assets/js/paper.js").read_text(
+        encoding="utf-8"
+    )
+    assert "function normalizeRougeLineBreaks(html)" in paper_js
+    assert "normalizeRougeLineBreaks(code.innerHTML)" in paper_js
+
+
+def test_node_split_matches_python_mirror():
+    repo = Path(__file__).resolve().parents[1]
+    script = """
+function normalizeRougeLineBreaks(html) {
+  return html.replace(/\\n(\\s*<\\/span>)/g, '$1\\n');
+}
+const sample = '<span class="c1"># foo\\n</span><span class="k">def</span> bar';
+const lines = sample.replace(/\\n(\\s*<\\/span>)/g, '$1\\n').split('\\n');
+console.log(JSON.stringify(lines));
+"""
+    out = subprocess.run(
+        ["node", "-e", script],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert out.stdout.strip() == '["<span class=\\"c1\\"># foo</span>","<span class=\\"k\\">def</span> bar"]'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

### PPO 页面：补充源码链接
在「📋 基本信息」表中新增 **GitHub** 行，包含：
- [openai/baselines (PPO2)](https://github.com/openai/baselines/tree/master/baselines/ppo2) — PPO 论文作者团队的官方参考实现
- [xbpeng/MimicKit](https://github.com/xbpeng/MimicKit) — 笔记中「MimicKit 源码对照」章节对应的工程实现

### 子页代码块显示 Bug 修复
**问题**：带 Rouge 语法高亮的代码块（如 MimicKit 源码对照中的 Python/YAML）出现：
- 行号跑到右侧
- 关键字被截断（`def` → `de`、`layers` → `la` 等）

**根因**：Rouge/kramdown 常在 `</span>` 之前输出换行；`paper.js` 按 HTML 字符串 naive 分行时会把 span 标签拆到两行，破坏 DOM 结构。

**修复**：在 `assets/js/paper.js` 的 `rebuildWithLineNumbers()` 中，分行前调用 `normalizeRougeLineBreaks()`，将 `\n</span>` 规范为 `</span>\n`。

## 验收截图

![修复后：MimicKit 源码对照代码块（桌面）](https://cursor.com/artifacts/c/art-51d902e7-cb17-45ef-83a3-dc608acb1653)

![修复后：基本信息 GitHub 链接](https://cursor.com/artifacts/c/art-4053ccb9-1216-47d2-bb4d-d9e7e9313976)

![修复后：MimicKit 代码块（移动端 390×844）](https://cursor.com/artifacts/c/art-a30fcf40-afee-4669-bb99-fd97bd8365e9)

## 测试
- `pytest tests/test_code_block_rouge_split.py` — Rouge 换行规范化回归
- `pytest tests/test_mobile_contain_css.py tests/test_heading_code_phrase.py` — 既有 UI 回归通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2931033-c5ce-4d8d-bd86-5a5c806e963f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2931033-c5ce-4d8d-bd86-5a5c806e963f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

