### PR TITLE
Add SplitAdapter paper to humanoid loco-manipulation tracking

### DIFF
--- a/papers/PROGRESS.md
+++ b/papers/PROGRESS.md
@@ -262,6 +262,7 @@
 | 186  | [SafeFlow: Real-Time Text-Driven Humanoid Whole-Body Control via Physics-Guided Rectified Flow and Selective Safety Gating](https://arxiv.org/abs/2603.23983) | 2026.03 |  | ⏳ 待读 |
 | 532  | [ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting](https://arxiv.org/abs/2605.06593) | 2026.05 |  | ⏳ 待读 |
 | 533  | [SUGAR: A Scalable Human-Video-Driven Generalizable Humanoid Loco-Manipulation Learning Framework](https://arxiv.org/abs/2605.20373) | 2026.05 | 🌟 | ⏳ 待读 |
+| 534  | [SplitAdapter: Load-Aware Humanoid Loco-Manipulation via Factorized Adaptation](https://arxiv.org/abs/2606.03297) | 2026.06 |  | ⏳ 待读 |
 
 
 ### Locomotion（84篇）


### PR DESCRIPTION
## Summary
Added a new paper entry to the PROGRESS.md tracking document for humanoid loco-manipulation research.

## Changes
- Added entry for "SplitAdapter: Load-Aware Humanoid Loco-Manipulation via Factorized Adaptation" (arxiv 2606.03297, June 2026) to the humanoid loco-manipulation papers list
- Assigned sequential ID 534 to the new entry
- Marked as unread (⏳ 待读) with no special priority flag

## Details
This paper addresses load-aware humanoid loco-manipulation through factorized adaptation techniques and has been added to the comprehensive paper tracking list maintained in PROGRESS.md.

https://claude.ai/code/session_01WxJxvacrUXzoZibLaP1Mkd