### PR TITLE
fix(UI): 移动端抽屉顶部留出 16px 间隙

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -521,7 +521,8 @@ html {
 
   .toc-sidebar {
     position: fixed;
-    top: 0;
+    /* Match Robotics_Notebooks mobile drawer: gap below viewport top / notch */
+    top: calc(16px + env(safe-area-inset-top, 0px));
     /* Stop above the floating sidebar toggle (24px + 48px) with breathing room */
     bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
     left: -280px;
@@ -582,7 +583,7 @@ html {
     /* Mirror subpage mobile drawer; desktop float/height must not leak here */
     float: none;
     position: fixed;
-    top: 0;
+    top: calc(16px + env(safe-area-inset-top, 0px));
     bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
     left: -280px;
     width: 260px;

--- a/tests/test_mobile_sidebar_fab_css.py
+++ b/tests/test_mobile_sidebar_fab_css.py
@@ -13,8 +13,12 @@ def _mobile_toc_block() -> str:
     return text[start:end]
 
 
+MOBILE_DRAWER_TOP = "top: calc(16px + env(safe-area-inset-top, 0px))"
+
+
 def test_mobile_toc_sidebar_clears_floating_toggle():
     block = _mobile_toc_block()
+    assert MOBILE_DRAWER_TOP in block
     assert "bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px))" in block
     assert "height: auto" in block
     assert "max-height: none" in block
@@ -27,6 +31,7 @@ def test_index_mobile_toc_sidebar_matches_subpage_drawer():
     end = text.index("/* ===== Search Box ===== */", start)
     block = text[start:end]
     assert "float: none" in block
+    assert MOBILE_DRAWER_TOP in block
     assert "bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px))" in block
     assert "height: auto" in block
     assert "overflow-y: auto" in block


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

参考 [Robotics_Notebooks 详情页](https://imchong.github.io/Robotics_Notebooks/detail.html?id=entity-paper-rpl-robust-humanoid-perceptive-locomotion) 的移动端抽屉几何，主站（`index`）与子页（`paper`）的 TOC 抽屉不再贴顶 `top: 0`，改为：

```css
top: calc(16px + env(safe-area-inset-top, 0px));
```

与视口顶缘（含刘海安全区）保持间距；底部仍保留在浮动 FAB 之上的 `bottom` 计算，避免与切换按钮重叠。

## 修改文件

- `assets/css/style.css`：`.toc-sidebar` 与 `.index-layout .toc-sidebar` 移动端规则
- `tests/test_mobile_sidebar_fab_css.py`：断言抽屉 `top` 与主/子页一致

## 验收截图（390×844）

**首页抽屉**

![修复后：首页移动端抽屉顶部间隙](https://cursor.com/artifacts/c/art-a21d22f4-c983-4b61-88dc-4fbe85d4757c)

**论文子页抽屉**

![修复后：论文页移动端抽屉顶部间隙](https://cursor.com/artifacts/c/art-633ba2b3-b848-4bfd-b9ec-ea71a255d931)

## 测试

- `pytest tests/test_mobile_sidebar_fab_css.py -v` 通过
- `ruff check scripts/ tests/` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6539c04f-986d-42d7-a20c-d46eb61ebd5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6539c04f-986d-42d7-a20c-d46eb61ebd5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

