### PR TITLE
fix(UI): 全站 site-header 固定悬浮于视口顶部

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -97,10 +97,13 @@ html {
 .site-header {
   background: var(--header-bg);
   border-bottom: 1px solid var(--header-border);
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 100;
+  right: 0;
+  left: 0;
+  z-index: 1200;
   backdrop-filter: blur(8px);
+  padding-top: env(safe-area-inset-top, 0px);
 }
 
 .header-inner {
@@ -159,7 +162,8 @@ html {
 .container {
   max-width: 960px;
   margin: 0 auto;
-  padding: 2rem 24px;
+  /* Reserve space for fixed site-header (min-height 56px + vertical padding). */
+  padding: calc(72px + env(safe-area-inset-top, 0px) + 2rem) 24px 2rem;
 }
 
 /* Paper pages: shift right to make room for left TOC */
@@ -503,20 +507,6 @@ html {
     box-sizing: border-box;
     overflow-x: hidden;
     overflow-x: clip;
-  }
-
-  .site-header {
-    position: fixed;
-    top: 0;
-    right: 0;
-    left: 0;
-    z-index: 1200;
-  }
-
-  .container {
-    /* Two-line site-title can grow header to ~68px; reserve 72px so
-       fixed header never overlaps content. */
-    padding-top: calc(72px + env(safe-area-inset-top, 0px));
   }
 
   .toc-sidebar {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

将 `.site-header` 从桌面端的 `position: sticky` 改为全视口 `position: fixed`，使主页与论文子页在上下滚动时 header 始终固定在窗口顶部。

同时为 `.container` 增加与 header 高度对应的 `padding-top`（含 `safe-area-inset-top`），避免正文被固定 header 遮挡；移动端原先已有的 fixed 规则已合并进全局样式，去除重复定义。

## 验收截图

**桌面端 — 首页滚动后 header 仍固定：**

![桌面首页滚动后 header 固定](https://cursor.com/artifacts/c/art-6fc06ee9-a7ed-4d68-b338-9df02a3d5f4c)

**桌面端 — 论文子页滚动后 header 仍固定：**

![论文子页滚动后 header 固定](https://cursor.com/artifacts/c/art-91b2079e-b5d6-498e-b1bd-9e8a5762a2bc)

**移动端 390×844 — 首页滚动后 header 仍固定：**

![移动端滚动后 header 固定](https://cursor.com/artifacts/c/art-dcf60862-5f4a-4b83-a176-c8451b6ee828)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e68c4e1-9ffa-4867-a72d-77401c2674a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e68c4e1-9ffa-4867-a72d-77401c2674a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

