### PR TITLE
fix(Mermaid): 修复移动端流程图公式与节点重叠

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,13 +93,16 @@
       });
 
       var nodes = Array.prototype.slice.call(document.querySelectorAll('.mermaid:not(#roadmap-mermaid)'));
-      if (nodes.length > 0) {
-        mermaid.run({ nodes: nodes });
-      }
+      var paperRun =
+        nodes.length > 0 ? Promise.resolve(mermaid.run({ nodes: nodes })) : Promise.resolve();
+      var roadmapRun =
+        window.renderRoadmapMermaid
+          ? window.renderRoadmapMermaid(document.documentElement.getAttribute('data-lang-mode') || 'en')
+          : Promise.resolve();
 
-      if (window.renderRoadmapMermaid) {
-        window.renderRoadmapMermaid(document.documentElement.getAttribute('data-lang-mode') || 'en');
-      }
+      Promise.all([paperRun, roadmapRun]).then(function() {
+        if (typeof window.initKaTeX === 'function') window.initKaTeX();
+      });
     }
   </script>
 
@@ -451,8 +454,9 @@
   </script>
 
   <script>
-    // KaTeX auto-render with HTML entity fix
-    function initKaTeX() {
+    // KaTeX auto-render with HTML entity fix (math inside Mermaid is rendered by Mermaid itself).
+    window.initKaTeX = function initKaTeX() {
+      if (window.__katexInitialized) return true;
       if (typeof renderMathInElement === 'undefined') return false;
 
       // Fix HTML entities inside math delimiters before KaTeX scans the DOM.
@@ -474,9 +478,19 @@
 
       // ⚡ Bolt Optimization: Include SHOW_ELEMENT to proactively prune irrelevant subtrees
       // (like code blocks) by returning FILTER_REJECT, avoiding deep DOM traversal.
+      function isInsideMermaid(node) {
+        for (var el = node.nodeType === 1 ? node : node.parentElement; el; el = el.parentElement) {
+          if (!el.classList) continue;
+          if (el.classList.contains('mermaid') || el.classList.contains('mermaid-container')) return true;
+          if (el.id === 'roadmap-mermaid') return true;
+        }
+        return false;
+      }
+
       var walker = document.createTreeWalker(
         mathContainer, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
           acceptNode: function(node) {
+            if (isInsideMermaid(node)) return NodeFilter.FILTER_REJECT;
             if (node.nodeType === 1) { // Element node
               var tag = node.tagName;
               if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'PRE' || tag === 'CODE' || tag === 'ANNOTATION' || tag === 'TEXTAREA') {
@@ -506,17 +520,24 @@
           {left: "$", right: "$", display: false},
           {left: "\\(", right: "\\)", display: false}
         ],
+        ignoredTags: ['script', 'style', 'pre', 'code', 'textarea', 'annotation'],
+        ignoredClasses: ['mermaid', 'mermaid-container'],
         throwOnError: false,
         strict: false
       });
+      window.__katexInitialized = true;
       return true;
-    }
+    };
 
     document.addEventListener("DOMContentLoaded", function() {
-      if (!initKaTeX()) {
-        var check = setInterval(function() {
-          if (initKaTeX()) clearInterval(check);
-        }, 100);
+      var hasMermaid =
+        document.querySelector('.mermaid') || document.getElementById('roadmap-mermaid');
+      if (!hasMermaid) {
+        if (!window.initKaTeX()) {
+          var check = setInterval(function() {
+            if (window.initKaTeX()) clearInterval(check);
+          }, 100);
+        }
       }
     });
   </script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1081,6 +1081,45 @@ body.mermaid-lightbox-open {
   overflow: visible;
 }
 
+/* Mobile Safari: nowrap flex labels + max-content KaTeX can paint outside node boxes. */
+@media (max-width: 600px) {
+  .paper-body .mermaid {
+    contain: none;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .paper-body .mermaid svg foreignObject {
+    overflow: hidden;
+  }
+
+  .paper-body .mermaid foreignObject .nodeLabel > div,
+  .paper-body .mermaid foreignObject .labelBkg,
+  .paper-body .mermaid foreignObject .edgeLabel > div {
+    display: block !important;
+    width: 100% !important;
+    max-width: calc(100vw - 3rem) !important;
+    white-space: normal !important;
+    line-height: 1.35 !important;
+    box-sizing: border-box;
+    text-align: center;
+  }
+
+  .paper-body .mermaid foreignObject .katex-display {
+    display: block !important;
+    width: auto !important;
+    max-width: 100% !important;
+    margin: 0 auto;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .paper-body .mermaid foreignObject .katex {
+    max-width: 100%;
+    font-size: 0.95em;
+  }
+}
+
 /* ===== Paper Nav ===== */
 .paper-nav {
   margin-top: 3rem;

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -11,14 +11,23 @@
   /** Extra density when opening the fullscreen lightbox. */
   var MERMAID_LIGHTBOX_SCALE = 1.85;
 
+  function isMobileViewport() {
+    return (
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(max-width: 600px)').matches
+    );
+  }
+
   function scaledFlowchart(scale) {
+    var mobile = isMobileViewport();
     return {
       useMaxWidth: false,
       curve: 'basis',
-      nodeSpacing: Math.round(50 * scale),
-      rankSpacing: Math.round(50 * scale),
-      wrappingWidth: Math.round(200 * scale),
-      diagramPadding: Math.round(20 * scale),
+      nodeSpacing: Math.round((mobile ? 36 : 50) * scale),
+      rankSpacing: Math.round((mobile ? 40 : 50) * scale),
+      wrappingWidth: mobile ? 150 : Math.round(200 * scale),
+      diagramPadding: Math.round((mobile ? 12 : 20) * scale),
     };
   }
 
@@ -94,12 +103,14 @@
   };
 
   window.getMermaidSiteConfig = function (theme) {
+    var mobile = isMobileViewport();
+    var scale = mobile ? 1.05 : MERMAID_RENDER_SCALE;
     return {
       startOnLoad: false,
       theme: theme === 'dark' ? 'dark' : 'default',
-      fontSize: Math.round(16 * MERMAID_RENDER_SCALE),
+      fontSize: Math.round((mobile ? 14 : 16) * scale),
       htmlLabels: true,
-      flowchart: scaledFlowchart(MERMAID_RENDER_SCALE),
+      flowchart: scaledFlowchart(scale),
       securityLevel: 'strict',
       // Site already loads KaTeX CSS; use CSS-based math for consistent flowchart labels.
       forceLegacyMathML: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端（约 390px 宽）查看 PPO 笔记 GAE 流程图时，KaTeX 公式与 Mermaid 节点发生重叠，公式浮在第一个节点上方（见截图）。

## 根因

1. **KaTeX 与 Mermaid 竞态**：`initKaTeX()` 在 `DOMContentLoaded` 时扫描 `#paper-body`，会把 `.mermaid` 内尚未渲染的 `$$...$$` 也转成 KaTeX DOM，与 Mermaid 内置公式渲染冲突。
2. **移动端 foreignObject 布局**：Mermaid 节点标签使用 `white-space: nowrap` + flex，配合 `.katex-display { width: max-content }`，在窄屏 Safari 上易导致公式绘制溢出节点框。

## 修复

- `_layouts/default.html`：KaTeX 排除 `.mermaid` / `.mermaid-container`；在 `mermaid.run()` 与 roadmap 渲染完成后再调用 `initKaTeX()`
- `assets/css/style.css`：600px 以下强制节点标签换行、限制 KaTeX 宽度，并取消 `.mermaid` 的 `contain: inline-size`
- `assets/js/mermaid-config.js`：窄屏下略减小字号与间距，提高换行空间

## 截图验收（390×844 移动端视口）

### GAE 流程图（修复后）

![移动端 GAE 流程图：公式在节点内正常换行，无重叠](https://cursor.com/artifacts/c/art-5c2c2b3a-b732-44d7-abd2-d4fca4723fcd)

### 完整训练流程图（修复后）

![移动端完整 PPO 流程图：含概率比与 L^CLIP 公式](https://cursor.com/artifacts/c/art-563bdaef-3956-4259-bbf8-ab879a6ff34d)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dd266d5-9f3a-4bc6-bcc6-348de90f6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dd266d5-9f3a-4bc6-bcc6-348de90f6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

