### PR TITLE
fix(Mermaid): 修复 iPhone 完整流程图公式重叠

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,7 +89,12 @@
           if (source) el.setAttribute('data-original-code', source);
         }
         el.removeAttribute('data-processed');
-        writeSource(el, el.getAttribute('data-original-code'));
+        var canonical = el.getAttribute('data-original-code');
+        var renderSource =
+          typeof window.prepareMermaidRenderSource === 'function'
+            ? window.prepareMermaidRenderSource(canonical)
+            : canonical;
+        writeSource(el, renderSource);
       });
 
       var nodes = Array.prototype.slice.call(document.querySelectorAll('.mermaid:not(#roadmap-mermaid)'));
@@ -101,6 +106,11 @@
           : Promise.resolve();
 
       Promise.all([paperRun, roadmapRun]).then(function() {
+        if (typeof window.patchMermaidForeignObjects === 'function') {
+          document.querySelectorAll('.mermaid:not(#roadmap-mermaid)').forEach(function(el) {
+            window.patchMermaidForeignObjects(el);
+          });
+        }
         if (typeof window.initKaTeX === 'function') window.initKaTeX();
       });
     }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1081,6 +1081,17 @@ body.mermaid-lightbox-open {
   overflow: visible;
 }
 
+/* iOS Safari: KaTeX display math inside foreignObject is unstable — prefer plain labels. */
+html.ios .paper-body .mermaid foreignObject .katex-display,
+html.ios .paper-body .mermaid foreignObject .katex {
+  display: none !important;
+}
+
+html.ios .paper-body .mermaid foreignObject .katex-mathml {
+  display: inline-block !important;
+  max-width: 100%;
+}
+
 /* Mobile Safari: nowrap flex labels + max-content KaTeX can paint outside node boxes. */
 @media (max-width: 600px) {
   .paper-body .mermaid {

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -19,6 +19,74 @@
     );
   }
 
+  function isIos() {
+    if (typeof navigator === 'undefined') return false;
+    return (
+      /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+    );
+  }
+
+  /** iOS Safari paints KaTeX-in-foreignObject unreliably; use plain labels instead. */
+  window.shouldUsePlainMermaidMath = function () {
+    return isIos();
+  };
+
+  window.mermaidMathToPlain = function (tex) {
+    return tex
+      .replace(/\\pi_\{\\theta_\{old\}\}\s*\\leftarrow\s*\\pi_\\theta/g, 'π_old ← π_θ')
+      .replace(/\\pi_\\theta,\s*\\,?\s*V_\\phi/g, 'π_θ, V_φ')
+      .replace(
+        /r_t\(\\theta\)=\\frac\{([^}]+)\}\{([^}]+)\}/g,
+        'r_t(θ)=$1/$2'
+      )
+      .replace(
+        /L\^\{CLIP\}=\\min\(r_t\\hat\{A\}_t,\\,\\mathrm\{clip\}\(r_t,0\.8,1\.2\)\\hat\{A\}_t\)/g,
+        'L^CLIP=min(r_t·Â_t, clip·Â_t)'
+      )
+      .replace(/\\hat\{A\}_t/g, 'Â_t')
+      .replace(/\\delta_t/g, 'δ_t')
+      .replace(/\\gamma\\lambda/g, 'γλ')
+      .replace(/\\gamma/g, 'γ')
+      .replace(/\\lambda/g, 'λ')
+      .replace(/N \\times T/g, 'N×T')
+      .replace(/\\min\(/g, 'min(')
+      .replace(/\\mathrm\{clip\}/g, 'clip')
+      .replace(/\\mid/g, '|')
+      .replace(/\\leftarrow/g, '←')
+      .replace(/\\theta/g, 'θ')
+      .replace(/\\phi/g, 'φ')
+      .replace(/\\pi/g, 'π')
+      .replace(/\\,/g, ' ')
+      .replace(/[{}]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  };
+
+  window.prepareMermaidRenderSource = function (source) {
+    if (!source || !window.shouldUsePlainMermaidMath()) return source;
+    return source.replace(/\$\$([\s\S]*?)\$\$/g, function (_match, tex) {
+      return window.mermaidMathToPlain(tex.trim());
+    });
+  };
+
+  window.patchMermaidForeignObjects = function (root) {
+    if (!isIos() && !isMobileViewport()) return;
+    var scope = root && root.querySelectorAll ? root : document;
+    scope.querySelectorAll('.mermaid svg foreignObject').forEach(function (fo) {
+      var inner = fo.querySelector('.nodeLabel > div, .edgeLabel > div, .labelBkg');
+      if (!inner) return;
+      inner.style.setProperty('display', 'block', 'important');
+      inner.style.setProperty('white-space', 'normal', 'important');
+      inner.style.setProperty('max-width', 'min(280px, calc(100vw - 3rem))', 'important');
+      inner.style.setProperty('box-sizing', 'border-box', 'important');
+      var w = inner.scrollWidth;
+      var h = inner.scrollHeight;
+      if (w > 0) fo.setAttribute('width', String(Math.ceil(w)));
+      if (h > 0) fo.setAttribute('height', String(Math.ceil(h)));
+    });
+  };
+
   function scaledFlowchart(scale) {
     var mobile = isMobileViewport();
     return {
@@ -104,6 +172,7 @@
 
   window.getMermaidSiteConfig = function (theme) {
     var mobile = isMobileViewport();
+    var ios = isIos();
     var scale = mobile ? 1.05 : MERMAID_RENDER_SCALE;
     return {
       startOnLoad: false,
@@ -112,8 +181,8 @@
       htmlLabels: true,
       flowchart: scaledFlowchart(scale),
       securityLevel: 'strict',
-      // Site already loads KaTeX CSS; use CSS-based math for consistent flowchart labels.
-      forceLegacyMathML: true,
+      // iOS Safari: native MathML; other platforms use KaTeX CSS in foreignObject.
+      forceLegacyMathML: !ios,
     };
   };
 
@@ -121,6 +190,10 @@
   window.buildMermaidLightboxGraph = function (source) {
     var text = (source || '').trim();
     if (!text) return '';
+    text =
+      typeof window.prepareMermaidRenderSource === 'function'
+        ? window.prepareMermaidRenderSource(text)
+        : text;
     return (
       '%%{init: ' +
       JSON.stringify(initDirective(MERMAID_LIGHTBOX_SCALE)) +
@@ -128,4 +201,8 @@
       text
     );
   };
+
+  if (typeof document !== 'undefined' && isIos()) {
+    document.documentElement.classList.add('ios');
+  }
 })();

--- a/assets/js/mermaid-zoom.js
+++ b/assets/js/mermaid-zoom.js
@@ -349,6 +349,9 @@
         if (renderSeq !== lightboxRenderSeq || lightbox.hidden) return;
         stage.removeAttribute('aria-busy');
         if (swapLightboxSvg(result.svg, sourceEl)) {
+          if (typeof window.patchMermaidForeignObjects === 'function') {
+            window.patchMermaidForeignObjects(stage);
+          }
           attachRoadmapLinksInLightbox(sourceEl);
         }
       })

--- a/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
+++ b/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
@@ -230,12 +230,12 @@ for epoch in range(10):
 
 <div class="mermaid">
 flowchart TB
-    I["初始化 $$\pi_\theta,\, V_\phi$$（随机）<br/>创建 N=32 个并行环境"]
+    I["初始化 π_θ, V_φ（随机）<br/>创建 N=32 个并行环境"]
     L["32 个环境并行收集，各 64 步<br/>→ 2048 个样本"]
-    G["按环境/轨迹独立计算 GAE 优势 $$\hat{A}_t$$"]
-    S["保存 $$\pi_{\theta_{old}} \leftarrow \pi_\theta$$"]
-    R["概率比 $$r_t(\theta)=\frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_{old}}(a_t \mid s_t)}$$"]
-    P["PPO 更新（10 epoch）<br/>$$L^{CLIP}=\min(r_t\hat{A}_t,\,\mathrm{clip}(r_t,0.8,1.2)\hat{A}_t)$$"]
+    G["按环境/轨迹独立计算 GAE 优势 Â_t"]
+    S["保存 π_old ← π_θ"]
+    R["概率比<br/>r_t(θ)=π_θ(a#124;s)/π_old(a#124;s)"]
+    P["PPO 更新（10 epoch）<br/>L^CLIP=min(r_t·Â_t, clip·Â_t)"]
     U["更新 θ（策略）与 φ（价值 MSE）"]
     Q{回报 > 目标?}
     DONE((训练完成))

--- a/tests/test_mermaid_ios_plain.py
+++ b/tests/test_mermaid_ios_plain.py
@@ -1,0 +1,23 @@
+"""Tests for iOS plain-label Mermaid math fallback."""
+
+from scripts.adapt_mermaid_blocks import escape_pipes_in_node_labels
+
+# Re-use inline logic until extracted; test via exec of mermaid-config patterns in JS is harder.
+# Python-side: verify PPO full flowchart source has no $$ after manual check.
+
+
+def test_ppo_full_flowchart_has_no_display_math_delimiters():
+    from pathlib import Path
+
+    path = Path("papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md")
+    text = path.read_text(encoding="utf-8")
+    start = text.index("### 完整流程图")
+    end = text.index("### ", start + 1)
+    block = text[start:end]
+    assert "$$" not in block, "完整流程图应使用 Unicode 纯文本，避免 iOS foreignObject 公式重叠"
+
+
+def test_escape_pipes_still_works():
+    src = 'R["pi(a|s)"]'
+    out = escape_pipes_in_node_labels(src)
+    assert "#124;" in out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在 iPhone Safari 上，PPO 笔记「完整流程图」中多段 `$$...$$` 公式会脱离节点、叠在流程图顶部（见 issue 截图）。

根因：iOS Safari 对 SVG `foreignObject` 内的 KaTeX display math 布局不可靠；同节点多段 `$$` 还会触发 Mermaid 已知问题。

## 修复

1. **PPO 完整流程图**：节点标签改为 Unicode 纯文本（`π_θ`、`Â_t`、`L^CLIP=...` 等），不再使用 `$$`。
2. **iOS 通用降级**：`prepareMermaidRenderSource()` 在 iOS 上将其余 Mermaid 块内的 `$$` 转为可读纯文本；`forceLegacyMathML: false`。
3. **渲染后修补**：`patchMermaidForeignObjects()` 修正 `foreignObject` 宽高；`html.ios` 下隐藏流程图内 KaTeX display，避免残留叠层。
4. **回归测试**：`tests/test_mermaid_ios_plain.py` 断言完整流程图无 `$$`。

## 验收（390×844，iPhone UA）

![修复后：PPO 完整流程图（iPhone 390×844）](https://cursor.com/artifacts/c/art-607b7334-2ee0-442f-b291-0db1e8d5924f)

![修复后：PPO GAE 流程图（iPhone 390×844）](https://cursor.com/artifacts/c/art-8390ba7e-576f-4f1e-88a9-83d46d101141)

本地 Playwright 验证：`html.ios=true`，Mermaid 内 `katex-display` 数量为 0。

## 测试

- `pytest tests/test_mermaid_ios_plain.py tests/test_mermaid_adaptation.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dd266d5-9f3a-4bc6-bcc6-348de90f6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dd266d5-9f3a-4bc6-bcc6-348de90f6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

