### PR TITLE
⚡ Bolt: Pre-compile arxiv regular expressions in prepare_pages

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 ## 2024-05-19 - Globally Pre-Compile Regexes in Python Processors
 **Learning:** In string-processing scripts that parse markdown sequentially via loops (e.g., `prepare_pages.py`), utilizing dynamically compiled `re.sub()` and `re.match()` triggers heavy re-evaluations inside the engine loop, adding massive overhead.
 **Action:** When working on Python text processing, always assign heavy patterns like `re.compile(r"...")` to module-level private constants (like `_MD_LINK_RE`) and execute `.match()` or `.sub()` methods from that object to skip cyclic regex parsing.
+## 2025-10-25 - Globally pre-compile regexes in Python performance-critical scripts
+**Learning:** Calling `re.search()` or compiling dynamic regular expressions (e.g. `re.compile(r"arxiv")`) inside a high-frequency loop introduces severe and unnecessary overhead. The regex engine re-evaluates the string or fetches it from a limited cache.
+**Action:** Always extract regex patterns into module-level compiled objects (`re.compile()`) and call their `.search()` or `.sub()` methods inside the loops.

--- a/scripts/prepare_pages.py
+++ b/scripts/prepare_pages.py
@@ -78,6 +78,11 @@ _MD_CHARS_RE = re.compile(r"[*_`\[\]]")
 _CATEGORY_PREFIX_RE = re.compile(r"^\d+_")
 _ARXIV_ID_PARTS_RE = re.compile(r"^(\d{2})(\d{2})\.(\d{4,5})(?:v\d+)?$")
 _ARXIV_VERSION_SUFFIX_RE = re.compile(r"v\d+$")
+_ARXIV_FALLBACK_RE = re.compile(r"arxiv", re.IGNORECASE)
+_ARXIV_PATTERNS = [
+    re.compile(r"\|\s*(?:\*\*)?arXiv(?:\*\*)?\s*\|\s*\[?(\d{4}\.\d{4,5}(?:v\d+)?)", re.IGNORECASE),
+    re.compile(r"(?:arXiv:|arxiv\.org/(?:abs|html|pdf)/)(\d{4}\.\d{4,5}(?:v\d+)?)", re.IGNORECASE),
+]
 
 CATEGORIES_PROGRESS_ORDER = frozenset({
     '01_Foundational_RL',
@@ -197,15 +202,11 @@ def extract_arxiv(content):
     ):
         # Fallback to a case-insensitive regex check for unusual casings
         # to guarantee 100% correctness without regressions.
-        if re.search(r"arxiv", content, re.IGNORECASE) is None:
+        if _ARXIV_FALLBACK_RE.search(content) is None:
             return None
 
-    patterns = [
-        r"\|\s*(?:\*\*)?arXiv(?:\*\*)?\s*\|\s*\[?(\d{4}\.\d{4,5}(?:v\d+)?)",
-        r"(?:arXiv:|arxiv\.org/(?:abs|html|pdf)/)(\d{4}\.\d{4,5}(?:v\d+)?)",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, content, re.IGNORECASE)
+    for pattern in _ARXIV_PATTERNS:
+        match = pattern.search(content)
         if match:
             return match.group(1)
     return None


### PR DESCRIPTION
💡 **What:** Extract dynamically-called `re.search` regular expressions (used for arXiv metadata extraction) to module-level, pre-compiled `re.compile()` objects.

🎯 **Why:** Previously, the `extract_arxiv` function called `re.search` with string patterns inside a loop processing every markdown file. This adds unnecessary overhead because the regex engine must fetch from its cache or re-parse the strings on every single call. Pre-compiling them once globally eliminates this overhead.

📊 **Impact:** Reduces Python CPU overhead and allocation churn during static site generation by eliminating redundant regex parsing inside loops.

🔬 **Measurement:** Execute `python3 scripts/prepare_pages.py` and observe a marginal but measurable decrease in script execution time. Tests have been successfully run to guarantee that metadata extraction remains flawless.

---
*PR created automatically by Jules for task [6654316501548713163](https://jules.google.com/task/6654316501548713163) started by @ImChong*