### PR TITLE
docs(Simulation Benchmark): 添加 ComFree-Sim 免互补约束解析接触物理引擎笔记总结（2026-06-10）

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1460,6 +1460,17 @@
     "display_name": "Simulation Benchmark",
     "papers": [
       {
+        "title": "ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control",
+        "path": "papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md",
+        "url": "/papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.html",
+        "dir": "ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine",
+        "arxiv": "2603.12185",
+        "has_open_source": true,
+        "published_date_zh": "2026-03-12 (arXiv)",
+        "published_date_en": "Mar 12, 2026 (arXiv)",
+        "zhname": "ComFree-Sim：免互补约束的解析接触物理引擎，闭式冲量 + GPU 并行实现接触数量近线性扩展，兼容 MuJoCo API"
+      },
+      {
         "title": "Towards Motion Turing Test: Evaluating Human-Likeness in Humanoid Robots",
         "path": "papers/11_Simulation_Benchmark/Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots/Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots.md",
         "url": "/papers/11_Simulation_Benchmark/Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots/Towards_Motion_Turing_Test__Evaluating_Human-Likeness_in_Humanoid_Robots.html",

--- a/papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md
+++ b/papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md
@@ -1,0 +1,209 @@
+---
+layout: paper
+paper_order: 7
+title: "ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control"
+zhname: "ComFree-Sim：一个「免互补约束」的解析接触物理引擎——把接触冲量写成闭式解、按接触对/摩擦锥面解耦后映射到 GPU，实现接触数量近线性扩展，并兼容 MuJoCo API"
+category: "Simulation Benchmark"
+---
+
+# ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control
+
+**接触密集（contact-rich）的机器人任务（抓取、灵巧操作、行走）在仿真里一直很慢，根因是传统接触求解把所有接触点耦合成一个全局「互补问题（complementarity problem）」，难以并行。ComFree-Sim 换一条路：用「免互补（complementarity-free）」建模，把每个接触点的冲量写成闭式（closed-form）解——在库仑摩擦锥的对偶锥里做一次「阻抗式预测—修正」更新。由于接触在「接触对之间」解耦、又在「摩擦锥面之间」可分离，整个计算天然映射到 GPU 核函数，运行时随接触数量近线性扩展。引擎兼容 MuJoCo API，底层用 NVIDIA Warp 实现。**
+
+> 📅 阅读日期: 2026-06-10
+>
+> 🏷️ 板块: 11 Simulation Benchmark · 接触物理引擎 / 免互补建模 / GPU 并行 / 接触密集仿真
+>
+> 🔁 推进轨: 模块轮转（10_Sim-to-Real → **11_Simulation_Benchmark**）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| arXiv | [2603.12185](https://arxiv.org/abs/2603.12185) |
+| HTML | [在线阅读](https://arxiv.org/html/2603.12185) |
+| PDF | [下载](https://arxiv.org/pdf/2603.12185) |
+| 项目主页 | [irislab.tech/comfree-sim](https://irislab.tech/comfree-sim/) |
+| 源码 | [asu-iris/comfree_warp](https://github.com/asu-iris/comfree_warp)（NVIDIA Warp，兼容 MuJoCo API） |
+| **发布时间** | 2026-03-12 (arXiv，2026-03-14 修订) |
+
+**作者**：Chetan Borse、Zhixian Xie（亚利桑那州立大学 IRIS Lab），Wei-Cheng Huang（UIUC Siebel 计算与数据科学学院），Wanxin Jin（通讯作者，ASU）
+**机构**：Arizona State University · Intelligent Robotics and Interactive Systems (IRIS) Lab；University of Illinois Urbana-Champaign
+**主题**：面向接触密集机器人仿真与控制的 GPU 并行解析接触引擎
+
+---
+
+## 🎯 一句话总结
+
+接触建模慢、难并行的老问题，根子在于经典 LCP/NCP 式求解把所有接触点拧成一个**全局互补约束**（接触处「要么速度为零、要么力为零」），必须整体迭代求解。ComFree-Sim 提出**免互补**的接触公式：在库仑摩擦锥的**对偶锥**里，用一次**阻抗式（impedance-style）的预测—修正（prediction–correction）**就能把每个接触冲量算成**闭式解**。这样接触在**接触对之间解耦**、并在**摩擦锥面（cone facets）之间可分离**，天然对应 GPU 上「一个接触 / 一个锥面 = 一个线程」的并行模式，于是**运行时随接触数量近线性扩展**。公式进一步推广为统一的 **6D 接触模型**（切向 + 扭转 + 滚动摩擦），并给出一个实用的**对偶锥阻抗启发式**。引擎对外兼容 **MuJoCo API**，底层基于 **NVIDIA Warp**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 全称 | 解释 |
+|---|---|---|
+| Contact-Rich | - | 接触密集：抓取、灵巧操作、行走等大量接触切换的任务 |
+| LCP / NCP | (Non)Linear Complementarity Problem | (非)线性互补问题，经典接触求解的数学形式 |
+| Complementarity | 互补约束 | "接触速度与接触力不能同时非零"的约束，把所有接触耦合在一起 |
+| Friction Cone | 库仑摩擦锥 | 合法接触力（法向 + 切向）所在的圆锥约束 |
+| Dual Cone | 对偶锥 | 摩擦锥的对偶集合，ComFree 在其中做投影/修正 |
+| Cone Facet | 摩擦锥面 | 把圆锥线性化后的若干面，每个面可独立并行处理 |
+| 6D Contact | - | 同时建模切向、扭转、滚动三类摩擦的统一接触模型 |
+| Warp | NVIDIA Warp | NVIDIA 的 Python GPU 核函数框架，本引擎的实现后端 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+**问题陈述**：接触密集任务的仿真为什么慢？因为主流物理引擎（MuJoCo、Bullet 等）把接触当成一个**互补问题**来解——所有接触点之间相互耦合，必须用迭代器（PGS、CG、Newton 等）**全局**求一个约束优化。接触越多，耦合越强，迭代越慢，而且这种全局耦合**很难切成 GPU 上互不依赖的并行任务**。
+
+这就带来两难：
+
+- 想用 GPU 大规模并行训练 RL / 做大批量仿真，但接触求解器恰恰是最难并行的那一环；
+- 接触越密集（灵巧手抓握、多指操作），传统求解器越慢、越不稳定。
+
+**核心问题**：
+
+> 能否构造一个**精度够用、又能在 GPU 上随接触数量近线性扩展**的接触物理引擎，让接触密集仿真真正吃满并行算力？
+
+---
+
+## 🔧 方法拆解：免互补 + 闭式冲量 + GPU 并行
+
+### 1. 核心思想：去掉互补约束
+
+传统做法把"接触速度 ⊥ 接触力"的**互补条件**作为硬约束，整体求解 → 全局耦合。ComFree-Sim 的关键转变：**不显式求解互补约束**，而是把接触冲量直接写成一个**闭式（closed-form）更新**，逐接触独立计算。
+
+### 2. 对偶锥里的阻抗式预测—修正
+
+每个接触冲量通过一次**预测—修正（prediction–correction）**得到：
+
+- **预测**：先按"无摩擦/自由"假设给出一个候选冲量；
+- **修正**：把候选冲量投影/拉回到**库仑摩擦锥的对偶锥**内，用一个**阻抗式（弹簧—阻尼风格）**的启发式来调节修正量，使结果满足摩擦约束。
+
+整个过程是解析的、无需全局迭代，因此每个接触点都能**单独**算出自己的冲量。
+
+### 3. 双重解耦 → 天然 GPU 并行
+
+- **接触对之间解耦**：不同接触点的冲量计算互不依赖 → 一个接触 = 一个 GPU 线程块；
+- **摩擦锥面之间可分离**：单个接触的摩擦修正在各**锥面**上可分别处理 → 进一步细粒度并行。
+
+两层解耦正好对应 GPU 的并行结构，于是**运行时随接触数量近线性增长**（而非传统求解器的超线性恶化）。
+
+### 4. 统一 6D 接触模型
+
+公式不止于点接触的切向摩擦，而是推广到统一的 **6D 接触**：同时刻画**切向（滑动）+ 扭转（spin）+ 滚动（rolling）**三类摩擦，更贴近灵巧操作中"指尖搓、滚、拧"的真实接触行为。
+
+### 5. 工程落地：MuJoCo API + NVIDIA Warp
+
+- 对外**兼容 MuJoCo 的 API**，已有 MuJoCo 模型/管线可低成本迁移；
+- 底层用 **NVIDIA Warp** 写 GPU 核函数，纯 Python 代码库；
+- 提供 Franka 抓方块基准、并行多手吞吐基准、交互查看器、无头流式渲染等示例。
+
+---
+
+## 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    SCENE["🌐 多环境 / 多接触场景<br/>(灵巧手抓取 · 行走 · 操作)"]
+
+    subgraph CLASSIC["❌ 传统做法: 互补问题求解"]
+        LCP["全局互补约束 LCP/NCP<br/>所有接触相互耦合"]
+        ITER["迭代求解器 (PGS/Newton...)<br/>难并行 · 接触多则超线性变慢"]
+        LCP --> ITER
+    end
+
+    subgraph COMFREE["✅ ComFree-Sim: 免互补 + 闭式冲量"]
+        PRED["① 预测<br/>自由假设下的候选冲量"]
+        CORR["② 修正<br/>投影到摩擦对偶锥<br/>阻抗式启发式"]
+        SIX["③ 统一 6D 接触<br/>切向 + 扭转 + 滚动摩擦"]
+        PRED --> CORR --> SIX
+    end
+
+    subgraph GPU["⚡ GPU 并行 (NVIDIA Warp)"]
+        DECOUPLE["接触对之间解耦<br/>锥面之间可分离"]
+        KERNEL["一个接触/锥面 = 一个线程<br/>运行时随接触数量近线性扩展"]
+        DECOUPLE --> KERNEL
+    end
+
+    SCENE --> COMFREE
+    SCENE -. 对照 .-> CLASSIC
+    SIX --> DECOUPLE
+
+    API["🔌 兼容 MuJoCo API<br/>已有模型/管线低成本迁移"]
+    KERNEL --> API
+    API --> OUT["🚀 大批量接触密集仿真 / RL 训练<br/>抓取 · 灵巧操作 · 行走"]
+
+    style CLASSIC fill:#fdecea,stroke:#c0392b
+    style COMFREE fill:#e8f4fd,stroke:#1f78b4
+    style GPU fill:#fff7e6,stroke:#e67e22
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **建模贡献**：提出**免互补**的接触公式——在摩擦对偶锥里用一次**阻抗式预测—修正**把接触冲量写成**闭式解**，从根上去掉了传统接触求解的全局耦合；
+2. **可扩展性贡献**：利用"接触对解耦 + 锥面可分离"的双重结构映射到 GPU，达到**接触数量近线性**的运行时扩展；
+3. **模型贡献**：统一的 **6D 接触模型**（切向/扭转/滚动摩擦）+ 实用的对偶锥阻抗启发式；
+4. **工程贡献**：开源 [comfree_warp](https://github.com/asu-iris/comfree_warp)，**兼容 MuJoCo API**、基于 **NVIDIA Warp**，提供抓取与并行吞吐基准，便于直接接入现有机器人学习管线。
+
+---
+
+## 📊 关键设定
+
+| 维度 | 值 |
+|---|---|
+| 接触建模 | 免互补（complementarity-free），闭式冲量 |
+| 求解形式 | 对偶锥内阻抗式预测—修正（无全局迭代） |
+| 摩擦模型 | 统一 6D：切向 + 扭转 + 滚动 |
+| 并行结构 | 接触对解耦 + 锥面可分离 → GPU 核函数 |
+| 扩展性 | 运行时随接触数量近线性 |
+| 实现 | NVIDIA Warp（纯 Python），兼容 MuJoCo API |
+| 示例/基准 | Franka 抓方块、并行多手吞吐、交互查看器、无头流式 |
+| 许可 | 核心组件「非商业学术研究许可」，上游 vendored 代码 Apache 2.0 |
+
+> 📌 具体加速比、与 MuJoCo/MJX 的吞吐对比、接触精度/穿透误差、RL 训练曲线等数值请以论文 PDF 实验章节为准。
+
+---
+
+## 🤖 对仿真基准 / 接触密集学习的意义
+
+| 方向 | 含义 |
+|---|---|
+| **接触求解的可并行性** | 把"最难并行的接触环节"重写成逐接触闭式更新，补上了 GPU 并行仿真的关键短板 |
+| **灵巧操作友好** | 6D 接触（含扭转/滚动）更贴近多指搓/拧/滚的真实物理，适合灵巧手训练 |
+| **低迁移成本** | 兼容 MuJoCo API，已有 MuJoCo/MJX 工程可平滑切换体验 |
+| **与 MJX / Genesis 等的定位** | 同属"GPU 并行物理引擎"赛道，但卖点在**接触建模本身的可并行公式**，而非仅靠批量化环境 |
+
+---
+
+## 🎤 面试参考
+
+**Q：为什么传统接触求解难在 GPU 上并行？**
+A：因为它把接触建成一个**互补问题**——每个接触点"要么速度为零、要么力为零"，这些条件把所有接触耦合成一个全局约束优化，必须用迭代器整体求解。接触之间相互依赖，没法切成互不通信的并行任务；接触越多耦合越强，迭代代价还会超线性增长。
+
+**Q：ComFree-Sim 的"免互补"具体免掉了什么？**
+A：免掉了显式求解互补约束这一步。它不去解"速度⊥力"的全局条件，而是对**每个接触**单独做一次"预测候选冲量 → 投影回摩擦对偶锥修正"的闭式更新。结果是每个接触可独立计算，天然并行。
+
+**Q："对偶锥里的阻抗式修正"是什么意思？**
+A：合法接触力被约束在库仑摩擦锥内；其对偶锥描述了合法的相对运动方向。ComFree 先给一个自由假设下的候选冲量，再把它**投影/拉回**到对偶锥内满足摩擦约束，修正量用一个**阻抗（弹簧—阻尼风格）**启发式来调节大小，避免硬投影带来的抖动或穿透。
+
+**Q：为什么要做到 6D 接触？**
+A：点接触只建切向滑动摩擦，但灵巧操作里指尖会**扭转（spin）和滚动（rolling）**，这些扭矩级的摩擦对抓握稳定性影响很大。统一的 6D 接触把这三类摩擦一并建模，仿真才更贴近真实手内操作。
+
+---
+
+## 🔗 相关阅读
+
+- [MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation](../MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md)：同模块的大规模仿真生态/基准，本仓库已有笔记
+- [HumanoidBench: Simulated Humanoid Benchmark for Whole-Body Locomotion and Manipulation](../HumanoidBench/HumanoidBench.md)：人形全身仿真基准，本仓库已有笔记
+- [Generative World Modelling for Humanoids: 1X World Model Challenge](../Generative_World_Modelling_for_Humanoids__1X_World_Model_Challenge_Technical_Report/Generative_World_Modelling_for_Humanoids__1X_World_Model_Challenge_Technical_Report.md)：另一种"学习式模拟器"路线（世界模型），与解析物理引擎形成对照，本仓库已有笔记
+
+---
+
+> 备注：本笔记基于 arXiv 摘要、项目主页（[irislab.tech/comfree-sim](https://irislab.tech/comfree-sim/)）与源码仓库（[asu-iris/comfree_warp](https://github.com/asu-iris/comfree_warp)）整理；网络受限期间论文全文 HTML/PDF 未完整抓取，**具体加速比、接触精度、与 MuJoCo/MJX 的吞吐对比及消融**请以论文 PDF 为准。

--- a/papers/DAILY_SUMMARY_LOG.md
+++ b/papers/DAILY_SUMMARY_LOG.md
@@ -260,6 +260,7 @@
 | 276 | DexterCap: An Affordable and Automated System for Capturing Dexterous Hand-Object Manipulation | 06_Manipulation | ✅ 已完成（2026-06-15） |
 | 539 | Adaptive Invariant Extended Kalman Filter for Legged Robot State Estimation | 09_State_Estimation | ✅ 已完成（2026-06-10） |
 | 540 | HALO: Closing Sim-to-Real Gap for Heavy-loaded Humanoid Agile Motion Skills via Differentiable Simulation | 10_Sim-to-Real | ✅ 已完成（2026-06-10） |
-| ? | （明日：11_Simulation_Benchmark 模块首个未完成论文；按 04 → 05 → 06 → 07 → 08 → 09 → 10 → 11 → 12 → 13 → 14 → 04 顺序循环） | 11_Simulation_Benchmark | ⏭️ 下一篇候选 |
+| 408 | ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control | 11_Simulation_Benchmark | ✅ 已完成（2026-06-10） |
+| ? | （明日：12_Hardware_Design 模块首个未完成论文；按 04 → 05 → 06 → 07 → 08 → 09 → 10 → 11 → 12 → 13 → 14 → 04 顺序循环） | 12_Hardware_Design | ⏭️ 下一篇候选 |
 
 > 实际推进时会按当天轮转到的模块在 `papers` 列表中扫描，跳过已有内容的笔记。

--- a/papers/PROGRESS.md
+++ b/papers/PROGRESS.md
@@ -541,7 +541,7 @@
 | 405  | [Humanoid-Gym: Reinforcement Learning for Humanoid Robot with Zero-Shot Sim2Real Transfer](https://arxiv.org/abs/2404.05695)               | 2024.04 |     | ⏳ 待读 |
 | 406  | [HumanoidBench: Simulated Humanoid Benchmark for Whole-Body Locomotion and Manipulation](https://arxiv.org/abs/2403.10506)                 | 2024.03 |     | ⏳ 待读 |
 | 407  | RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots                                            | -       |     | ⏳ 待读 |
-| 408  | [ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control](https://arxiv.org/abs/2603.12185) | 2026.03 |  | ⏳ 待读 |
+| 408  | [ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control](https://arxiv.org/abs/2603.12185) ✅ [笔记](11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md) | 2026.03 |  | ✅ 已总结 |
 | 409  | [Humanoid Everyday: A Comprehensive Robotic Dataset for Open-World Humanoid Manipulation](https://arxiv.org/abs/2510.08807) | 2025.10 |  | ⏳ 待读 |
 | 527  | [MuJoCo Playground](https://playground.mujoco.org/)                                                                                       | 2025.01 |     | ⏳ 待读 |
 

--- a/progress.json
+++ b/progress.json
@@ -41,10 +41,10 @@
         "13_Physics-Based_Animation",
         "14_Human_Motion"
       ],
-      "last_module": "10_Sim-to-Real",
-      "last_index": 540,
-      "last_title": "HALO: Closing Sim-to-Real Gap for Heavy-loaded Humanoid Agile Motion Skills via Differentiable Simulation",
-      "next_module": "11_Simulation_Benchmark"
+      "last_module": "11_Simulation_Benchmark",
+      "last_index": 408,
+      "last_title": "ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control",
+      "next_module": "12_Hardware_Design"
     },
     "last_summary_index": 355,
     "last_summary_date": "2026-06-17",
@@ -819,6 +819,18 @@
         "arxiv": "2603.15084",
         "source_repo": null,
         "project_page": "https://mwondering.github.io/halo-humanoid/"
+      },
+      {
+        "date": "2026-06-10",
+        "index": 408,
+        "title": "ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control",
+        "module": "11_Simulation_Benchmark",
+        "category": "11_Simulation_Benchmark",
+        "note_path": "papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md",
+        "track": "module_rotation",
+        "arxiv": "2603.12185",
+        "source_repo": "https://github.com/asu-iris/comfree_warp",
+        "project_page": "https://irislab.tech/comfree-sim/"
       }
     ],
     "last_completed_index": 373,


### PR DESCRIPTION
## 📌 每日论文总结（模块轮转：10_Sim-to-Real → **11_Simulation_Benchmark** → 下一篇 12_Hardware_Design）

本次推进 **11 仿真平台与基准** 模块中最新发表的待读论文 **#408 ComFree-Sim**（arXiv:2603.12185，2026-03 发布）。

### 论文信息
- **标题**：ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control
- **机构**：Arizona State University · IRIS Lab；UIUC
- **arXiv**：[2603.12185](https://arxiv.org/abs/2603.12185) · [HTML](https://arxiv.org/html/2603.12185) · [PDF](https://arxiv.org/pdf/2603.12185)
- **项目主页**：[irislab.tech/comfree-sim](https://irislab.tech/comfree-sim/)
- **源码**：[asu-iris/comfree_warp](https://github.com/asu-iris/comfree_warp)（NVIDIA Warp，兼容 MuJoCo API）

### 核心内容
- **免互补（complementarity-free）建模**：摆脱传统 LCP/NCP 把所有接触耦合成全局互补问题的做法，把每个接触冲量写成**闭式解**；
- **对偶锥阻抗式预测—修正**：在库仑摩擦对偶锥里做一次「预测候选冲量 → 投影修正」即可满足摩擦约束；
- **双重解耦 → GPU 并行**：接触对之间解耦、摩擦锥面之间可分离，天然映射到 GPU 核函数，**运行时随接触数量近线性扩展**；
- **统一 6D 接触模型**：同时建模切向 + 扭转 + 滚动摩擦，贴近灵巧操作；
- **工程落地**：兼容 MuJoCo API、基于 NVIDIA Warp，便于接入现有机器人学习管线。

### 本次改动
- 新增笔记 `papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/`（含 mermaid 流程图：传统互补求解 vs ComFree 闭式冲量 + GPU 并行对照）
- 同步更新 `papers/PROGRESS.md`（#408 标记为已总结）、`_data/papers.json`、`papers/DAILY_SUMMARY_LOG.md`、`progress.json`（模块轮转状态推进至 11，下一篇指向 12_Hardware_Design）

> 笔记基于 arXiv 摘要、项目主页与源码仓库整理；网络受限期间论文全文 PDF 未完整抓取，具体加速比/接触精度/吞吐对比以论文 PDF 为准。

https://claude.ai/code/session_01PH1bUDAb8c5KdXXTJhQA9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH1bUDAb8c5KdXXTJhQA9K)_