### PR TITLE
Add publication years to roadmap visualization nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,14 @@
 
 ## 学习路线图
 
+> 💡 括号内为论文 arXiv 首次发布年份，与首页路线图节点下方的年份小字一致。
+
 ```
 ① 【基础 RL】
-  PPO → AWR
-       ↓
+  PPO (2017) → AWR (2019)
+              ↓
    【人体动作数据层】        ← 模仿类方法开始需要参考数据
-  AMASS / HumanML3D  →  人体 SMPL 动作数据集
+  AMASS (2019) / HumanML3D (2022)  →  人体 SMPL 动作数据集
        ↓
    【动作重定向层】          ← 人体骨架 → 机器人骨架的桥梁
   几何重定向 (IK-based)  →  GMR / Retargeting Matters (2025)
@@ -129,30 +131,30 @@
   PHC (2023)            ADD (2025)
        ↓
 ③ 【技能组合 / 扩散】
-  ASE (2022) → CALM (2023) → PULSE (2024)
-  Diffusion Policy → BeyondMimic (2025)
+  ASE (2022) → CALM (2023) → PULSE (2023)
+  Diffusion Policy (2023) → BeyondMimic (2025)
        ↓
 ④ 【全身控制 WBC】        ← 把技能 / 扩散策略落到整机关节
-  Expressive WBC (2024) → HOVER / HugWBC / ExBody2
+  Expressive WBC (2024) → HOVER (2024) / HugWBC (2025) / ExBody2 (2024)
        ↓
    ┌── 从 WBC / 扩散分出多条上行支线，最终都汇聚到 ⑨ ──┐
    │
-   ├─ ⑤ 操作 Manipulation：         iDP3 → EgoMimic → HumDex
+   ├─ ⑤ 操作 Manipulation：         iDP3 (2024) → EgoMimic (2024) → HumDex (2026)
    │                                （3D 扩散策略 / 自我中心视频 / 灵巧手）
    │
-   ├─ ⑥ 移动操作 Loco-Manipulation： HOMIE → ULTRA → Ψ₀
+   ├─ ⑥ 移动操作 Loco-Manipulation： HOMIE (2025) → ULTRA (2026) → Ψ₀ (2026)
    │                                （外骨骼遥操作 → 多模态全身控制 → loco-manip 基础模型）
    │
-   └─ ⑦ 世界模型 World Model：       DreamDojo → 1X World Model；HAIC（动力学感知 WM）
+   └─ ⑦ 世界模型 World Model：       DreamDojo (2026) → 1X World Model (2025)；HAIC (2026)（动力学感知 WM）
             ↓（世界模型"会做梦"预测未来 / 动力学，再升级为可直接当策略的模型）
-       ⑧ 世界-动作模型 WAM：         DreamZero（World Action Models are Zero-shot Policies）
+       ⑧ 世界-动作模型 WAM：         DreamZero (2026)（World Action Models are Zero-shot Policies）
        ↓
 ⑨ 【基础模型终点 (VLA / BFM)】   ← 一路从 PPO 爬到这里
-  VLA：GR00T N1                  ── 视觉-语言-动作，端到端通才策略
-  BFM：Behavior Foundation Model ── 行为基础模型 / 全身控制先验
+  VLA：GR00T N1 (2025)                  ── 视觉-语言-动作，端到端通才策略
+  BFM：Behavior Foundation Model (2025) ── 行为基础模型 / 全身控制先验
 
 【Sim-to-Real 工程层】  ← 横跨整个路线
-  Domain Randomization (2017) → LCP (2025)
+  Domain Randomization (2017) → LCP (2024)
   ↑ sim环境随机化迁移        ↑ 动作平滑，替代低通滤波器
 ```
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -190,47 +190,47 @@
       var roadmapGraphs = {
         en: `graph TD
     subgraph SG_Basic ["1 · Basic RL"]
-        PPO(["PPO"]) --> AWR(["AWR"])
-        AWR --> DM(["DeepMimic"])
+        PPO(["PPO<br/><span class='roadmap-node-year'>2017</span>"]) --> AWR(["AWR<br/><span class='roadmap-node-year'>2019</span>"])
+        AWR --> DM(["DeepMimic<br/><span class='roadmap-node-year'>2018</span>"])
     end
     subgraph SG_Data ["Data and Retargeting"]
-        DataNode(["AMASS / HumanML3D"]) --> Target(["Motion Retargeting"])
+        DataNode(["AMASS / HumanML3D<br/><span class='roadmap-node-year'>2019 / 2022</span>"]) --> Target(["Motion Retargeting<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_Style ["2 · Imitation and Style"]
-        DM --> AMP(["AMP"])
-        DM --> PHC(["PHC"])
-        AMP --> ADD(["ADD"])
+        DM --> AMP(["AMP<br/><span class='roadmap-node-year'>2021</span>"])
+        DM --> PHC(["PHC<br/><span class='roadmap-node-year'>2023</span>"])
+        AMP --> ADD(["ADD<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_Skills ["3 · Skills and Diffusion"]
-        ASE(["ASE"]) --> CALM(["CALM"]) --> PULSE(["PULSE"])
-        DP(["Diffusion Policy"]) --> BM(["BeyondMimic"])
+        ASE(["ASE<br/><span class='roadmap-node-year'>2022</span>"]) --> CALM(["CALM<br/><span class='roadmap-node-year'>2023</span>"]) --> PULSE(["PULSE<br/><span class='roadmap-node-year'>2023</span>"])
+        DP(["Diffusion Policy<br/><span class='roadmap-node-year'>2023</span>"]) --> BM(["BeyondMimic<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_WBC ["4 · Whole-Body Control"]
-        EWBC(["Expressive WBC"]) --> HOVER(["HOVER"])
-        EWBC --> HugWBC(["HugWBC"])
-        EWBC --> ExBody2(["ExBody2"])
+        EWBC(["Expressive WBC<br/><span class='roadmap-node-year'>2024</span>"]) --> HOVER(["HOVER<br/><span class='roadmap-node-year'>2024</span>"])
+        EWBC --> HugWBC(["HugWBC<br/><span class='roadmap-node-year'>2025</span>"])
+        EWBC --> ExBody2(["ExBody2<br/><span class='roadmap-node-year'>2024</span>"])
     end
     subgraph SG_Manip ["5 · Manipulation"]
-        iDP3(["iDP3"]) --> EgoMimic(["EgoMimic"])
-        EgoMimic --> HumDex(["HumDex"])
+        iDP3(["iDP3<br/><span class='roadmap-node-year'>2024</span>"]) --> EgoMimic(["EgoMimic<br/><span class='roadmap-node-year'>2024</span>"])
+        EgoMimic --> HumDex(["HumDex<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_Loco ["6 · Loco-Manipulation"]
-        HOMIE(["HOMIE"]) --> ULTRA(["ULTRA"])
-        ULTRA --> Psi(["Ψ₀"])
+        HOMIE(["HOMIE<br/><span class='roadmap-node-year'>2025</span>"]) --> ULTRA(["ULTRA<br/><span class='roadmap-node-year'>2026</span>"])
+        ULTRA --> Psi(["Ψ₀<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_WM ["7 · World Model"]
-        DreamDojo(["DreamDojo"]) --> WM1X(["1X World Model"])
-        HAIC(["HAIC — Dynamics-Aware WM"])
+        DreamDojo(["DreamDojo<br/><span class='roadmap-node-year'>2026</span>"]) --> WM1X(["1X World Model<br/><span class='roadmap-node-year'>2025</span>"])
+        HAIC(["HAIC — Dynamics-Aware WM<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_WAM ["8 · World Action Model"]
-        DreamZero(["DreamZero"])
+        DreamZero(["DreamZero<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_FM ["9 · Foundation Models"]
-        VLA(["VLA — GR00T N1"])
-        BFM(["BFM — Behavior FM"])
+        VLA(["VLA — GR00T N1<br/><span class='roadmap-node-year'>2025</span>"])
+        BFM(["BFM — Behavior FM<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_Eng ["Engineering"]
-        DR(["Domain Randomization"]) --> LCP(["LCP"])
+        DR(["Domain Randomization<br/><span class='roadmap-node-year'>2017</span>"]) --> LCP(["LCP<br/><span class='roadmap-node-year'>2024</span>"])
     end
     Target -.-> DM
     Target -.-> AMP
@@ -254,47 +254,47 @@
     DreamZero --> BFM`,
         zh: `graph TD
     subgraph SG_Basic ["1 · 基础 RL"]
-        PPO(["PPO"]) --> AWR(["AWR"])
-        AWR --> DM(["DeepMimic"])
+        PPO(["PPO<br/><span class='roadmap-node-year'>2017</span>"]) --> AWR(["AWR<br/><span class='roadmap-node-year'>2019</span>"])
+        AWR --> DM(["DeepMimic<br/><span class='roadmap-node-year'>2018</span>"])
     end
     subgraph SG_Data ["数据与重定向"]
-        DataNode(["AMASS / HumanML3D"]) --> Target(["动作重定向"])
+        DataNode(["AMASS / HumanML3D<br/><span class='roadmap-node-year'>2019 / 2022</span>"]) --> Target(["动作重定向<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_Style ["2 · 模仿与风格"]
-        DM --> AMP(["AMP"])
-        DM --> PHC(["PHC"])
-        AMP --> ADD(["ADD"])
+        DM --> AMP(["AMP<br/><span class='roadmap-node-year'>2021</span>"])
+        DM --> PHC(["PHC<br/><span class='roadmap-node-year'>2023</span>"])
+        AMP --> ADD(["ADD<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_Skills ["3 · 技能与扩散"]
-        ASE(["ASE"]) --> CALM(["CALM"]) --> PULSE(["PULSE"])
-        DP(["扩散策略"]) --> BM(["BeyondMimic"])
+        ASE(["ASE<br/><span class='roadmap-node-year'>2022</span>"]) --> CALM(["CALM<br/><span class='roadmap-node-year'>2023</span>"]) --> PULSE(["PULSE<br/><span class='roadmap-node-year'>2023</span>"])
+        DP(["扩散策略<br/><span class='roadmap-node-year'>2023</span>"]) --> BM(["BeyondMimic<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_WBC ["4 · 全身控制 WBC"]
-        EWBC(["表达性 WBC"]) --> HOVER(["HOVER"])
-        EWBC --> HugWBC(["HugWBC"])
-        EWBC --> ExBody2(["ExBody2"])
+        EWBC(["表达性 WBC<br/><span class='roadmap-node-year'>2024</span>"]) --> HOVER(["HOVER<br/><span class='roadmap-node-year'>2024</span>"])
+        EWBC --> HugWBC(["HugWBC<br/><span class='roadmap-node-year'>2025</span>"])
+        EWBC --> ExBody2(["ExBody2<br/><span class='roadmap-node-year'>2024</span>"])
     end
     subgraph SG_Manip ["5 · 操作 Manipulation"]
-        iDP3(["iDP3"]) --> EgoMimic(["EgoMimic"])
-        EgoMimic --> HumDex(["HumDex"])
+        iDP3(["iDP3<br/><span class='roadmap-node-year'>2024</span>"]) --> EgoMimic(["EgoMimic<br/><span class='roadmap-node-year'>2024</span>"])
+        EgoMimic --> HumDex(["HumDex<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_Loco ["6 · 移动操作 Loco-Manip"]
-        HOMIE(["HOMIE"]) --> ULTRA(["ULTRA"])
-        ULTRA --> Psi(["Ψ₀"])
+        HOMIE(["HOMIE<br/><span class='roadmap-node-year'>2025</span>"]) --> ULTRA(["ULTRA<br/><span class='roadmap-node-year'>2026</span>"])
+        ULTRA --> Psi(["Ψ₀<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_WM ["7 · 世界模型 World Model"]
-        DreamDojo(["DreamDojo"]) --> WM1X(["1X 世界模型"])
-        HAIC(["HAIC — 动力学感知 WM"])
+        DreamDojo(["DreamDojo<br/><span class='roadmap-node-year'>2026</span>"]) --> WM1X(["1X 世界模型<br/><span class='roadmap-node-year'>2025</span>"])
+        HAIC(["HAIC — 动力学感知 WM<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_WAM ["8 · 世界-动作模型 WAM"]
-        DreamZero(["DreamZero"])
+        DreamZero(["DreamZero<br/><span class='roadmap-node-year'>2026</span>"])
     end
     subgraph SG_FM ["9 · 基础模型 VLA / BFM"]
-        VLA(["VLA — GR00T N1"])
-        BFM(["BFM — 行为基础模型"])
+        VLA(["VLA — GR00T N1<br/><span class='roadmap-node-year'>2025</span>"])
+        BFM(["BFM — 行为基础模型<br/><span class='roadmap-node-year'>2025</span>"])
     end
     subgraph SG_Eng ["工程实践"]
-        DR(["域随机化"]) --> LCP(["LCP"])
+        DR(["域随机化<br/><span class='roadmap-node-year'>2017</span>"]) --> LCP(["LCP<br/><span class='roadmap-node-year'>2024</span>"])
     end
     Target -.-> DM
     Target -.-> AMP

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -723,6 +723,14 @@ html {
   cursor: pointer;
 }
 
+#roadmap-mermaid .roadmap-node-year,
+.mermaid-lightbox__stage .roadmap-node-year {
+  font-size: 0.72em;
+  font-weight: 400;
+  opacity: 0.68;
+  line-height: 1.2;
+}
+
 #roadmap-mermaid svg g.roadmap-node-link:focus {
   outline: none;
 }


### PR DESCRIPTION
## Summary
Enhanced the research roadmap visualization by adding publication years to each algorithm/method node in both English and Chinese versions. This provides better temporal context for understanding the evolution of techniques in the research timeline.

## Key Changes
- **Roadmap Graph Updates**: Added publication years (in `<br/><span class='roadmap-node-year'>YYYY</span>` format) to all 40+ nodes across both language versions (English and Chinese)
  - Basic RL methods: PPO (2017), AWR (2019), DeepMimic (2018)
  - Data nodes: AMASS/HumanML3D (2019/2022), Motion Retargeting (2025)
  - Imitation & Style: AMP (2021), PHC (2023), ADD (2025)
  - Skills & Diffusion: ASE (2022), CALM (2023), PULSE (2023), Diffusion Policy (2023), BeyondMimic (2025)
  - Whole-Body Control: Expressive WBC (2024), HOVER (2024), HugWBC (2025), ExBody2 (2024)
  - Manipulation: iDP3 (2024), EgoMimic (2024), HumDex (2026)
  - Loco-Manipulation: HOMIE (2025), ULTRA (2026), Ψ₀ (2026)
  - World Models: DreamDojo (2026), 1X World Model (2025), HAIC (2026)
  - Foundation Models: VLA/GR00T N1 (2025), BFM (2025)
  - Engineering: Domain Randomization (2017), LCP (2024)

- **CSS Styling**: Added `.roadmap-node-year` class with:
  - Reduced font size (0.72em) for subtle year display
  - Lighter font weight (400) and reduced opacity (0.68) for visual hierarchy
  - Proper line-height (1.2) for multi-line node labels
  - Applied to both main roadmap and lightbox views

## Implementation Details
- Years are displayed as secondary text below node names using HTML line breaks
- Styling ensures years don't overwhelm the primary node labels while remaining readable
- Consistent formatting across both English and Chinese roadmap versions

https://claude.ai/code/session_01CxXgGX8vWhZAoKMAoyhVYb