### PR TITLE
Fix roadmap year text rendering in iOS Safari

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -723,11 +723,15 @@ html {
   cursor: pointer;
 }
 
+/* 年份淡化只能用文字颜色实现，不能用 opacity / filter / transform：
+   这些属性会让 WebKit（iOS Safari）为 foreignObject 内的元素单独建合成层，
+   绘制时丢失祖先 SVG 的 transform，所有年份会堆叠到图表左上角原点。
+   color-mix 不支持时回退为继承色（位置正确，仅不淡化）。 */
 #roadmap-mermaid .roadmap-node-year,
 .mermaid-lightbox__stage .roadmap-node-year {
   font-size: 0.72em;
   font-weight: 400;
-  opacity: 0.68;
+  color: color-mix(in srgb, currentColor 68%, transparent);
   line-height: 1.2;
 }
 


### PR DESCRIPTION
## Summary
Fixed a rendering issue where roadmap year text would stack at the chart's origin point in iOS Safari by replacing `opacity` with `color-mix()` for the fade effect.

## Key Changes
- Replaced `opacity: 0.68` with `color-mix(in srgb, currentColor 68%, transparent)` on `.roadmap-node-year` elements
- Added detailed comment explaining the WebKit compositing layer issue that caused the bug
- Maintains visual fade effect while avoiding CSS properties that trigger unwanted compositing behavior in iOS Safari

## Implementation Details
The issue occurred because `opacity`, `filter`, and `transform` properties cause WebKit (iOS Safari) to create separate compositing layers for elements inside SVG `foreignObject` tags. This caused those elements to lose the ancestor SVG's transform context during rendering, resulting in all year labels stacking at the top-left origin point.

The solution uses `color-mix()` to achieve the same 68% opacity effect through text color manipulation instead. This approach:
- Avoids triggering the problematic compositing behavior
- Gracefully falls back to inherited color in browsers that don't support `color-mix()` (text remains visible but not faded)
- Maintains the intended visual appearance on all modern browsers

https://claude.ai/code/session_014YM3gCdtoFSD3Y8p1yJW7U