### PR TITLE
fix(mermaid): iPhone WebKit 论文流程图公式改走原生 MathML 真实渲染

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1119,15 +1119,32 @@ body.mermaid-lightbox-open {
   overflow: visible;
 }
 
-/* iOS Safari: KaTeX display math inside foreignObject is unstable — prefer plain labels. */
-html.ios .paper-body .mermaid foreignObject .katex-display,
-html.ios .paper-body .mermaid foreignObject .katex {
+/* iOS WebKit:foreignObject 内任何自带合成层的内容（opacity、filter、滚动
+   容器、定位偏移）都会丢失祖先 SVG 变换、被画到图表左上角原点。KaTeX 的
+   HTML 输出依赖 position:relative 偏移排版，无法整体规避，因此 iOS 上
+   Mermaid 公式改走原生 MathML（mermaid-config.js 中 forceLegacyMathML:
+   false）。以下为兜底：若意外出现 KaTeX 双输出，隐藏会触发 bug 的 HTML
+   部分，并把默认用 absolute+clip 隐藏的 MathML 副本恢复为可见静态排版
+   （absolute 定位本身也会触发该 bug）。 */
+html.ios :is(.paper-body .mermaid, .mermaid-lightbox__stage) foreignObject .katex-html {
   display: none !important;
 }
 
-html.ios .paper-body .mermaid foreignObject .katex-mathml {
+html.ios :is(.paper-body .mermaid, .mermaid-lightbox__stage) foreignObject .katex-mathml {
+  position: static !important;
+  clip: auto !important;
+  width: auto !important;
+  height: auto !important;
+  overflow: visible !important;
   display: inline-block !important;
   max-width: 100%;
+}
+
+/* 下方移动端规则会把 .katex-display 变成滚动容器；滚动容器在 WebKit 里
+   也是层叠合成层，处于 foreignObject 内同样触发错位，iOS 上保持不可滚动。 */
+html.ios .paper-body .mermaid foreignObject .katex-display {
+  overflow: visible !important;
+  -webkit-overflow-scrolling: auto !important;
 }
 
 /* Mobile Safari: nowrap flex labels + max-content KaTeX can paint outside node boxes. */

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -27,9 +27,17 @@
     );
   }
 
-  /** iOS Safari paints KaTeX-in-foreignObject unreliably; use plain labels instead. */
+  /**
+   * Kill-switch for the legacy plain-text math downgrade. iOS now renders
+   * Mermaid math as native MathML (see getMermaidSiteConfig): KaTeX's HTML
+   * output leans on position:relative offsets, which iOS WebKit paints at
+   * the SVG origin inside foreignObject (the compositing-layer bug — same
+   * class of issue as the roadmap-year opacity fix), while MathML creates
+   * no layers. If MathML misbehaves on some WebKit build, revert this to
+   * `return isIos();` to restore the mermaidMathToPlain downgrade below.
+   */
   window.shouldUsePlainMermaidMath = function () {
-    return isIos();
+    return false;
   };
 
   window.mermaidMathToPlain = function (tex) {
@@ -141,10 +149,15 @@
       /<foreignObject([^>]*)>([\s\S]*?)<\/foreignObject>/gi,
       function (_match, attrs, inner) {
         var id = foreignObjects.length;
+        // mathMl profile: on iOS Mermaid emits math as native MathML
+        // (forceLegacyMathML: false). DOMPurify ignores ALLOWED_TAGS /
+        // ALLOWED_ATTR once USE_PROFILES is set, so extras go via ADD_*.
+        // semantics/annotation are KaTeX's inert TeX-source carriers —
+        // stripping them keeps their text and leaks raw TeX into the label.
         var safeInner = DOMPurify.sanitize(inner, {
-          USE_PROFILES: { html: true },
-          ALLOWED_TAGS: ['div', 'span', 'p', 'br', 'b', 'i', 'em', 'strong'],
-          ALLOWED_ATTR: ['style', 'class', 'xmlns'],
+          USE_PROFILES: { html: true, mathMl: true },
+          ADD_TAGS: ['semantics', 'annotation'],
+          ADD_ATTR: ['xmlns', 'encoding'],
         });
         foreignObjects.push({ attrs: attrs, inner: safeInner, id: id });
         return '<foreignObject data-fo-placeholder="' + id + '"></foreignObject>';
@@ -181,7 +194,9 @@
       htmlLabels: true,
       flowchart: scaledFlowchart(scale),
       securityLevel: 'strict',
-      // iOS Safari: native MathML; other platforms use KaTeX CSS in foreignObject.
+      // iOS WebKit: native MathML — KaTeX HTML inside foreignObject trips the
+      // compositing-layer bug (fragments fly to the SVG origin). Other
+      // platforms keep KaTeX HTML rendering via the KaTeX stylesheet.
       forceLegacyMathML: !ios,
     };
   };

--- a/tests/test_mermaid_ios_plain.py
+++ b/tests/test_mermaid_ios_plain.py
@@ -1,12 +1,16 @@
-"""Tests for iOS plain-label Mermaid math fallback."""
+"""Tests for the iOS Mermaid math strategy (native MathML + plain-text kill-switch)."""
 
 from pathlib import Path
 
 from scripts.adapt_mermaid_blocks import escape_pipes_in_node_labels
 
-# The iOS foreignObject-overlap workaround happens at runtime:
-# prepareMermaidRenderSource() downgrades $$...$$ to Unicode plain text on iOS
-# only. The markdown source must keep KaTeX math so desktop/Android render it.
+# iOS WebKit paints foreignObject content that gets its own compositing layer
+# (opacity, filters, scroll containers, position offsets) at the SVG origin.
+# KaTeX's HTML output relies on position:relative offsets, so Mermaid math on
+# iOS renders as native MathML instead (forceLegacyMathML: false) and the
+# lightbox sanitizer must let MathML through. The old plain-text downgrade
+# (mermaidMathToPlain) stays in the bundle as a kill-switch: flipping
+# shouldUsePlainMermaidMath back to `return isIos();` restores it.
 
 
 def _ppo_full_flowchart_block() -> str:
@@ -21,19 +25,42 @@ def _ppo_full_flowchart_block() -> str:
 
 def test_ppo_full_flowchart_keeps_katex_math_in_source():
     block = _ppo_full_flowchart_block()
-    assert "$$" in block, "完整流程图源码应保留 $$..$$ KaTeX 公式（iOS 降级由前端运行时处理）"
+    assert "$$" in block, "完整流程图源码应保留 $$..$$ KaTeX 公式（iOS 由 Mermaid 渲染为原生 MathML）"
     assert r"\hat{A}_t" in block
     assert r"\pi_{\theta_{old}}" in block
 
 
-def test_ios_runtime_fallback_covers_full_flowchart_formulas():
+def test_ios_mathml_strategy_wired_in_config():
+    config_js = Path("assets/js/mermaid-config.js").read_text(encoding="utf-8")
+    # iOS renders math as native MathML; other platforms keep KaTeX HTML.
+    assert "forceLegacyMathML: !ios" in config_js
+    # The lightbox sanitizer must not strip MathML out of foreignObject.
+    assert "mathMl: true" in config_js
+    assert "'semantics', 'annotation'" in config_js
+
+
+def test_plain_text_kill_switch_retained():
     config_js = Path("assets/js/mermaid-config.js").read_text(encoding="utf-8")
     assert "prepareMermaidRenderSource" in config_js
     assert "shouldUsePlainMermaidMath" in config_js
-    # Plain-text replacements exist for each formula used in the flowchart.
+    # Plain-text replacements for the PPO flowchart formulas stay available.
     assert "mermaidMathToPlain" in config_js
     assert r"\\hat\{A\}_t" in config_js
     assert "L\\^\\{CLIP\\}" in config_js
+
+
+def test_ios_css_does_not_blank_mathml_output():
+    css = Path("assets/css/style.css").read_text(encoding="utf-8")
+    # Regression guard: with output:'mathml' the whole formula lives inside
+    # .katex — hiding it on iOS would blank every Mermaid formula.
+    assert (
+        "html.ios .paper-body .mermaid foreignObject .katex-display,\n"
+        "html.ios .paper-body .mermaid foreignObject .katex {" not in css
+    )
+    # Dual-output safety net: hide the layer-creating HTML half, surface the
+    # MathML copy without absolute positioning.
+    assert "foreignObject .katex-html" in css
+    assert "position: static !important" in css
 
 
 def test_escape_pipes_still_works():


### PR DESCRIPTION
## 背景

此 commit（`085e63c`）在 #260 被合并后才推送到分支，未随 #260 进入 main，本 PR 单独补送。

iPhone（WebKit）上论文笔记页的 Mermaid 流程图公式此前被降级为 Unicode 纯文本（如 `r_t(θ)=π_θ(...)/π_old(...)`）。根因与 #260 的路线图年份错位同源：**WebKit 会把 foreignObject 内自带合成层的内容（opacity、filter、定位偏移、滚动容器）画到 SVG 原点**，而 KaTeX 的 HTML 输出依赖 `position: relative` + `top` 偏移排版上下标和分数，每个片段都会触发该 bug，故旧方案直接弃用了真实公式渲染。

## 方案

MathML 输出是纯标记、零合成层，可整体绕过该 bug。`forceLegacyMathML: !ios` 配置中 MathML 方案其实早已就位，但被三道旧"保险"扼杀，本 PR 逐一拆除：

1. **mermaid-config.js**：`shouldUsePlainMermaidMath()` 改为返回 `false`，`$$..$$` 原样交给 Mermaid 渲染（iOS 上经 KaTeX 输出原生 MathML）。纯文本降级表保留为回退开关，改回 `return isIos()` 即恢复旧行为。
2. **sanitizeMermaidSvg**：DOMPurify 增加 `mathMl` profile 及 `semantics`/`annotation` 白名单。旧配置会把 `<math>` 整棵丢弃（lightbox 高清重渲中公式直接消失）；若缺 annotation 白名单，TeX 源码会泄漏为可见文本。
3. **style.css**：移除 iOS 上 `display: none` 隐藏 `.katex` 的规则（纯 MathML 输出整体位于 `.katex` 内，不删则公式全被藏掉），改为双输出兜底（隐藏 `.katex-html`、将 absolute+clip 的 `.katex-mathml` 副本恢复为静态可见），并取消 iOS 上 `.katex-display` 的滚动容器属性（滚动容器也是合成层）。

非 iOS 平台（桌面 Chrome/Firefox、Android）渲染路径与输出完全不变。

## 验证

- 从 CDN 核对线上 `mermaid@11.4.1` 真实逻辑：iOS 检测 `window.MathMLElement` 后确实走纯 MathML 输出分支；KaTeX 已内置打包（无 CSP / 额外网络加载问题）
- 用与线上同版本 DOMPurify 3.2.4 + jsdom 对仓库内真实 `sanitizeMermaidSvg` 做端到端验证：`<math>/<mfrac>/<msub>/<semantics>/<annotation>` 完整保留、TeX 不泄漏、transform 链不变；并复证旧配置确实会丢弃 `<math>`
- `ruff` 通过；`pytest` 112 项全部通过（含更新后的策略回归测试）

## 截图说明（AGENTS.md 验收要求）

本改动仅影响 iOS WebKit 的渲染路径：容器内无法运行 Safari/WebKit，而 Chromium 渲染前后**有意保持完全一致**，截图无法体现修复本身。请在 iPhone 上验收：打开 [PPO 笔记页](`https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.html)，「训练流程（四步循环）」「第` 2 步 GAE」「完整流程图」三张图中应出现真实的分数线与上下标公式（而非单行纯文本），点击放大后的 lightbox 同样如此。

https://claude.ai/code/session_014YM3gCdtoFSD3Y8p1yJW7U

---
_Generated by [Claude Code](https://claude.ai/code/session_014YM3gCdtoFSD3Y8p1yJW7U)_