### PR TITLE
fix(mermaid): 修复 iPhone 流程图「是/否」边标签背景拉成整图宽条

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -698,6 +698,10 @@ html {
   overflow-y: visible;
   -webkit-overflow-scrolling: touch;
   contain: inline-size;
+  /* iOS 文本自动放大会让 foreignObject 内文字超出 Mermaid 渲染时测量的
+     标签宽度，行尾字符被裁掉（如「并行环境」缺「境」）。 */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 /* Mermaid sometimes injects fixed-width SVGs that can stretch the document
@@ -1184,6 +1188,17 @@ html.ios .paper-body .mermaid foreignObject .katex-display {
     max-width: 100%;
     font-size: 0.95em;
   }
+}
+
+/* iOS WebKit 会把 foreignObject 内的百分比宽度按外层 SVG 视口（而非
+   foreignObject 自身）解析，上方媒体查询的 width: 100% 因此把「是/否」
+   等短边标签的背景拉成横贯整图的宽条。iOS 改用内在尺寸取宽——
+   fit-content 不依赖包含块解析，在解析正确的浏览器上与 100%
+   （= 标签实测宽度）结果一致。 */
+html.ios .paper-body .mermaid foreignObject .nodeLabel > div,
+html.ios .paper-body .mermaid foreignObject .labelBkg,
+html.ios .paper-body .mermaid foreignObject .edgeLabel > div {
+  width: fit-content !important;
 }
 
 /* ===== Paper Nav ===== */

--- a/tests/test_mermaid_ios_plain.py
+++ b/tests/test_mermaid_ios_plain.py
@@ -63,6 +63,16 @@ def test_ios_css_does_not_blank_mathml_output():
     assert "position: static !important" in css
 
 
+def test_ios_edge_label_width_is_intrinsic():
+    css = Path("assets/css/style.css").read_text(encoding="utf-8")
+    # WebKit resolves percentage widths inside foreignObject against the SVG
+    # viewport, so the mobile `width: 100%` rule stretches short edge labels
+    # (是/否) into diagram-wide bars on iOS. Intrinsic sizing avoids the
+    # containing-block resolution entirely.
+    idx = css.index("html.ios .paper-body .mermaid foreignObject .labelBkg")
+    assert "width: fit-content !important" in css[idx : idx + 400]
+
+
 def test_escape_pipes_still_works():
     src = 'R["pi(a|s)"]'
     out = escape_pipes_in_node_labels(src)


### PR DESCRIPTION
## 问题

#261 合并后 iPhone 实测：公式已正常渲染 ✅，但暴露出两个新问题（见 issue 截图）：

1. 流程图判断分支的「是」「否」边标签背景被拉成横贯整图的宽灰条；
2. 个别节点行尾字符被裁掉（如「创建 N=32 个并行环境」缺「境」）。

## 根因与修复

**宽条**：移动端媒体查询对边标签背景 `.labelBkg` 强制 `width: 100% !important`（为了让长标签换行收窄）。但 WebKit 存在另一个 foreignObject 怪癖：**内部 HTML 的百分比宽度按外层 SVG 视口（而非 foreignObject 自身）解析**，于是「否」的背景从约 10px 被撑到接近整图宽。解析正确的浏览器上 100% = foreignObject 宽 = 标签实测宽度，所以桌面端从未显形。

修复：iOS 上（`html.ios`，类由 mermaid-config.js 注入）改用**内在尺寸** `width: fit-content !important` —— 按内容取宽、完全不依赖包含块解析；在健康浏览器上与原 100% 结果一致，行为零变化。

**行尾裁字**：iOS 文本自动放大（text autosizing）会把 foreignObject 内文字放大到超出 Mermaid 渲染时测量好的标签宽度，行尾字符被 `overflow: hidden` 裁掉。对 `.mermaid` 容器局部声明 `text-size-adjust: 100%` 关闭自动放大（仅作用于图表子树，页面其他文字不受影响）。

## 验证

- `ruff` 通过；`pytest` 113 项全部通过（新增 `fit-content` 回归测试）
- 非 iOS 浏览器（桌面 Chrome/Firefox、Android）规则不被 `html.ios` 命中，渲染零变化

## 截图说明（AGENTS.md 验收要求）

两处修复均仅在 iOS WebKit 上有可见效果：容器内无法运行 Safari，Chromium 渲染前后无差异，截图无法体现修复。请在 iPhone 上验收 [PPO 笔记页](`https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.html)「完整流程图」：「是」「否」标签背景应紧贴文字呈小块，「并行环境」应完整显示。`

https://claude.ai/code/session_014YM3gCdtoFSD3Y8p1yJW7U

---
_Generated by [Claude Code](https://claude.ai/code/session_014YM3gCdtoFSD3Y8p1yJW7U)_