### PR TITLE
fix(roadmap): 修复 iOS WebKit 切换中英文后路线图年份消失

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -367,6 +367,17 @@
         });
       };
 
+      function finishRoadmapInsert(mermaidRoadmap) {
+        mermaidRoadmap.removeAttribute('data-processed');
+        window.attachRoadmapNodeLinks(mermaidRoadmap);
+        if (typeof window.patchRoadmapMermaidDom === 'function') {
+          window.patchRoadmapMermaidDom(mermaidRoadmap);
+          requestAnimationFrame(function() {
+            window.patchRoadmapMermaidDom(mermaidRoadmap);
+          });
+        }
+      }
+
       window.renderRoadmapMermaid = function(mode) {
         var mermaidRoadmap = document.getElementById('roadmap-mermaid');
         if (!mermaidRoadmap) return Promise.resolve();
@@ -379,8 +390,7 @@
 
         if (cachedSvg) {
           mermaidRoadmap.innerHTML = cachedSvg;
-          mermaidRoadmap.removeAttribute('data-processed');
-          window.attachRoadmapNodeLinks(mermaidRoadmap);
+          finishRoadmapInsert(mermaidRoadmap);
           return Promise.resolve();
         }
 
@@ -399,8 +409,7 @@
                 : '';
           roadmapSvgCache[cacheKey] = safeSvg;
           mermaidRoadmap.innerHTML = safeSvg;
-          mermaidRoadmap.removeAttribute('data-processed');
-          window.attachRoadmapNodeLinks(mermaidRoadmap);
+          finishRoadmapInsert(mermaidRoadmap);
         }).catch(function() {
           // Keep the previous SVG visible if rendering fails.
         });

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -727,15 +727,15 @@ html {
   cursor: pointer;
 }
 
-/* 年份淡化只能用文字颜色实现，不能用 opacity / filter / transform：
-   这些属性会让 WebKit（iOS Safari）为 foreignObject 内的元素单独建合成层，
-   绘制时丢失祖先 SVG 的 transform，所有年份会堆叠到图表左上角原点。
-   color-mix 不支持时回退为继承色（位置正确，仅不淡化）。 */
+/* 年份淡化只能用不透明文字色实现，不能用 opacity / filter / transform /
+   color-mix(..., transparent) 等会引入 alpha 的属性：WebKit（iOS Safari）
+   会为 foreignObject 内元素单独建合成层，绘制时丢失祖先 SVG 的 transform，
+   年份会堆叠到图表左上角或在中英文切换后 innerHTML 重插时消失。 */
 #roadmap-mermaid .roadmap-node-year,
 .mermaid-lightbox__stage .roadmap-node-year {
   font-size: 0.72em;
   font-weight: 400;
-  color: color-mix(in srgb, currentColor 68%, transparent);
+  color: var(--text-secondary);
   line-height: 1.2;
 }
 

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -95,6 +95,22 @@
     });
   };
 
+  /** After roadmap SVG insert (incl. lang-cache swap), fix iOS foreignObject sizing
+   *  and strip alpha/compositing styles from year labels. */
+  window.patchRoadmapMermaidDom = function (container) {
+    if (!container) return;
+    if (typeof window.patchMermaidForeignObjects === 'function') {
+      window.patchMermaidForeignObjects(container);
+    }
+    if (!isIos()) return;
+    container.querySelectorAll('.roadmap-node-year').forEach(function (el) {
+      el.style.removeProperty('opacity');
+      el.style.removeProperty('filter');
+      el.style.removeProperty('transform');
+      el.style.removeProperty('-webkit-transform');
+    });
+  };
+
   function scaledFlowchart(scale) {
     var mobile = isMobileViewport();
     return {

--- a/tests/test_roadmap_links.py
+++ b/tests/test_roadmap_links.py
@@ -11,6 +11,7 @@ PAPERS_DIR = ROOT / "papers"
 DEFAULT_LAYOUT = ROOT / "_layouts" / "default.html"
 INDEX_HTML = ROOT / "index.html"
 ZOOM_JS = ROOT / "assets" / "js" / "mermaid-zoom.js"
+CONFIG_JS = ROOT / "assets" / "js" / "mermaid-config.js"
 STYLE_CSS = ROOT / "assets" / "css" / "style.css"
 
 
@@ -73,3 +74,20 @@ def test_roadmap_link_styles_present():
     css = STYLE_CSS.read_text(encoding="utf-8")
     assert ".roadmap-node-link" in css
     assert ".mermaid-lightbox__stage svg g.roadmap-node-link" in css
+
+
+def test_roadmap_year_labels_avoid_ios_compositing():
+    css = STYLE_CSS.read_text(encoding="utf-8")
+    assert ".roadmap-node-year" in css
+    assert "color-mix" not in css.split(".roadmap-node-year")[1].split("}")[0]
+    assert "var(--text-secondary)" in css
+    assert "opacity:" not in css.split(".roadmap-node-year")[1].split("}")[0]
+
+
+def test_roadmap_lang_switch_reapplies_ios_patch():
+    layout = DEFAULT_LAYOUT.read_text(encoding="utf-8")
+    config = CONFIG_JS.read_text(encoding="utf-8")
+    assert "finishRoadmapInsert" in layout
+    assert "patchRoadmapMermaidDom" in config
+    assert "requestAnimationFrame" in layout
+    assert "window.patchRoadmapMermaidDom" in layout


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在 iPhone Safari（WebKit）上，主页「推荐学习路线图」首次加载时节点下方的发表年份正常显示；切换中英文后，年份会消失或错位。

根因与此前 #261 中修复的 iOS foreignObject 合成层 bug 同类：`color-mix(..., transparent)` 仍会引入 alpha，WebKit 为 foreignObject 内元素单独建层；中英文切换通过 `innerHTML` 重插 SVG 缓存时，该 bug 再次触发。

## 修复

1. **CSS**：年份标签改用不透明 `var(--text-secondary)`，不再使用 `color-mix(..., transparent)`。
2. **JS**：新增 `patchRoadmapMermaidDom`，在路线图 SVG 插入/缓存命中后：
   - 调用 `patchMermaidForeignObjects` 修正 foreignObject 尺寸（含第二行年份高度）；
   - 在 iOS 上清除年份 span 可能残留的 `opacity` / `filter` / `transform` 内联样式；
   - 通过 `requestAnimationFrame` 在布局稳定后再 patch 一次。

## 验收

iPhone 13 视口（390×844）下切换中英文，31 个 `.roadmap-node-year` 节点均保留。

![修复后：iPhone 视口路线图节点年份可见（390×844）](https://cursor.com/artifacts/c/art-2335ca8a-276d-430c-b5fc-74ef546614b4)

## 测试

- `pytest tests/test_roadmap_links.py` 新增 2 项断言
- Playwright iPhone 13 模拟：初始 / 切中文 / 切回英文，年份计数均为 31

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4d4466c-0b06-485e-bf47-085ed0164d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4d4466c-0b06-485e-bf47-085ed0164d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

