### PR TITLE
Add test job to CI/CD pipeline before build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Ruff (lint)
+        run: ruff check scripts/ tests/
+
+      - name: Pytest
+        run: pytest -v
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
This PR adds a dedicated test job to the GitHub Actions deployment workflow that runs before the build job, ensuring code quality and test coverage are validated before building artifacts.

## Key Changes
- Added a new `test` job that runs on Ubuntu latest
- Configured Python 3.12 environment setup
- Installed development dependencies from `requirements-dev.txt`
- Added Ruff linting checks for `scripts/` and `tests/` directories
- Added Pytest test execution with verbose output
- Updated the `build` job to depend on the `test` job completing successfully

## Implementation Details
The test job is configured to run before the build job using the `needs: test` dependency, ensuring that:
- Code passes linting checks (Ruff)
- All tests pass (Pytest)
- Build only proceeds if tests succeed

This improves CI/CD reliability by catching issues early in the pipeline.

https://claude.ai/code/session_019G2U7w3opLofVqRV1iP6Q6