### PR TITLE
feat(UI): 添加赞助按钮与微信收款二维码弹窗

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,7 @@
       <button id="lang-toggle" class="lang-toggle" aria-label="Switch language">
         <span class="lang-label">中文</span>
       </button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">☀️</button>
       <button
         id="sponsor-toggle"
         class="sponsor-toggle"
@@ -16,7 +17,6 @@
         aria-haspopup="dialog"
         aria-controls="sponsor-dialog"
         title="Support me">❤️</button>
-      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">☀️</button>
     </div>
   </div>
 </header>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

参考 [Robot_Retarget_Online](https://github.com/ImChong/Robot_Retarget_Online)，为本站页头添加爱心赞助按钮；点击后弹出微信收款二维码对话框，二维码图像与参考项目相同（`wechat-pay.png`）。

## 变更内容

- 页头 `header-right` 区域新增 ❤️ 赞助按钮
- 按钮顺序：**GitHub → 中英文 → 白天/黑夜 → 赞助**（赞助按钮在最右侧）
- 新增 `_includes/sponsor-dialog.html` 弹窗（标题、提示文案、二维码、关闭按钮）
- 新增 `assets/sponsor/wechat-pay.png`（与 Robot_Retarget_Online 同源）
- 样式与交互：爱心按钮高亮、弹窗遮罩、Esc / 点击遮罩关闭
- 中英文切换：标题、提示、关闭按钮、二维码 `alt` 随站点语言切换
- 赞助按钮宽高与白天/黑夜切换按钮完全一致

## 验收截图

![页头按钮顺序：GitHub · 语言 · 主题 · 赞助](https://cursor.com/artifacts/c/art-80f3e360-1d12-4822-9b7f-f6f687dab67e)

![赞助弹窗（微信收款码）](https://cursor.com/artifacts/c/art-291bb4be-59b2-4902-85f7-17a2df70d295)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27526dad-d02d-4e45-b160-77cdabff40f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27526dad-d02d-4e45-b160-77cdabff40f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

