### PR TITLE
feat(UI): 赞助按钮改用 ☕，文案与 Robotics_Notebooks 一致

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,12 +11,12 @@
         id="sponsor-toggle"
         class="sponsor-toggle"
         type="button"
-        data-en-aria-label="Buy me a coffee"
-        data-zh-aria-label="请我喝杯咖啡"
-        aria-label="Buy me a coffee"
+        data-en-aria-label="Support me"
+        data-zh-aria-label="赞助我"
+        aria-label="Support me"
         aria-haspopup="dialog"
         aria-controls="sponsor-dialog"
-        title="Buy me a coffee"><span class="sponsor-icon" aria-hidden="true">☕</span></button>
+        title="Support me"><span class="sponsor-icon" aria-hidden="true">☕</span></button>
     </div>
   </div>
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,12 +11,12 @@
         id="sponsor-toggle"
         class="sponsor-toggle"
         type="button"
-        data-en-aria-label="Support me"
-        data-zh-aria-label="赞助我"
-        aria-label="Support me"
+        data-en-aria-label="Buy me a coffee"
+        data-zh-aria-label="请我喝杯咖啡"
+        aria-label="Buy me a coffee"
         aria-haspopup="dialog"
         aria-controls="sponsor-dialog"
-        title="Support me"><span class="sponsor-icon" aria-hidden="true">❤</span></button>
+        title="Buy me a coffee"><span class="sponsor-icon" aria-hidden="true">☕</span></button>
     </div>
   </div>
 </header>

--- a/_includes/sponsor-dialog.html
+++ b/_includes/sponsor-dialog.html
@@ -1,8 +1,8 @@
 <div id="sponsor-dialog" class="sponsor-dialog" role="dialog" aria-modal="true" aria-labelledby="sponsor-title" hidden>
   <div class="sponsor-dialog__backdrop" data-sponsor-close></div>
   <div class="sponsor-dialog__panel">
-    <h2 id="sponsor-title" class="sponsor-dialog__title" data-en="Support me" data-zh="赞助我">Support me</h2>
-    <p class="sponsor-dialog__hint" data-en="Scan with WeChat to support the author ❤" data-zh="微信扫一扫，赞助支持作者 ❤">Scan with WeChat to support the author ❤</p>
+    <h2 id="sponsor-title" class="sponsor-dialog__title" data-en="Buy me a coffee" data-zh="请我喝杯咖啡">Buy me a coffee</h2>
+    <p class="sponsor-dialog__hint" data-en="Scan with WeChat to buy me a coffee ☕" data-zh="微信扫一扫，请我喝杯咖啡 ☕">Scan with WeChat to buy me a coffee ☕</p>
     <img
       id="sponsor-qr"
       class="sponsor-dialog__qr"

--- a/_includes/sponsor-dialog.html
+++ b/_includes/sponsor-dialog.html
@@ -1,8 +1,8 @@
 <div id="sponsor-dialog" class="sponsor-dialog" role="dialog" aria-modal="true" aria-labelledby="sponsor-title" hidden>
   <div class="sponsor-dialog__backdrop" data-sponsor-close></div>
   <div class="sponsor-dialog__panel">
-    <h2 id="sponsor-title" class="sponsor-dialog__title" data-en="Buy me a coffee" data-zh="请我喝杯咖啡">Buy me a coffee</h2>
-    <p class="sponsor-dialog__hint" data-en="Scan with WeChat to buy me a coffee ☕" data-zh="微信扫一扫，请我喝杯咖啡 ☕">Scan with WeChat to buy me a coffee ☕</p>
+    <h2 id="sponsor-title" class="sponsor-dialog__title" data-en="Support me" data-zh="赞助我">Support me</h2>
+    <p class="sponsor-dialog__hint" data-en="Scan with WeChat to support the author ☕" data-zh="微信扫一扫，赞助支持作者 ☕">Scan with WeChat to support the author ☕</p>
     <img
       id="sponsor-qr"
       class="sponsor-dialog__qr"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

赞助入口图标改为 ☕，文案与 [Robotics_Notebooks](https://imchong.github.io/Robotics_Notebooks/) 保持一致：

| 位置 | 英文 | 中文 |
|------|------|------|
| 顶栏按钮图标 | ☕ | ☕ |
| 按钮 `aria-label` / `title` | Support me | 赞助我 |
| 弹窗标题 | Support me | 赞助我 |
| 弹窗提示 | Scan with WeChat to support the author ☕ | 微信扫一扫，赞助支持作者 ☕ |

## 修改文件

- `_includes/header.html` — 按钮图标与无障碍文案
- `_includes/sponsor-dialog.html` — 弹窗标题与提示文案

## 验收截图

![修复后：顶栏赞助咖啡按钮](https://cursor.com/artifacts/c/art-6d40c57b-61f6-4ce9-8da3-be0aae405f4a)

![修复后：赞助弹窗英文文案](https://cursor.com/artifacts/c/art-f1763579-c817-477b-ae62-044b8f2ffa5b)

![修复后：赞助弹窗中文文案](https://cursor.com/artifacts/c/art-ddedc5e6-89d4-47e0-b552-eef1e2b3124d)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee00eba8-b49c-45ac-9db1-307a755e52d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee00eba8-b49c-45ac-9db1-307a755e52d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

