### PR TITLE
style(Sponsor): 赞助浮窗遮罩增加半透明模糊效果

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1356,6 +1356,8 @@ body.sponsor-dialog-open {
   position: absolute;
   inset: 0;
   background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .sponsor-dialog__panel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

参考 [Robotics Notebooks](https://imchong.github.io/Robotics_Notebooks/) 的赞助浮窗样式，为遮罩层 `.sponsor-dialog__backdrop` 增加 `backdrop-filter: blur(4px)` 与 `-webkit-backdrop-filter`，使浮窗外的页面内容呈现半透明模糊效果，与参考站点一致。

## 验收截图

![修复后：赞助浮窗遮罩半透明模糊（1280×800）](https://cursor.com/artifacts/c/art-0441e000-e17e-4d28-b230-dd4750bfb8a1)

## 测试

- 本地 `bundle exec jekyll serve` 打开首页，点击 ☕ 按钮验证遮罩模糊效果
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-685d8314-435e-45b7-9225-94b0f1ada715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-685d8314-435e-45b7-9225-94b0f1ada715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

