### PR TITLE
fix(UI): 视口不足 1440px 时 TOC 改用抽屉避免左侧裁切

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -521,7 +521,44 @@ html {
   opacity: 1;
 }
 
-/* Show TOC only on wide screens */
+/* Sticky left TOC needs ~1440px viewport (960px container + 24px padding +
+   260px negative margin). Below that, use the drawer to avoid left-edge clipping. */
+@media (max-width: 1439px) {
+  .toc-sidebar {
+    position: fixed;
+    /* Match Robotics_Notebooks mobile drawer: gap below viewport top / notch */
+    top: calc(16px + env(safe-area-inset-top, 0px));
+    /* Stop above the floating sidebar toggle (24px + 48px) with breathing room */
+    bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
+    left: -280px;
+    width: 260px;
+    height: auto;
+    max-height: none;
+    background: var(--bg);
+    margin: 0;
+    padding: 20px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    box-shadow: 2px 0 12px rgba(0,0,0,0.15);
+    border-radius: 0 16px 16px 0;
+    z-index: 1300;
+    transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    display: block;
+    margin-left: 0;
+    float: none;
+  }
+  .toc-sidebar.open {
+    left: 0;
+  }
+  .sidebar-toggle {
+    display: flex;
+    z-index: 1350;
+  }
+  .sidebar-overlay {
+    z-index: 1250;
+  }
+}
+
 @media (max-width: 1200px) {
   html,
   body {
@@ -543,39 +580,6 @@ html {
     box-sizing: border-box;
     overflow-x: hidden;
     overflow-x: clip;
-  }
-
-  .toc-sidebar {
-    position: fixed;
-    /* Match Robotics_Notebooks mobile drawer: gap below viewport top / notch */
-    top: calc(16px + env(safe-area-inset-top, 0px));
-    /* Stop above the floating sidebar toggle (24px + 48px) with breathing room */
-    bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
-    left: -280px;
-    width: 260px;
-    height: auto;
-    max-height: none;
-    background: var(--bg);
-    margin: 0;
-    padding: 20px;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    box-shadow: 2px 0 12px rgba(0,0,0,0.15);
-    border-radius: 0 16px 16px 0;
-    z-index: 1300;
-    transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    display: block; /* Overriding previous display: none */
-    margin-left: 0;
-  }
-  .toc-sidebar.open {
-    left: 0;
-  }
-  .sidebar-toggle {
-    display: flex;
-    z-index: 1350;
-  }
-  .sidebar-overlay {
-    z-index: 1250;
   }
 }
 
@@ -604,9 +608,9 @@ html {
   overflow-y: auto;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1439px) {
   .index-layout .toc-sidebar {
-    /* Mirror subpage mobile drawer; desktop float/height must not leak here */
+    /* Mirror subpage drawer; desktop float/height must not leak here */
     float: none;
     position: fixed;
     top: calc(16px + env(safe-area-inset-top, 0px));

--- a/assets/js/paper.js
+++ b/assets/js/paper.js
@@ -133,7 +133,8 @@
     var headingArr = Array.from(headings);
     var sidebar = document.getElementById('toc-sidebar');
     var overlay = document.getElementById('sidebar-overlay');
-    var mobileQuery = window.matchMedia('(max-width: 1200px)');
+    /* Keep in sync with style.css TOC drawer breakpoint (sticky sidebar clips below 1440px). */
+    var mobileQuery = window.matchMedia('(max-width: 1439px)');
 
     function closeMobileSidebar() {
       if (sidebar) sidebar.classList.remove('open');

--- a/tests/test_mobile_sidebar_fab_css.py
+++ b/tests/test_mobile_sidebar_fab_css.py
@@ -7,7 +7,7 @@ STYLE = Path(__file__).resolve().parents[1] / "assets" / "css" / "style.css"
 
 def _mobile_toc_block() -> str:
     text = STYLE.read_text(encoding="utf-8")
-    marker = "/* Show TOC only on wide screens */"
+    marker = "/* Sticky left TOC needs ~1440px viewport"
     start = text.index(marker)
     end = text.index("/* Wider container for paper pages", start)
     return text[start:end]
@@ -18,6 +18,7 @@ MOBILE_DRAWER_TOP = "top: calc(16px + env(safe-area-inset-top, 0px))"
 
 def test_mobile_toc_sidebar_clears_floating_toggle():
     block = _mobile_toc_block()
+    assert "@media (max-width: 1439px)" in block
     assert MOBILE_DRAWER_TOP in block
     assert "bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px))" in block
     assert "height: auto" in block
@@ -27,7 +28,7 @@ def test_mobile_toc_sidebar_clears_floating_toggle():
 
 def test_index_mobile_toc_sidebar_matches_subpage_drawer():
     text = STYLE.read_text(encoding="utf-8")
-    start = text.index("@media (max-width: 1200px) {\n  .index-layout .toc-sidebar")
+    start = text.index("@media (max-width: 1439px) {\n  .index-layout .toc-sidebar")
     end = text.index("/* ===== Search Box ===== */", start)
     block = text[start:end]
     assert "float: none" in block


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

桌面端 TOC 通过 `margin-left: -260px` 挂在 960px 主栏左侧。当浏览器窗口宽度在约 **1201px～1439px**（新窗口默认尺寸常落在此区间）时，TOC 左侧会被视口裁切，只能看到一半。

## 修复

将 TOC **抽屉模式**断点从 `1200px` 提升至 **`1439px`**：

- **≥ 1440px**：保持原有 sticky 侧栏 TOC（此时负边距不会超出视口左缘）
- **≤ 1439px**：改用抽屉 + 左下角 FAB，与移动端行为一致
- `paper.js` 中 `matchMedia` 同步更新，确保点击目录链接后自动关闭抽屉

移动端布局（`overflow-x: clip`、单列排版等）仍保留在 `1200px` 断点，仅 TOC 展示方式单独扩展。

## 验收截图

**1300px（修复前会裁切，修复后为抽屉）：**

![1300px 抽屉关闭：无裁切，显示 FAB](https://cursor.com/artifacts/c/art-1a37350a-f427-49a3-98dc-58a8538524f3)

![1300px 抽屉打开：完整目录](https://cursor.com/artifacts/c/art-5496525e-fe0b-4d6a-b76d-924fe7fef09b)

**1500px（仍使用 sticky 侧栏）：**

![1500px sticky TOC 完整显示](https://cursor.com/artifacts/c/art-bbcaf244-b50b-4a9f-8ce7-978626c223b7)

## 测试

- `pytest -v tests/test_mobile_sidebar_fab_css.py` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3821ff9-17d4-4d67-90cb-8f11c780511a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3821ff9-17d4-4d67-90cb-8f11c780511a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

