### PR TITLE
fix(Home): 移动端折叠按钮移至列表底部

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -305,15 +305,12 @@ html {
   margin-bottom: 0.4rem;
 }
 
-.paper-list-toggle-item {
-  list-style: none;
-  margin: 0.2rem 0 0.6rem;
-}
-
 .paper-list-toggle-btn {
   display: block;
   width: 100%;
-  padding: 0.55rem 1rem;
+  min-height: 44px;
+  margin: 0.2rem 0 0.6rem;
+  padding: 0.65rem 1rem;
   font-family: 'Arial', 'Helvetica Neue', sans-serif;
   font-size: 0.88rem;
   color: var(--link);
@@ -322,6 +319,8 @@ html {
   border-radius: 6px;
   cursor: pointer;
   text-align: center;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .paper-list-toggle-btn:hover {
@@ -661,6 +660,11 @@ html {
   }
   .index-layout .toc-sidebar.open {
     left: 0;
+  }
+
+  /* Keep fold toggles above the floating sidebar FAB on narrow viewports. */
+  .index-main {
+    padding-bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -328,7 +328,11 @@ html {
   color: var(--bg);
 }
 
-.paper-list.is-folded:not(.search-expanded) .paper-list-item-folded {
+.paper-list.is-folded .paper-list-item-folded {
+  display: none;
+}
+
+body.index-search-active .paper-list-toggle-btn {
   display: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -253,90 +253,209 @@ title: "Home"
   var roadmapTocItem = document.querySelector('.toc-item[data-toc-for="roadmap-title"]');
 
   var searchTimeout;
-  // ⚡ Bolt Optimization: Debounce search input to prevent rapid DOM updates on every keystroke
-  var foldedLists = document.querySelectorAll('.paper-list.has-paper-fold');
+  var FOLD_PREFIX = 'paper-fold:';
+  var foldLists = Array.from(document.querySelectorAll('.paper-list.has-paper-fold[data-fold-id]'));
+  var foldStateBeforeSearch = null;
 
-  searchInput.addEventListener('input', function() {
-    clearTimeout(searchTimeout);
-    searchTimeout = setTimeout(function() {
-      var query = searchInput.value.toLowerCase().trim();
-      var hasAnyMatch = false;
-      var isSearching = query !== '';
+  function getLang() {
+    return document.documentElement.getAttribute('data-lang-mode') === 'zh' ? 'zh' : 'en';
+  }
 
-      foldedLists.forEach(function(list) {
-        if (isSearching) {
-          list.classList.add('search-expanded');
-        } else {
-          list.classList.remove('search-expanded');
-        }
+  function updateToggleLabel(btn, expanded) {
+    var useZh = getLang() === 'zh';
+    if (expanded) {
+      btn.textContent = useZh ? btn.getAttribute('data-zh-expanded') : btn.getAttribute('data-en-expanded');
+    } else {
+      btn.textContent = useZh ? btn.getAttribute('data-zh') : btn.getAttribute('data-en');
+    }
+  }
+
+  function setFoldState(list, expanded, persist) {
+    var foldId = list.getAttribute('data-fold-id');
+    var btn = document.querySelector('.paper-list-toggle-btn[data-fold-id="' + foldId + '"]');
+    if (expanded) {
+      list.classList.remove('is-folded');
+    } else {
+      list.classList.add('is-folded');
+    }
+    if (btn) {
+      btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      updateToggleLabel(btn, expanded);
+    }
+    if (persist && foldId) {
+      try {
+        localStorage.setItem(FOLD_PREFIX + foldId, expanded ? 'true' : 'false');
+      } catch (e) {}
+    }
+  }
+
+  foldLists.forEach(function(list) {
+    var foldId = list.getAttribute('data-fold-id');
+    var btn = document.querySelector('.paper-list-toggle-btn[data-fold-id="' + foldId + '"]');
+    if (!btn) return;
+
+    var saved = null;
+    try {
+      saved = localStorage.getItem(FOLD_PREFIX + foldId);
+    } catch (e) {}
+    if (saved === 'true') {
+      setFoldState(list, true, false);
+    } else {
+      updateToggleLabel(btn, false);
+    }
+
+    btn.addEventListener('click', function() {
+      var expanded = list.classList.contains('is-folded');
+      setFoldState(list, expanded, true);
+    });
+  });
+
+  document.addEventListener('cl-lang-changed', function() {
+    document.querySelectorAll('.paper-list-toggle-btn[data-fold-id]').forEach(function(btn) {
+      var expanded = btn.getAttribute('aria-expanded') === 'true';
+      updateToggleLabel(btn, expanded);
+    });
+  });
+
+  function setSearchFoldMode(active) {
+    if (active) {
+      if (foldStateBeforeSearch) return;
+      foldStateBeforeSearch = new Map();
+      foldLists.forEach(function(list) {
+        var id = list.getAttribute('data-fold-id');
+        foldStateBeforeSearch.set(id, list.classList.contains('is-folded'));
+        list.classList.remove('is-folded');
       });
-
-      if (roadmapTocItem) {
-        roadmapTocItem.style.display = query === '' ? '' : 'none';
+      document.body.classList.add('index-search-active');
+      return;
+    }
+    if (!foldStateBeforeSearch) return;
+    foldLists.forEach(function(list) {
+      var id = list.getAttribute('data-fold-id');
+      if (foldStateBeforeSearch.get(id)) {
+        list.classList.add('is-folded');
+      } else {
+        list.classList.remove('is-folded');
       }
+    });
+    foldStateBeforeSearch = null;
+    document.body.classList.remove('index-search-active');
+  }
 
-      cachedCategories.forEach(function(catCache) {
-        var catHasMatch = false;
-        var catTotalMatch = 0;
+  function resetAllItemDisplays() {
+    cachedCategories.forEach(function(catCache) {
+      catCache.subcategories.forEach(function(subcatCache) {
+        subcatCache.items.forEach(function(itemCache) {
+          itemCache.el.style.removeProperty('display');
+        });
+        subcatCache.el.style.removeProperty('display');
+      });
+      catCache.directItems.forEach(function(itemCache) {
+        itemCache.el.style.removeProperty('display');
+      });
+      catCache.el.style.removeProperty('display');
+    });
+  }
 
-        catCache.subcategories.forEach(function(subcatCache) {
-          var subcatHasMatch = false;
-          var subcatMatchCount = 0;
-          
-          subcatCache.items.forEach(function(itemCache) {
-            if (itemCache.text.indexOf(query) !== -1) {
-              if (itemCache.el.style.display !== '') itemCache.el.style.display = '';
+  function runSearch() {
+    if (!searchInput) return;
+    var query = searchInput.value.toLowerCase().trim();
+    var hasAnyMatch = false;
+    var isSearching = query !== '';
+
+    setSearchFoldMode(isSearching);
+
+    if (!isSearching) {
+      resetAllItemDisplays();
+    }
+
+    if (roadmapTocItem) {
+      roadmapTocItem.style.display = query === '' ? '' : 'none';
+    }
+
+    cachedCategories.forEach(function(catCache) {
+      var catHasMatch = false;
+      var catTotalMatch = 0;
+
+      catCache.subcategories.forEach(function(subcatCache) {
+        var subcatHasMatch = false;
+        var subcatMatchCount = 0;
+
+        subcatCache.items.forEach(function(itemCache) {
+          if (!isSearching || itemCache.text.indexOf(query) !== -1) {
+            itemCache.el.style.removeProperty('display');
+            if (isSearching) {
               subcatHasMatch = true;
               subcatMatchCount++;
               catHasMatch = true;
               hasAnyMatch = true;
-            } else {
-              if (itemCache.el.style.display !== 'none') itemCache.el.style.display = 'none';
             }
-          });
-          
-          var targetSubcatDisplay = subcatHasMatch || query === '' ? '' : 'none';
-          if (subcatCache.el.style.display !== targetSubcatDisplay) subcatCache.el.style.display = targetSubcatDisplay;
-          if (subcatCache.tocItem) {
-            if (subcatCache.tocItem.style.display !== targetSubcatDisplay) subcatCache.tocItem.style.display = targetSubcatDisplay;
+          } else {
+            itemCache.el.style.display = 'none';
+          }
+        });
+
+        var targetSubcatDisplay = subcatHasMatch || query === '' ? '' : 'none';
+        if (subcatCache.el.style.display !== targetSubcatDisplay) subcatCache.el.style.display = targetSubcatDisplay;
+        if (subcatCache.tocItem) {
+          if (subcatCache.tocItem.style.display !== targetSubcatDisplay) subcatCache.tocItem.style.display = targetSubcatDisplay;
+          if (isSearching) {
             var countEl = subcatCache.tocItem.querySelector('.toc-count');
             if (countEl) {
               var targetText = '(' + subcatMatchCount + ')';
               if (countEl.textContent !== targetText) countEl.textContent = targetText;
             }
           }
-          catTotalMatch += subcatMatchCount;
-        });
+        }
+        if (isSearching) catTotalMatch += subcatMatchCount;
+      });
 
-        var directMatchCount = 0;
-        catCache.directItems.forEach(function(itemCache) {
-          if (itemCache.text.indexOf(query) !== -1) {
-            if (itemCache.el.style.display !== '') itemCache.el.style.display = '';
+      var directMatchCount = 0;
+      catCache.directItems.forEach(function(itemCache) {
+        if (!isSearching || itemCache.text.indexOf(query) !== -1) {
+          itemCache.el.style.removeProperty('display');
+          if (isSearching) {
             catHasMatch = true;
             hasAnyMatch = true;
             directMatchCount++;
-          } else {
-            if (itemCache.el.style.display !== 'none') itemCache.el.style.display = 'none';
           }
-        });
-        catTotalMatch += directMatchCount;
+        } else {
+          itemCache.el.style.display = 'none';
+        }
+      });
+      if (isSearching) catTotalMatch += directMatchCount;
 
-        var targetCatDisplay = catHasMatch || query === '' ? '' : 'none';
-        if (catCache.el.style.display !== targetCatDisplay) catCache.el.style.display = targetCatDisplay;
-        if (catCache.tocItem) {
-          if (catCache.tocItem.style.display !== targetCatDisplay) catCache.tocItem.style.display = targetCatDisplay;
+      var targetCatDisplay = catHasMatch || query === '' ? '' : 'none';
+      if (catCache.el.style.display !== targetCatDisplay) catCache.el.style.display = targetCatDisplay;
+      if (catCache.tocItem) {
+        if (catCache.tocItem.style.display !== targetCatDisplay) catCache.tocItem.style.display = targetCatDisplay;
+        if (isSearching) {
           var countEl = catCache.tocItem.querySelector('.toc-count');
           if (countEl) {
             var targetText = '(' + catTotalMatch + ')';
             if (countEl.textContent !== targetText) countEl.textContent = targetText;
           }
         }
-      });
+      }
+    });
 
+    if (noResults) {
       var targetNoResultsDisplay = hasAnyMatch || query === '' ? 'none' : 'block';
       if (noResults.style.display !== targetNoResultsDisplay) noResults.style.display = targetNoResultsDisplay;
-    }, 150);
-  });
+    }
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', function(e) {
+      if (e.isComposing) return;
+      clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(runSearch, 150);
+    });
+    searchInput.addEventListener('compositionend', function() {
+      clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(runSearch, 0);
+    });
+  }
 
   var sidebar = document.getElementById('toc-sidebar');
   if (!sidebar) return;
@@ -407,70 +526,5 @@ title: "Home"
     }
   });
   updateActive();
-})();
-
-(function() {
-  var FOLD_PREFIX = 'paper-fold:';
-  var lists = document.querySelectorAll('.paper-list.has-paper-fold[data-fold-id]');
-
-  function getLang() {
-    return document.documentElement.getAttribute('data-lang-mode') === 'zh' ? 'zh' : 'en';
-  }
-
-  function updateToggleLabel(btn, expanded) {
-    var useZh = getLang() === 'zh';
-    if (expanded) {
-      btn.textContent = useZh ? btn.getAttribute('data-zh-expanded') : btn.getAttribute('data-en-expanded');
-    } else {
-      btn.textContent = useZh ? btn.getAttribute('data-zh') : btn.getAttribute('data-en');
-    }
-  }
-
-  function setFoldState(list, expanded, persist) {
-    var foldId = list.getAttribute('data-fold-id');
-    var btn = document.querySelector('.paper-list-toggle-btn[data-fold-id="' + foldId + '"]');
-    if (expanded) {
-      list.classList.remove('is-folded');
-    } else {
-      list.classList.add('is-folded');
-    }
-    if (btn) {
-      btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-      updateToggleLabel(btn, expanded);
-    }
-    if (persist && foldId) {
-      try {
-        localStorage.setItem(FOLD_PREFIX + foldId, expanded ? 'true' : 'false');
-      } catch (e) {}
-    }
-  }
-
-  lists.forEach(function(list) {
-    var foldId = list.getAttribute('data-fold-id');
-    var btn = document.querySelector('.paper-list-toggle-btn[data-fold-id="' + foldId + '"]');
-    if (!btn) return;
-
-    var saved = null;
-    try {
-      saved = localStorage.getItem(FOLD_PREFIX + foldId);
-    } catch (e) {}
-    if (saved === 'true') {
-      setFoldState(list, true, false);
-    } else {
-      updateToggleLabel(btn, false);
-    }
-
-    btn.addEventListener('click', function() {
-      var expanded = list.classList.contains('is-folded');
-      setFoldState(list, expanded, true);
-    });
-  });
-
-  document.addEventListener('cl-lang-changed', function() {
-    document.querySelectorAll('.paper-list-toggle-btn[data-fold-id]').forEach(function(btn) {
-      var expanded = btn.getAttribute('aria-expanded') === 'true';
-      updateToggleLabel(btn, expanded);
-    });
-  });
 })();
 </script>

--- a/index.html
+++ b/index.html
@@ -160,20 +160,18 @@ title: "Home"
       {% endunless %}
       <ul class="paper-list{% if should_fold %} has-paper-fold is-folded{% endif %}"{% if should_fold %} data-fold-id="cat-{{ forloop.index }}-papers"{% endif %}>
         {% for paper in cat_data.papers %}
-        {% if should_fold and forloop.index == 11 %}
-        <li class="paper-list-toggle-item" aria-hidden="true">
-          <button type="button" class="paper-list-toggle-btn" data-fold-id="cat-{{ forloop.parentloop.index }}-papers" aria-expanded="false"
-            data-en="Show {{ fold_hidden }} older notes ▾"
-            data-zh="展开其余 {{ fold_hidden }} 篇笔记 ▾"
-            data-en-expanded="Hide older notes ▴"
-            data-zh-expanded="收起较早笔记 ▴">Show {{ fold_hidden }} older notes ▾</button>
-        </li>
-        {% endif %}
         <li{% if should_fold and forloop.index > fold_limit %} class="paper-list-item-folded"{% endif %} data-search="{{ paper.title | escape }} {{ paper.zhname | escape }} {{ paper.arxiv | escape }}">
           {% include paper-card.html paper=paper %}
         </li>
         {% endfor %}
       </ul>
+      {% if should_fold %}
+      <button type="button" class="paper-list-toggle-btn" data-fold-id="cat-{{ forloop.index }}-papers" aria-expanded="false"
+        data-en="Show {{ fold_hidden }} older notes ▾"
+        data-zh="展开其余 {{ fold_hidden }} 篇笔记 ▾"
+        data-en-expanded="Hide older notes ▴"
+        data-zh-expanded="收起较早笔记 ▴">Show {{ fold_hidden }} older notes ▾</button>
+      {% endif %}
       {% else %}
       <p class="empty-hint" data-en="No notes yet, stay tuned..." data-zh="暂无笔记，敬请期待...">No notes yet, stay tuned...</p>
       {% endif %}

--- a/tests/test_index_paper_fold.py
+++ b/tests/test_index_paper_fold.py
@@ -23,7 +23,15 @@ def test_index_fold_search_expansion_hook():
     assert "has-paper-fold" in text
 
 
+def test_index_fold_toggle_follows_paper_list():
+    text = INDEX.read_text(encoding="utf-8")
+    assert "</ul>\n      {% if should_fold %}\n      <button type=\"button\" class=\"paper-list-toggle-btn\"" in text
+    assert "paper-list-toggle-item" not in text
+
+
 def test_style_hides_folded_items_when_collapsed():
     css = STYLE.read_text(encoding="utf-8")
     assert ".paper-list.is-folded:not(.search-expanded) .paper-list-item-folded" in css
     assert ".paper-list-toggle-btn" in css
+    assert "min-height: 44px" in css
+    assert ".index-main" in css

--- a/tests/test_index_paper_fold.py
+++ b/tests/test_index_paper_fold.py
@@ -17,10 +17,14 @@ def test_index_declares_fold_exempt_categories():
     assert "paper-list-toggle-btn" in text
 
 
-def test_index_fold_search_expansion_hook():
+def test_index_search_unfolds_folded_lists():
     text = INDEX.read_text(encoding="utf-8")
-    assert "search-expanded" in text
-    assert "has-paper-fold" in text
+    assert "setSearchFoldMode" in text
+    assert "index-search-active" in text
+    assert "foldStateBeforeSearch" in text
+    assert "resetAllItemDisplays" in text
+    assert "compositionend" in text
+    assert "search-expanded" not in text
 
 
 def test_index_fold_toggle_follows_paper_list():
@@ -31,7 +35,8 @@ def test_index_fold_toggle_follows_paper_list():
 
 def test_style_hides_folded_items_when_collapsed():
     css = STYLE.read_text(encoding="utf-8")
-    assert ".paper-list.is-folded:not(.search-expanded) .paper-list-item-folded" in css
+    assert ".paper-list.is-folded .paper-list-item-folded" in css
+    assert "body.index-search-active .paper-list-toggle-btn" in css
     assert ".paper-list-toggle-btn" in css
     assert "min-height: 44px" in css
     assert ".index-main" in css


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

本 PR 包含两项首页折叠相关修复：

### 1. 移动端折叠按钮位置（#301 原内容）

展开/收起按钮移至列表底部，避免移动端展开后需滚回中部才能收起。

### 2. 搜索可命中折叠中的笔记

**问题**：仅靠 CSS `search-expanded` 绕过折叠，在部分场景下（inline `display` 与折叠态叠加）可能漏检折叠中的论文。

**修复**：
- 搜索开始时：`setSearchFoldMode(true)` 临时移除 `is-folded`，展开全部候选条目
- 搜索过滤：对不匹配项设置 `display: none`，匹配项 `removeProperty('display')`
- 清空搜索：恢复折叠状态 + `resetAllItemDisplays()` 清除 inline 样式
- 搜索期间隐藏折叠按钮（`body.index-search-active`）
- 支持中文输入法 `compositionend` 后再触发搜索

## 受影响模块

Loco-Manipulation (35)、Manipulation (11)、Locomotion (11) 等超过 10 篇且启用折叠的分类。

## 验收截图（390×844 · 折叠按钮位置）

![移动端折叠态：按钮在 10 篇笔记底部](https://cursor.com/artifacts/c/art-41a62399-dc9a-4e5f-a680-4d0bf15a364d)

![移动端展开态：收起按钮在全部笔记底部](https://cursor.com/artifacts/c/art-8fc04b50-df6d-48ff-9525-530b947eadb6)

搜索行为变更：折叠列表在输入关键词时临时展开，清空后恢复；无额外静态 UI 变化，已在 Playwright 中验证 `MeshMimic` / `HERO` / 中文关键词可命中折叠条目。

## 测试

- `pytest tests/test_index_paper_fold.py -v`
- `ruff check tests/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-154274c3-36c8-4740-ba96-ffc40cf2b0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-154274c3-36c8-4740-ba96-ffc40cf2b0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

