### PR TITLE
docs(Locomotion): 为 GDAF 论文笔记补充官方源码链接

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1222,6 +1222,7 @@
         "url": "/papers/05_Locomotion/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits.html",
         "dir": "Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits",
         "arxiv": "2602.21666",
+        "has_open_source": true,
         "published_date_zh": "2026年2月25日（arXiv）",
         "published_date_en": "Feb 25, 2026 (arXiv)",
         "zhname": "用生物力学定量度量人形步态：GDAF 框架与 28 速 G1 数据集",

--- a/papers/05_Locomotion/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits.md
+++ b/papers/05_Locomotion/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits.md
@@ -24,9 +24,9 @@ category: "Locomotion"
 | arXiv | [2602.21666](https://arxiv.org/abs/2602.21666) |
 | HTML | [在线阅读](https://arxiv.org/html/2602.21666v1) |
 | PDF | [下载](https://arxiv.org/pdf/2602.21666) |
-| 项目主页 | 暂未明确单独主页（数据集与代码随论文释出） |
+| 项目主页 | [fengluying/GDAF](https://github.com/fengluying/GDAF)（作者仓库，代码随论文录用后释出） |
 | **发布时间** | 2026-02-25 (arXiv) |
-| 源码 | 含 MuJoCo 可视化 + 两个 Jupyter Notebook（`GDAF_01_Data_Visualization.ipynb` / `GDAF_02_Divergence_Analysis.ipynb`），随论文释出 |
+| 源码 | [fengluying/GDAF](https://github.com/fengluying/GDAF)（MuJoCo 可视化 `mujoco_gait_player.py` + `GDAF_01_Data_Visualization.ipynb` / `GDAF_02_Divergence_Analysis.ipynb`） |
 | 数据集 | 28 速 Unitree G1 步态轨迹（关节位置 / 力矩 / 功率），与人类步态配对，随论文释出 |
 | 提交日期 | 2026-02 |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

为 [Biomechanical Comparisons Reveal Divergence of Human and Humanoid Gaits](papers/05_Locomotion/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits/Biomechanical_Comparisons_Reveal_Divergence_of_Human_and_Humanoid_Gaits.md) 笔记补充官方源码仓库链接。

- **源码**：指向第一作者仓库 [fengluying/GDAF](https://github.com/fengluying/GDAF)
- **项目主页**：同步指向同一仓库（README 注明代码随论文录用后释出）
- `_data/papers.json`：`has_open_source` 标记已同步为 `true`

## 验收截图

![修复后：GDAF 基本信息表含源码链接](https://cursor.com/artifacts/c/art-d4bd837c-a8db-4376-9f94-b31ccabd764c)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9864a134-a7c2-47fb-b4fc-6d0f8e080b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9864a134-a7c2-47fb-b4fc-6d0f8e080b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

