### PR TITLE
docs: 补全模块 06/07/11/13/14 上游缺失论文笔记（holes 全清零）

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1326,6 +1326,17 @@
         "zh_title": "DreamDojo：从大规模人类视频中学到的通用机器人世界模型"
       },
       {
+        "title": "A Systematic Study of Data Modalities and Strategies for Co-training Large Behavior Models for Robot Manipulation",
+        "path": "papers/06_Manipulation/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models.md",
+        "url": "/papers/06_Manipulation/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models.html",
+        "dir": "A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models",
+        "arxiv": "2602.01067",
+        "published_date_zh": "2026年2月",
+        "published_date_en": "Feb 2026",
+        "zhname": "面向机器人操作的大行为模型协同训练：数据模态与策略的系统研究",
+        "zh_title": "面向机器人操作的大行为模型协同训练：数据模态与策略的系统研究"
+      },
+      {
         "title": "HumanoidVLM: Vision-Language-Guided Impedance Control for Contact-Rich Humanoid Manipulation",
         "path": "papers/06_Manipulation/HumanoidVLM_Vision-Language-Guided_Impedance_Control_for_Contact-Rich_Humanoid_Manipulation/HumanoidVLM_Vision-Language-Guided_Impedance_Control_for_Contact-Rich_Humanoid_Manipulation.md",
         "url": "/papers/06_Manipulation/HumanoidVLM_Vision-Language-Guided_Impedance_Control_for_Contact-Rich_Humanoid_Manipulation/HumanoidVLM_Vision-Language-Guided_Impedance_Control_for_Contact-Rich_Humanoid_Manipulation.html",
@@ -1725,6 +1736,28 @@
         "published_date_en": "Oct 2024",
         "zhname": "Learning to Look：用策略因子化为决策寻求信息",
         "zh_title": "Learning to Look：用策略因子化为决策寻求信息"
+      },
+      {
+        "title": "OKAMI: Teaching Humanoid Robots Manipulation Skills through Single Video Imitation",
+        "path": "papers/06_Manipulation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation.md",
+        "url": "/papers/06_Manipulation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation.html",
+        "dir": "OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation",
+        "arxiv": "2410.11792",
+        "published_date_zh": "2024年10月",
+        "published_date_en": "Oct 2024",
+        "zhname": "OKAMI：通过单段视频模仿教人形机器人操作技能",
+        "zh_title": "OKAMI：通过单段视频模仿教人形机器人操作技能"
+      },
+      {
+        "title": "Learning Visuotactile Skills with Two Multifingered Hands",
+        "path": "papers/06_Manipulation/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.md",
+        "url": "/papers/06_Manipulation/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.html",
+        "dir": "Learning_Visuotactile_Skills_with_Two_Multifingered_Hands",
+        "arxiv": "2404.16823",
+        "published_date_zh": "2024年4月",
+        "published_date_en": "Apr 2024",
+        "zhname": "用两只多指手学习视触觉技能",
+        "zh_title": "用两只多指手学习视触觉技能"
       }
     ],
     "zhname": "灵巧操作",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -2996,6 +2996,72 @@
         "zh_title": "用百万级人类动作扩展大型动作模型"
       },
       {
+        "title": "Flexible Motion In-betweening with Diffusion Models",
+        "path": "papers/14_Human_Motion/Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.md",
+        "url": "/papers/14_Human_Motion/Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.html",
+        "dir": "Flexible_Motion_In-betweening_with_Diffusion_Models",
+        "arxiv": "2405.11126",
+        "published_date_zh": "2024年5月",
+        "published_date_en": "May 2024",
+        "zhname": "用扩散模型做灵活的动作中间帧补全",
+        "zh_title": "用扩散模型做灵活的动作中间帧补全"
+      },
+      {
+        "title": "Taming Diffusion Probabilistic Models for Character Control",
+        "path": "papers/14_Human_Motion/Taming_Diffusion_Probabilistic_Models_for_Character_Control/Taming_Diffusion_Probabilistic_Models_for_Character_Control.md",
+        "url": "/papers/14_Human_Motion/Taming_Diffusion_Probabilistic_Models_for_Character_Control/Taming_Diffusion_Probabilistic_Models_for_Character_Control.html",
+        "dir": "Taming_Diffusion_Probabilistic_Models_for_Character_Control",
+        "arxiv": "2404.15121",
+        "published_date_zh": "2024年4月",
+        "published_date_en": "Apr 2024",
+        "zhname": "驯服扩散概率模型以实现角色控制",
+        "zh_title": "驯服扩散概率模型以实现角色控制"
+      },
+      {
+        "title": "TEDi: Temporally-Entangled Diffusion for Long-Term Motion Synthesis",
+        "path": "papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.md",
+        "url": "/papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.html",
+        "dir": "TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis",
+        "arxiv": "2307.15042",
+        "published_date_zh": "2023年7月",
+        "published_date_en": "Jul 2023",
+        "zhname": "TEDi：时间纠缠扩散的长时程动作合成",
+        "zh_title": "TEDi：时间纠缠扩散的长时程动作合成"
+      },
+      {
+        "title": "Example-based Motion Synthesis via Generative Motion Matching",
+        "path": "papers/14_Human_Motion/Example-based_Motion_Synthesis_via_Generative_Motion_Matching/Example-based_Motion_Synthesis_via_Generative_Motion_Matching.md",
+        "url": "/papers/14_Human_Motion/Example-based_Motion_Synthesis_via_Generative_Motion_Matching/Example-based_Motion_Synthesis_via_Generative_Motion_Matching.html",
+        "dir": "Example-based_Motion_Synthesis_via_Generative_Motion_Matching",
+        "arxiv": "2306.00378",
+        "published_date_zh": "2023年6月",
+        "published_date_en": "Jun 2023",
+        "zhname": "GenMM：用生成式动作匹配做范例驱动的动作合成",
+        "zh_title": "GenMM：用生成式动作匹配做范例驱动的动作合成"
+      },
+      {
+        "title": "Guided Motion Diffusion for Controllable Human Motion Synthesis",
+        "path": "papers/14_Human_Motion/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md",
+        "url": "/papers/14_Human_Motion/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.html",
+        "dir": "Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis",
+        "arxiv": "2305.12577",
+        "published_date_zh": "2023年5月",
+        "published_date_en": "May 2023",
+        "zhname": "GMD：用引导式动作扩散做可控的人体动作合成",
+        "zh_title": "GMD：用引导式动作扩散做可控的人体动作合成"
+      },
+      {
+        "title": "PhysDiff: Physics-Guided Human Motion Diffusion Model",
+        "path": "papers/14_Human_Motion/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model.md",
+        "url": "/papers/14_Human_Motion/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model.html",
+        "dir": "PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model",
+        "arxiv": "2212.02500",
+        "published_date_zh": "2022年12月",
+        "published_date_en": "Dec 2022",
+        "zhname": "PhysDiff：物理引导的人体动作扩散模型",
+        "zh_title": "PhysDiff：物理引导的人体动作扩散模型"
+      },
+      {
         "title": "Learned Motion Matching",
         "path": "papers/14_Human_Motion/Learned_Motion_Matching/Learned_Motion_Matching.md",
         "url": "/papers/14_Human_Motion/Learned_Motion_Matching/Learned_Motion_Matching.html",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1582,6 +1582,73 @@
         "zh_title": "DreamGen：用视频世界模型解锁机器人学习的泛化"
       },
       {
+        "title": "EgoDex: Learning Dexterous Manipulation from Large-Scale Egocentric Video",
+        "path": "papers/06_Manipulation/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md",
+        "url": "/papers/06_Manipulation/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.html",
+        "dir": "EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video",
+        "arxiv": "2505.11709",
+        "has_open_source": true,
+        "published_date_zh": "2025年5月",
+        "published_date_en": "May 2025",
+        "zhname": "EgoDex：从大规模第一视角视频学习灵巧操作",
+        "zh_title": "EgoDex：从大规模第一视角视频学习灵巧操作"
+      },
+      {
+        "title": "Sim-and-Real Co-Training: A Simple Recipe for Vision-Based Robotic Manipulation",
+        "path": "papers/06_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation.md",
+        "url": "/papers/06_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation.html",
+        "dir": "Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation",
+        "arxiv": "2503.24361",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "Sim-and-Real 协同训练：基于视觉的机器人操作的简单配方",
+        "zh_title": "Sim-and-Real 协同训练：基于视觉的机器人操作的简单配方"
+      },
+      {
+        "title": "Humanoid Policy ~ Human Policy",
+        "path": "papers/06_Manipulation/Humanoid_Policy__Human_Policy/Humanoid_Policy__Human_Policy.md",
+        "url": "/papers/06_Manipulation/Humanoid_Policy__Human_Policy/Humanoid_Policy__Human_Policy.html",
+        "dir": "Humanoid_Policy__Human_Policy",
+        "arxiv": "2503.13441",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "Humanoid Policy ~ Human Policy：人形策略≈人类策略",
+        "zh_title": "Humanoid Policy ~ Human Policy：人形策略≈人类策略"
+      },
+      {
+        "title": "Humanoids in Hospitals: A Technical Study of Humanoid Robot Surrogates for Dexterous Medical Interventions",
+        "path": "papers/06_Manipulation/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions.md",
+        "url": "/papers/06_Manipulation/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions.html",
+        "dir": "Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions",
+        "arxiv": "2503.12725",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "Humanoids in Hospitals：人形机器人替身做灵巧医疗干预的技术研究",
+        "zh_title": "Humanoids in Hospitals：人形机器人替身做灵巧医疗干预的技术研究"
+      },
+      {
+        "title": "Unified Video Action Model",
+        "path": "papers/06_Manipulation/Unified_Video_Action_Model/Unified_Video_Action_Model.md",
+        "url": "/papers/06_Manipulation/Unified_Video_Action_Model/Unified_Video_Action_Model.html",
+        "dir": "Unified_Video_Action_Model",
+        "arxiv": "2503.00200",
+        "published_date_zh": "2025年2月",
+        "published_date_en": "Feb 2025",
+        "zhname": "Unified Video Action Model：统一视频-动作模型",
+        "zh_title": "Unified Video Action Model：统一视频-动作模型"
+      },
+      {
+        "title": "Dexterous Safe Control for Humanoids in Cluttered Environments via Projected Safe Set Algorithm",
+        "path": "papers/06_Manipulation/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set.md",
+        "url": "/papers/06_Manipulation/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set.html",
+        "dir": "Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set",
+        "arxiv": "2502.02858",
+        "published_date_zh": "2025年2月",
+        "published_date_en": "Feb 2025",
+        "zhname": "用投影安全集算法实现杂乱环境中人形的灵巧安全控制",
+        "zh_title": "用投影安全集算法实现杂乱环境中人形的灵巧安全控制"
+      },
+      {
         "title": "EgoMimic: Scaling Imitation Learning via Egocentric Video",
         "path": "papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.md",
         "url": "/papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.html",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -2930,6 +2930,72 @@
         "zh_title": "用稀疏接触标注 + 优化求解从单目视频高效、可扩展地重建 4D 人-物交互动作"
       },
       {
+        "title": "Being-M0.5: A Real-Time Controllable Vision-Language-Motion Model",
+        "path": "papers/14_Human_Motion/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.md",
+        "url": "/papers/14_Human_Motion/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.html",
+        "dir": "Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model",
+        "arxiv": "2508.07863",
+        "published_date_zh": "2025年8月",
+        "published_date_en": "Aug 2025",
+        "zhname": "Being-M0.5：实时可控的视觉-语言-动作模型",
+        "zh_title": "Being-M0.5：实时可控的视觉-语言-动作模型"
+      },
+      {
+        "title": "PICO: Reconstructing 3D People In Contact with Objects",
+        "path": "papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md",
+        "url": "/papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.html",
+        "dir": "PICO__Reconstructing_3D_People_In_Contact_with_Objects",
+        "arxiv": "2504.17695",
+        "published_date_zh": "2025年4月",
+        "published_date_en": "Apr 2025",
+        "zhname": "PICO：重建与物体接触的 3D 人体",
+        "zh_title": "PICO：重建与物体接触的 3D 人体"
+      },
+      {
+        "title": "FRAME: Floor-aligned Representation for Avatar Motion from Egocentric Video",
+        "path": "papers/14_Human_Motion/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.md",
+        "url": "/papers/14_Human_Motion/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.html",
+        "dir": "FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video",
+        "arxiv": "2503.23094",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "FRAME：面向第一视角视频化身动作的地面对齐表示",
+        "zh_title": "FRAME：面向第一视角视频化身动作的地面对齐表示"
+      },
+      {
+        "title": "ClimbingCap: Multi-Modal Dataset and Method for Rock Climbing in World Coordinate",
+        "path": "papers/14_Human_Motion/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.md",
+        "url": "/papers/14_Human_Motion/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.html",
+        "dir": "ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate",
+        "arxiv": "2503.21268",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "ClimbingCap：世界坐标系下攀岩的多模态数据集与方法",
+        "zh_title": "ClimbingCap：世界坐标系下攀岩的多模态数据集与方法"
+      },
+      {
+        "title": "PRIMAL: Physically Reactive and Interactive Motor Model for Avatar Learning",
+        "path": "papers/14_Human_Motion/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.md",
+        "url": "/papers/14_Human_Motion/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.html",
+        "dir": "PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning",
+        "arxiv": "2503.17544",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "PRIMAL：可物理反应与交互的化身运动模型",
+        "zh_title": "PRIMAL：可物理反应与交互的化身运动模型"
+      },
+      {
+        "title": "Scaling Large Motion Models with Million-Level Human Motions",
+        "path": "papers/14_Human_Motion/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.md",
+        "url": "/papers/14_Human_Motion/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.html",
+        "dir": "Scaling_Large_Motion_Models_with_Million-Level_Human_Motions",
+        "arxiv": "2410.03311",
+        "published_date_zh": "2024年10月",
+        "published_date_en": "Oct 2024",
+        "zhname": "用百万级人类动作扩展大型动作模型",
+        "zh_title": "用百万级人类动作扩展大型动作模型"
+      },
+      {
         "title": "Learned Motion Matching",
         "path": "papers/14_Human_Motion/Learned_Motion_Matching/Learned_Motion_Matching.md",
         "url": "/papers/14_Human_Motion/Learned_Motion_Matching/Learned_Motion_Matching.html",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1450,6 +1450,72 @@
         "zh_title": "面向接触丰富操作的人形视觉-触觉-动作数据集"
       },
       {
+        "title": "Towards Proprioception-Aware Embodied Planning for Dual-Arm Humanoid Robots",
+        "path": "papers/06_Manipulation/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots.md",
+        "url": "/papers/06_Manipulation/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots.html",
+        "dir": "Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots",
+        "arxiv": "2510.07882",
+        "published_date_zh": "2025年10月",
+        "published_date_en": "Oct 2025",
+        "zhname": "面向双臂人形的本体感受感知具身规划",
+        "zh_title": "面向双臂人形的本体感受感知具身规划"
+      },
+      {
+        "title": "EgoDemoGen: Egocentric Demonstration Generation for Viewpoint Generalization in Robotic Manipulation",
+        "path": "papers/06_Manipulation/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization.md",
+        "url": "/papers/06_Manipulation/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization.html",
+        "dir": "EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization",
+        "arxiv": "2509.22578",
+        "published_date_zh": "2025年9月",
+        "published_date_en": "Sep 2025",
+        "zhname": "EgoDemoGen：为操作视角泛化生成第一视角演示",
+        "zh_title": "EgoDemoGen：为操作视角泛化生成第一视角演示"
+      },
+      {
+        "title": "Residual Off-Policy RL for Finetuning Behavior Cloning Policies",
+        "path": "papers/06_Manipulation/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies.md",
+        "url": "/papers/06_Manipulation/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies.html",
+        "dir": "Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies",
+        "arxiv": "2509.19301",
+        "published_date_zh": "2025年9月",
+        "published_date_en": "Sep 2025",
+        "zhname": "用残差离策略 RL 微调行为克隆策略",
+        "zh_title": "用残差离策略 RL 微调行为克隆策略"
+      },
+      {
+        "title": "MimicDroid: In-Context Learning for Humanoid Robot Manipulation from Human Play Videos",
+        "path": "papers/06_Manipulation/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md",
+        "url": "/papers/06_Manipulation/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.html",
+        "dir": "MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos",
+        "arxiv": "2509.09769",
+        "published_date_zh": "2025年9月",
+        "published_date_en": "Sep 2025",
+        "zhname": "MimicDroid：从人类玩耍视频做人形操作的上下文学习",
+        "zh_title": "MimicDroid：从人类玩耍视频做人形操作的上下文学习"
+      },
+      {
+        "title": "Masquerade: Learning from In-the-wild Human Videos using Data-Editing",
+        "path": "papers/06_Manipulation/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md",
+        "url": "/papers/06_Manipulation/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.html",
+        "dir": "Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing",
+        "arxiv": "2508.09976",
+        "published_date_zh": "2025年8月",
+        "published_date_en": "Aug 2025",
+        "zhname": "Masquerade：用数据编辑从野外人类视频学习",
+        "zh_title": "Masquerade：用数据编辑从野外人类视频学习"
+      },
+      {
+        "title": "TOP: Time Optimization Policy for Stable and Accurate Standing Manipulation with Humanoid Robots",
+        "path": "papers/06_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation.md",
+        "url": "/papers/06_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation.html",
+        "dir": "TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation",
+        "arxiv": "2508.00355",
+        "published_date_zh": "2025年8月",
+        "published_date_en": "Aug 2025",
+        "zhname": "TOP：面向人形稳定精确站立操作的时间优化策略",
+        "zh_title": "TOP：面向人形稳定精确站立操作的时间优化策略"
+      },
+      {
         "title": "EgoMimic: Scaling Imitation Learning via Egocentric Video",
         "path": "papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.md",
         "url": "/papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.html",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -2252,6 +2252,17 @@
         "zh_title": "迈向动作图灵测试：评估人形机器人的「类人度」"
       },
       {
+        "title": "RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots",
+        "path": "papers/11_Simulation_Benchmark/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.md",
+        "url": "/papers/11_Simulation_Benchmark/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.html",
+        "dir": "RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots",
+        "arxiv": "2603.04356",
+        "published_date_zh": "2026年3月",
+        "published_date_en": "Mar 2026",
+        "zhname": "RoboCasa365：训练与评测通才机器人的大规模仿真框架",
+        "zh_title": "RoboCasa365：训练与评测通才机器人的大规模仿真框架"
+      },
+      {
         "title": "MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation",
         "path": "papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.md",
         "url": "/papers/11_Simulation_Benchmark/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation/MolmoSpaces__A_Large-Scale_Open_Ecosystem_for_Robot_Navigation_and_Manipulation.html",
@@ -2299,6 +2310,83 @@
         "zh_title": "人形机器人生成式世界建模：1X 世界模型挑战赛技术报告"
       },
       {
+        "title": "HumanoidGen: Data Generation for Bimanual Dexterous Manipulation via LLM Reasoning",
+        "path": "papers/11_Simulation_Benchmark/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md",
+        "url": "/papers/11_Simulation_Benchmark/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.html",
+        "dir": "HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning",
+        "arxiv": "2507.00833",
+        "published_date_zh": "2025年7月",
+        "published_date_en": "Jul 2025",
+        "zhname": "HumanoidGen：用大模型推理为双手灵巧操作生成数据",
+        "zh_title": "HumanoidGen：用大模型推理为双手灵巧操作生成数据"
+      },
+      {
+        "title": "DualTHOR: A Dual-Arm Humanoid Simulation Platform for Contingency-Aware Planning",
+        "path": "papers/11_Simulation_Benchmark/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning.md",
+        "url": "/papers/11_Simulation_Benchmark/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning.html",
+        "dir": "DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning",
+        "arxiv": "2506.16012",
+        "published_date_zh": "2025年6月",
+        "published_date_en": "Jun 2025",
+        "zhname": "DualTHOR：面向意外感知规划的双臂人形仿真平台",
+        "zh_title": "DualTHOR：面向意外感知规划的双臂人形仿真平台"
+      },
+      {
+        "title": "Learning with pyCub: A Simulation and Exercise Framework for Humanoid Robotics",
+        "path": "papers/11_Simulation_Benchmark/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics.md",
+        "url": "/papers/11_Simulation_Benchmark/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics.html",
+        "dir": "Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics",
+        "arxiv": "2506.01756",
+        "published_date_zh": "2025年6月",
+        "published_date_en": "Jun 2025",
+        "zhname": "Learning with pyCub：人形机器人学的仿真与练习框架",
+        "zh_title": "Learning with pyCub：人形机器人学的仿真与练习框架"
+      },
+      {
+        "title": "Humanoid World Models: Open World Foundation Models for Humanoid Robotics",
+        "path": "papers/11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md",
+        "url": "/papers/11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.html",
+        "dir": "Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics",
+        "arxiv": "2506.01182",
+        "published_date_zh": "2025年6月",
+        "published_date_en": "Jun 2025",
+        "zhname": "Humanoid World Models：面向人形机器人的开放世界基础模型",
+        "zh_title": "Humanoid World Models：面向人形机器人的开放世界基础模型"
+      },
+      {
+        "title": "Mimicking-Bench: A Benchmark for Generalizable Humanoid-Scene Interaction Learning via Human Mimicking",
+        "path": "papers/11_Simulation_Benchmark/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning.md",
+        "url": "/papers/11_Simulation_Benchmark/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning.html",
+        "dir": "Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning",
+        "arxiv": "2412.17730",
+        "published_date_zh": "2024年12月",
+        "published_date_en": "Dec 2024",
+        "zhname": "Mimicking-Bench：经由模仿人类的可泛化人形-场景交互学习基准",
+        "zh_title": "Mimicking-Bench：经由模仿人类的可泛化人形-场景交互学习基准"
+      },
+      {
+        "title": "ManiSkill-HAB: A Benchmark for Low-Level Manipulation in Home Rearrangement Tasks",
+        "path": "papers/11_Simulation_Benchmark/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md",
+        "url": "/papers/11_Simulation_Benchmark/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.html",
+        "dir": "ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks",
+        "arxiv": "2412.13211",
+        "published_date_zh": "2024年12月",
+        "published_date_en": "Dec 2024",
+        "zhname": "ManiSkill-HAB：家居重排任务中低层操作的基准",
+        "zh_title": "ManiSkill-HAB：家居重排任务中低层操作的基准"
+      },
+      {
+        "title": "DexMimicGen: Automated Data Generation for Bimanual Dexterous Manipulation via Imitation Learning",
+        "path": "papers/11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md",
+        "url": "/papers/11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.html",
+        "dir": "DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation",
+        "arxiv": "2410.24185",
+        "published_date_zh": "2024年10月",
+        "published_date_en": "Oct 2024",
+        "zhname": "DexMimicGen：经由模仿学习的双手灵巧操作自动数据生成",
+        "zh_title": "DexMimicGen：经由模仿学习的双手灵巧操作自动数据生成"
+      },
+      {
         "title": "GRUtopia: Dream General Robots in a City at Scale",
         "path": "papers/11_Simulation_Benchmark/GRUtopia__Dream_General_Robots_in_a_City_at_Scale/GRUtopia__Dream_General_Robots_in_a_City_at_Scale.md",
         "url": "/papers/11_Simulation_Benchmark/GRUtopia__Dream_General_Robots_in_a_City_at_Scale/GRUtopia__Dream_General_Robots_in_a_City_at_Scale.html",
@@ -2309,6 +2397,28 @@
         "published_date_en": "Jul 15, 2024 (arXiv)",
         "zhname": "GRUtopia：城市级交互式 3D 社会，给通用机器人造一座可训练的「乌托邦」",
         "zh_title": "GRUtopia：城市级交互式 3D 社会，给通用机器人造一座可训练的「乌托邦」"
+      },
+      {
+        "title": "BiGym: A Demo-Driven Mobile Bi-Manual Manipulation Benchmark",
+        "path": "papers/11_Simulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.md",
+        "url": "/papers/11_Simulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.html",
+        "dir": "BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark",
+        "arxiv": "2407.07788",
+        "published_date_zh": "2024年7月",
+        "published_date_en": "Jul 2024",
+        "zhname": "BiGym：演示驱动的移动双手操作基准",
+        "zh_title": "BiGym：演示驱动的移动双手操作基准"
+      },
+      {
+        "title": "RoboCasa: Large-Scale Simulation of Everyday Tasks for Generalist Robots",
+        "path": "papers/11_Simulation_Benchmark/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md",
+        "url": "/papers/11_Simulation_Benchmark/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.html",
+        "dir": "RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots",
+        "arxiv": "2406.02523",
+        "published_date_zh": "2024年6月",
+        "published_date_en": "Jun 2024",
+        "zhname": "RoboCasa：面向通才机器人的日常任务大规模仿真",
+        "zh_title": "RoboCasa：面向通才机器人的日常任务大规模仿真"
       },
       {
         "title": "HumanoidBench: Simulated Humanoid Benchmark for Whole-Body Locomotion and Manipulation",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1516,6 +1516,72 @@
         "zh_title": "TOP：面向人形稳定精确站立操作的时间优化策略"
       },
       {
+        "title": "H-RDT: Human Manipulation Enhanced Bimanual Robotic Manipulation",
+        "path": "papers/06_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md",
+        "url": "/papers/06_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.html",
+        "dir": "H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation",
+        "arxiv": "2507.23523",
+        "published_date_zh": "2025年7月",
+        "published_date_en": "Jul 2025",
+        "zhname": "H-RDT：用人类操作增强的双臂机器人操作",
+        "zh_title": "H-RDT：用人类操作增强的双臂机器人操作"
+      },
+      {
+        "title": "Being-H0: Vision-Language-Action Pretraining from Large-Scale Human Videos",
+        "path": "papers/06_Manipulation/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md",
+        "url": "/papers/06_Manipulation/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.html",
+        "dir": "Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos",
+        "arxiv": "2507.15597",
+        "published_date_zh": "2025年7月",
+        "published_date_en": "Jul 2025",
+        "zhname": "Being-H0：从大规模人类视频做视觉-语言-动作预训练",
+        "zh_title": "Being-H0：从大规模人类视频做视觉-语言-动作预训练"
+      },
+      {
+        "title": "Robot Drummer: Learning Rhythmic Skills for Humanoid Drumming",
+        "path": "papers/06_Manipulation/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming.md",
+        "url": "/papers/06_Manipulation/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming.html",
+        "dir": "Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming",
+        "arxiv": "2507.11498",
+        "published_date_zh": "2025年7月",
+        "published_date_en": "Jul 2025",
+        "zhname": "Robot Drummer：为人形打鼓学习节奏技能",
+        "zh_title": "Robot Drummer：为人形打鼓学习节奏技能"
+      },
+      {
+        "title": "Hierarchical Vision-Language Planning for Multi-Step Humanoid Manipulation",
+        "path": "papers/06_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.md",
+        "url": "/papers/06_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.html",
+        "dir": "Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation",
+        "arxiv": "2506.22827",
+        "published_date_zh": "2025年6月",
+        "published_date_en": "Jun 2025",
+        "zhname": "面向多步人形操作的分层视觉-语言规划",
+        "zh_title": "面向多步人形操作的分层视觉-语言规划"
+      },
+      {
+        "title": "Vision in Action: Learning Active Perception from Human Demonstrations",
+        "path": "papers/06_Manipulation/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md",
+        "url": "/papers/06_Manipulation/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.html",
+        "dir": "Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations",
+        "arxiv": "2506.15666",
+        "published_date_zh": "2025年6月",
+        "published_date_en": "Jun 2025",
+        "zhname": "Vision in Action：从人类演示学习主动感知",
+        "zh_title": "Vision in Action：从人类演示学习主动感知"
+      },
+      {
+        "title": "DreamGen: Unlocking Generalization in Robot Learning through Video World Models",
+        "path": "papers/06_Manipulation/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md",
+        "url": "/papers/06_Manipulation/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.html",
+        "dir": "DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models",
+        "arxiv": "2505.12705",
+        "published_date_zh": "2025年5月",
+        "published_date_en": "May 2025",
+        "zhname": "DreamGen：用视频世界模型解锁机器人学习的泛化",
+        "zh_title": "DreamGen：用视频世界模型解锁机器人学习的泛化"
+      },
+      {
         "title": "EgoMimic: Scaling Imitation Learning via Egocentric Video",
         "path": "papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.md",
         "url": "/papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.html",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -2861,6 +2861,16 @@
         "published_date_en": "Sep 26, 2025 (arXiv)",
         "zhname": "Learning to Ball：用「策略组合 + 高层软路由」拼出长程篮球连招",
         "zh_title": "Learning to Ball：用「策略组合 + 高层软路由」拼出长程篮球连招"
+      },
+      {
+        "title": "Spatial Relationship Preserving Character Motion Adaptation",
+        "path": "papers/13_Physics-Based_Animation/Spatial_Relationship_Preserving_Character_Motion_Adaptation/Spatial_Relationship_Preserving_Character_Motion_Adaptation.md",
+        "url": "/papers/13_Physics-Based_Animation/Spatial_Relationship_Preserving_Character_Motion_Adaptation/Spatial_Relationship_Preserving_Character_Motion_Adaptation.html",
+        "dir": "Spatial_Relationship_Preserving_Character_Motion_Adaptation",
+        "published_date_zh": "2010 年（SIGGRAPH 2010 / ACM TOG 29（4））",
+        "published_date_en": "2010 (SIGGRAPH 2010 / ACM TOG 29 (4))",
+        "zhname": "保持空间关系的角色运动适配",
+        "zh_title": "保持空间关系的角色运动适配"
       }
     ],
     "zhname": "物理动画",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -2941,6 +2941,17 @@
         "zh_title": "Being-M0.5：实时可控的视觉-语言-动作模型"
       },
       {
+        "title": "Go to Zero: Towards Zero-shot Motion Generation with Million-scale Data",
+        "path": "papers/14_Human_Motion/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data.md",
+        "url": "/papers/14_Human_Motion/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data.html",
+        "dir": "Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data",
+        "arxiv": "2507.07095",
+        "published_date_zh": "2025年7月",
+        "published_date_en": "Jul 2025",
+        "zhname": "Go to Zero：迈向百万级数据的零样本动作生成",
+        "zh_title": "Go to Zero：迈向百万级数据的零样本动作生成"
+      },
+      {
         "title": "PICO: Reconstructing 3D People In Contact with Objects",
         "path": "papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md",
         "url": "/papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.html",
@@ -3018,6 +3029,17 @@
         "zh_title": "驯服扩散概率模型以实现角色控制"
       },
       {
+        "title": "EgoPoser: Robust Real-Time Egocentric Pose Estimation from Sparse and Intermittent Observations Everywhere",
+        "path": "papers/14_Human_Motion/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md",
+        "url": "/papers/14_Human_Motion/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.html",
+        "dir": "EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors",
+        "arxiv": "2308.06493",
+        "published_date_zh": "2023年8月（ECCV 2024）",
+        "published_date_en": "Aug 2023 (ECCV 2024)",
+        "zhname": "EgoPoser：随处可用、面向稀疏且间歇观测的鲁棒实时第一视角姿态估计",
+        "zh_title": "EgoPoser：随处可用、面向稀疏且间歇观测的鲁棒实时第一视角姿态估计"
+      },
+      {
         "title": "TEDi: Temporally-Entangled Diffusion for Long-Term Motion Synthesis",
         "path": "papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.md",
         "url": "/papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.html",
@@ -3074,6 +3096,17 @@
         "zh_title": "学习式动作匹配：用三张小网络替代海量动作数据库"
       },
       {
+        "title": "AvatarPoser: Articulated Full-Body Pose Tracking from Sparse Motion Sensing",
+        "path": "papers/14_Human_Motion/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md",
+        "url": "/papers/14_Human_Motion/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.html",
+        "dir": "AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing",
+        "arxiv": "2207.13784",
+        "published_date_zh": "2022年7月（ECCV 2022）",
+        "published_date_en": "Jul 2022 (ECCV 2022)",
+        "zhname": "AvatarPoser：从稀疏运动感知做关节化全身姿态跟踪",
+        "zh_title": "AvatarPoser：从稀疏运动感知做关节化全身姿态跟踪"
+      },
+      {
         "title": "Generating Diverse and Natural 3D Human Motions from Textual Descriptions",
         "path": "papers/14_Human_Motion/HumanML3D/HumanML3D.md",
         "url": "/papers/14_Human_Motion/HumanML3D/HumanML3D.html",
@@ -3095,6 +3128,36 @@
         "published_date_en": "Dec 2025 (SIGGRAPH Asia 2025, Hong Kong, Dec 15–18)",
         "zhname": "控制算子：让非技术用户也能搭出自己的「学习型」角色控制器",
         "zh_title": "控制算子：让非技术用户也能搭出自己的「学习型」角色控制器"
+      },
+      {
+        "title": "Implicit Bézier Motion Model for Precise Spatial and Temporal Control",
+        "path": "papers/14_Human_Motion/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control.md",
+        "url": "/papers/14_Human_Motion/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control.html",
+        "dir": "Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control",
+        "published_date_zh": "2025年12月（SIGGRAPH MIG 2025）",
+        "published_date_en": "Dec 2025 (SIGGRAPH MIG 2025)",
+        "zhname": "隐式贝塞尔运动模型：精确的空间与时间控制",
+        "zh_title": "隐式贝塞尔运动模型：精确的空间与时间控制"
+      },
+      {
+        "title": "Climber Force and Motion Estimation from Video",
+        "path": "papers/14_Human_Motion/Climber_Force_and_Motion_Estimation_from_Video/Climber_Force_and_Motion_Estimation_from_Video.md",
+        "url": "/papers/14_Human_Motion/Climber_Force_and_Motion_Estimation_from_Video/Climber_Force_and_Motion_Estimation_from_Video.html",
+        "dir": "Climber_Force_and_Motion_Estimation_from_Video",
+        "published_date_zh": "2025年4月（arXiv，详见项目页）",
+        "published_date_en": "Apr 2025 (arXiv, 详见项目页)",
+        "zhname": "从视频估计攀岩者的受力与运动",
+        "zh_title": "从视频估计攀岩者的受力与运动"
+      },
+      {
+        "title": "MANIKIN: Biomechanically Accurate Neural Inverse Kinematics for Human Motion Estimation",
+        "path": "papers/14_Human_Motion/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation.md",
+        "url": "/papers/14_Human_Motion/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation.html",
+        "dir": "MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation",
+        "published_date_zh": "2024 年（ECCV 2024）",
+        "published_date_en": "2024 (ECCV 2024)",
+        "zhname": "MANIKIN：生物力学精确的神经逆运动学用于人体动作估计",
+        "zh_title": "MANIKIN：生物力学精确的神经逆运动学用于人体动作估计"
       }
     ],
     "zhname": "人体动作分析与生成",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1649,6 +1649,61 @@
         "zh_title": "用投影安全集算法实现杂乱环境中人形的灵巧安全控制"
       },
       {
+        "title": "MobileH2R: Learning Generalizable Human to Mobile Robot Handover Exclusively from Scalable and Diverse Synthetic Data",
+        "path": "papers/06_Manipulation/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data.md",
+        "url": "/papers/06_Manipulation/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data.html",
+        "dir": "MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data",
+        "arxiv": "2501.04595",
+        "published_date_zh": "2025年1月",
+        "published_date_en": "Jan 2025",
+        "zhname": "MobileH2R：仅用可扩展多样合成数据学习泛化的人到移动机器人递交",
+        "zh_title": "MobileH2R：仅用可扩展多样合成数据学习泛化的人到移动机器人递交"
+      },
+      {
+        "title": "ARMADA: Augmented Reality for Robot Manipulation and Robot-Free Data Acquisition",
+        "path": "papers/06_Manipulation/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition.md",
+        "url": "/papers/06_Manipulation/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition.html",
+        "dir": "ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition",
+        "arxiv": "2412.10631",
+        "published_date_zh": "2024年12月",
+        "published_date_en": "Dec 2024",
+        "zhname": "ARMADA：用增强现实做机器人操作与无机器人数据采集",
+        "zh_title": "ARMADA：用增强现实做机器人操作与无机器人数据采集"
+      },
+      {
+        "title": "Object-Centric Dexterous Manipulation from Human Motion Data",
+        "path": "papers/06_Manipulation/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.md",
+        "url": "/papers/06_Manipulation/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.html",
+        "dir": "Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data",
+        "arxiv": "2411.04005",
+        "published_date_zh": "2024年11月",
+        "published_date_en": "Nov 2024",
+        "zhname": "以物体为中心：从人类动作数据学习灵巧操作",
+        "zh_title": "以物体为中心：从人类动作数据学习灵巧操作"
+      },
+      {
+        "title": "DexHub and DART: Towards Internet Scale Robot Data Collection",
+        "path": "papers/06_Manipulation/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection.md",
+        "url": "/papers/06_Manipulation/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection.html",
+        "dir": "DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection",
+        "arxiv": "2411.02214",
+        "published_date_zh": "2024年11月",
+        "published_date_en": "Nov 2024",
+        "zhname": "DexHub 与 DART：迈向互联网规模的机器人数据采集",
+        "zh_title": "DexHub 与 DART：迈向互联网规模的机器人数据采集"
+      },
+      {
+        "title": "Learning to Look Around: Enhancing Teleoperation and Learning with a Human-like Actuated Neck",
+        "path": "papers/06_Manipulation/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.md",
+        "url": "/papers/06_Manipulation/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.html",
+        "dir": "Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning",
+        "arxiv": "2411.00704",
+        "published_date_zh": "2024年11月",
+        "published_date_en": "Nov 2024",
+        "zhname": "Learning to Look Around：用拟人可动颈增强遥操作与学习",
+        "zh_title": "Learning to Look Around：用拟人可动颈增强遥操作与学习"
+      },
+      {
         "title": "EgoMimic: Scaling Imitation Learning via Egocentric Video",
         "path": "papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.md",
         "url": "/papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.html",
@@ -1659,6 +1714,17 @@
         "published_date_en": "Oct 2024 (arXiv)",
         "zhname": "EgoMimic：通过第一视角视频扩展模仿学习",
         "zh_title": "EgoMimic：通过第一视角视频扩展模仿学习"
+      },
+      {
+        "title": "Learning to Look: Seeking Information for Decision Making via Policy Factorization",
+        "path": "papers/06_Manipulation/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.md",
+        "url": "/papers/06_Manipulation/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.html",
+        "dir": "Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization",
+        "arxiv": "2410.18964",
+        "published_date_zh": "2024年10月",
+        "published_date_en": "Oct 2024",
+        "zhname": "Learning to Look：用策略因子化为决策寻求信息",
+        "zh_title": "Learning to Look：用策略因子化为决策寻求信息"
       }
     ],
     "zhname": "灵巧操作",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1384,6 +1384,72 @@
         "zh_title": "SafeHumanoid：用 VLM-RAG 驱动人形上身阻抗控制"
       },
       {
+        "title": "Dexterity from Smart Lenses: Multi-Fingered Robot Manipulation with In-the-Wild Human Demonstrations",
+        "path": "papers/06_Manipulation/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md",
+        "url": "/papers/06_Manipulation/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.html",
+        "dir": "Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos",
+        "arxiv": "2511.16661",
+        "published_date_zh": "2025年11月",
+        "published_date_en": "Nov 2025",
+        "zhname": "Dexterity from Smart Lenses：用智能眼镜的野外人类演示学多指操作",
+        "zh_title": "Dexterity from Smart Lenses：用智能眼镜的野外人类演示学多指操作"
+      },
+      {
+        "title": "In-N-On: Scaling Egocentric Manipulation with in-the-wild and on-task Data",
+        "path": "papers/06_Manipulation/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md",
+        "url": "/papers/06_Manipulation/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.html",
+        "dir": "In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data",
+        "arxiv": "2511.15704",
+        "published_date_zh": "2025年11月",
+        "published_date_en": "Nov 2025",
+        "zhname": "In-N-On：用「野外 + 任务对齐」数据规模化第一视角操作",
+        "zh_title": "In-N-On：用「野外 + 任务对齐」数据规模化第一视角操作"
+      },
+      {
+        "title": "Lightning Grasp: High Performance Procedural Grasp Synthesis with Contact Fields",
+        "path": "papers/06_Manipulation/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields.md",
+        "url": "/papers/06_Manipulation/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields.html",
+        "dir": "Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields",
+        "arxiv": "2511.07418",
+        "published_date_zh": "2025年11月",
+        "published_date_en": "Nov 2025",
+        "zhname": "Lightning Grasp：用接触场做高性能程序化抓取合成",
+        "zh_title": "Lightning Grasp：用接触场做高性能程序化抓取合成"
+      },
+      {
+        "title": "EgoMI: Learning Active Vision and Whole-Body Manipulation from Egocentric Human Demonstrations",
+        "path": "papers/06_Manipulation/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md",
+        "url": "/papers/06_Manipulation/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.html",
+        "dir": "EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos",
+        "arxiv": "2511.00153",
+        "published_date_zh": "2025年11月",
+        "published_date_en": "Nov 2025",
+        "zhname": "EgoMI：从第一视角人类演示学习主动视觉与全身操作",
+        "zh_title": "EgoMI：从第一视角人类演示学习主动视觉与全身操作"
+      },
+      {
+        "title": "Endowing GPT-4 with a Humanoid Body: Building the Bridge Between Off-the-Shelf VLMs and the Physical World",
+        "path": "papers/06_Manipulation/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.md",
+        "url": "/papers/06_Manipulation/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.html",
+        "dir": "Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World",
+        "arxiv": "2511.00041",
+        "published_date_zh": "2025年11月",
+        "published_date_en": "Nov 2025",
+        "zhname": "给 GPT-4 一具人形身体：在现成 VLM 与物理世界间架桥",
+        "zh_title": "给 GPT-4 一具人形身体：在现成 VLM 与物理世界间架桥"
+      },
+      {
+        "title": "A Humanoid Visual-Tactile-Action Dataset for Contact-Rich Manipulation",
+        "path": "papers/06_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.md",
+        "url": "/papers/06_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.html",
+        "dir": "A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation",
+        "arxiv": "2510.25725",
+        "published_date_zh": "2025年10月",
+        "published_date_en": "Oct 2025",
+        "zhname": "面向接触丰富操作的人形视觉-触觉-动作数据集",
+        "zh_title": "面向接触丰富操作的人形视觉-触觉-动作数据集"
+      },
+      {
         "title": "EgoMimic: Scaling Imitation Learning via Egocentric Video",
         "path": "papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.md",
         "url": "/papers/06_Manipulation/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video/EgoMimic_Scaling_Imitation_Learning_via_Egocentric_Video.html",

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -1461,6 +1461,17 @@
         "zh_title": "学习式神经遥操作：用 RL 端到端策略替换 IK+PD，让 VR 控制器直接驱动人形机器人"
       },
       {
+        "title": "TWIST2: Scalable, Portable, and Holistic Humanoid Data Collection System",
+        "path": "papers/07_Teleoperation/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md",
+        "url": "/papers/07_Teleoperation/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.html",
+        "dir": "TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System",
+        "arxiv": "2511.02832",
+        "published_date_zh": "2025年11月",
+        "published_date_en": "Nov 2025",
+        "zhname": "TWIST2：可扩展、便携、整体式的人形数据采集系统",
+        "zh_title": "TWIST2：可扩展、便携、整体式的人形数据采集系统"
+      },
+      {
         "title": "Development of an Intuitive GUI for Non-Expert Teleoperation of Humanoid Robots",
         "path": "papers/07_Teleoperation/Intuitive_GUI_for_Non-Expert_Teleoperation_of_Humanoid_Robots/Intuitive_GUI_for_Non-Expert_Teleoperation_of_Humanoid_Robots.md",
         "url": "/papers/07_Teleoperation/Intuitive_GUI_for_Non-Expert_Teleoperation_of_Humanoid_Robots/Intuitive_GUI_for_Non-Expert_Teleoperation_of_Humanoid_Robots.html",
@@ -1492,6 +1503,127 @@
         "published_date_en": "Oct 3, 2025 (arXiv v1; v2 Feb 16, 2026)",
         "zhname": "LapSurgie：人形机器人经遥操作手持腹腔镜执行手术",
         "zh_title": "LapSurgie：人形机器人经遥操作手持腹腔镜执行手术"
+      },
+      {
+        "title": "Whole-Body Bilateral Teleoperation with Multi-Stage Object Parameter Estimation for Wheeled Humanoid Locomanipulation",
+        "path": "papers/07_Teleoperation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation.md",
+        "url": "/papers/07_Teleoperation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation.html",
+        "dir": "Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation",
+        "arxiv": "2508.09846",
+        "published_date_zh": "2025年8月",
+        "published_date_en": "Aug 2025",
+        "zhname": "面向轮式人形移动操作的多阶段物体参数估计全身双边遥操作",
+        "zh_title": "面向轮式人形移动操作的多阶段物体参数估计全身双边遥操作"
+      },
+      {
+        "title": "CHILD: a Whole-Body Humanoid Teleoperation System",
+        "path": "papers/07_Teleoperation/CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md",
+        "url": "/papers/07_Teleoperation/CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.html",
+        "dir": "CHILD__a_Whole-Body_Humanoid_Teleoperation_System",
+        "arxiv": "2508.00162",
+        "published_date_zh": "2025年8月",
+        "published_date_en": "Aug 2025",
+        "zhname": "CHILD：全身人形遥操作系统",
+        "zh_title": "CHILD：全身人形遥操作系统"
+      },
+      {
+        "title": "Heavy lifting tasks via haptic teleoperation of a wheeled humanoid",
+        "path": "papers/07_Teleoperation/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid.md",
+        "url": "/papers/07_Teleoperation/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid.html",
+        "dir": "Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid",
+        "arxiv": "2505.19530",
+        "published_date_zh": "2025年5月",
+        "published_date_en": "May 2025",
+        "zhname": "通过力触觉遥操作让轮式人形完成重物搬运",
+        "zh_title": "通过力触觉遥操作让轮式人形完成重物搬运"
+      },
+      {
+        "title": "TeleOpBench: A Simulator-Centric Benchmark for Dual-Arm Dexterous Teleoperation",
+        "path": "papers/07_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation.md",
+        "url": "/papers/07_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation.html",
+        "dir": "TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation",
+        "arxiv": "2505.12748",
+        "published_date_zh": "2025年5月",
+        "published_date_en": "May 2025",
+        "zhname": "TeleOpBench：以仿真为中心的双臂灵巧遥操作基准",
+        "zh_title": "TeleOpBench：以仿真为中心的双臂灵巧遥操作基准"
+      },
+      {
+        "title": "Human-Robot Collaboration for the Remote Control of Mobile Humanoid Robots with Torso-Arm Coordination",
+        "path": "papers/07_Teleoperation/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots.md",
+        "url": "/papers/07_Teleoperation/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots.html",
+        "dir": "Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots",
+        "arxiv": "2505.05773",
+        "published_date_zh": "2025年5月",
+        "published_date_en": "May 2025",
+        "zhname": "面向移动人形远程控制的人机协作躯干-手臂协调",
+        "zh_title": "面向移动人形远程控制的人机协作躯干-手臂协调"
+      },
+      {
+        "title": "TWIST: Teleoperated Whole-Body Imitation System",
+        "path": "papers/07_Teleoperation/TWIST__Teleoperated_Whole-Body_Imitation_System/TWIST__Teleoperated_Whole-Body_Imitation_System.md",
+        "url": "/papers/07_Teleoperation/TWIST__Teleoperated_Whole-Body_Imitation_System/TWIST__Teleoperated_Whole-Body_Imitation_System.html",
+        "dir": "TWIST__Teleoperated_Whole-Body_Imitation_System",
+        "arxiv": "2505.02833",
+        "published_date_zh": "2025年5月",
+        "published_date_en": "May 2025",
+        "zhname": "TWIST：遥操作全身模仿系统",
+        "zh_title": "TWIST：遥操作全身模仿系统"
+      },
+      {
+        "title": "NuExo: A Wearable Exoskeleton Covering all Upper Limb ROM for Outdoor Data Collection and Teleoperation of Humanoid Robots",
+        "path": "papers/07_Teleoperation/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md",
+        "url": "/papers/07_Teleoperation/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.html",
+        "dir": "NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM",
+        "arxiv": "2503.10554",
+        "published_date_zh": "2025年3月",
+        "published_date_en": "Mar 2025",
+        "zhname": "NuExo：覆盖全上肢活动范围的可穿戴外骨骼，用于户外数据采集与人形遥操作",
+        "zh_title": "NuExo：覆盖全上肢活动范围的可穿戴外骨骼，用于户外数据采集与人形遥操作"
+      },
+      {
+        "title": "Mobile-TeleVision: Predictive Motion Priors for Humanoid Whole-Body Control",
+        "path": "papers/07_Teleoperation/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md",
+        "url": "/papers/07_Teleoperation/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.html",
+        "dir": "Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control",
+        "arxiv": "2412.07773",
+        "published_date_zh": "2024年12月",
+        "published_date_en": "Dec 2024",
+        "zhname": "Mobile-TeleVision：面向人形全身控制的预测式运动先验",
+        "zh_title": "Mobile-TeleVision：面向人形全身控制的预测式运动先验"
+      },
+      {
+        "title": "High-Speed and Impact Resilient Teleoperation of Humanoid Robots",
+        "path": "papers/07_Teleoperation/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots.md",
+        "url": "/papers/07_Teleoperation/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots.html",
+        "dir": "High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots",
+        "arxiv": "2409.04639",
+        "published_date_zh": "2024年9月",
+        "published_date_en": "Sep 2024",
+        "zhname": "人形机器人的高速且抗冲击遥操作",
+        "zh_title": "人形机器人的高速且抗冲击遥操作"
+      },
+      {
+        "title": "ACE: A Cross-Platform Visual-Exoskeletons System for Low-Cost Dexterous Teleoperation",
+        "path": "papers/07_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md",
+        "url": "/papers/07_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.html",
+        "dir": "ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation",
+        "arxiv": "2408.11805",
+        "published_date_zh": "2024年8月",
+        "published_date_en": "Aug 2024",
+        "zhname": "ACE：面向低成本灵巧遥操作的跨平台视觉-外骨骼系统",
+        "zh_title": "ACE：面向低成本灵巧遥操作的跨平台视觉-外骨骼系统"
+      },
+      {
+        "title": "Bunny-VisionPro: Real-Time Bimanual Dexterous Teleoperation for Imitation Learning",
+        "path": "papers/07_Teleoperation/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning.md",
+        "url": "/papers/07_Teleoperation/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning.html",
+        "dir": "Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning",
+        "arxiv": "2407.03162",
+        "published_date_zh": "2024年7月",
+        "published_date_en": "Jul 2024",
+        "zhname": "Bunny-VisionPro：面向模仿学习的实时双手灵巧遥操作",
+        "zh_title": "Bunny-VisionPro：面向模仿学习的实时双手灵巧遥操作"
       },
       {
         "title": "HumanPlus: Humanoid Shadowing and Imitation from Humans",

--- a/papers/06_Manipulation/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition.md
+++ b/papers/06_Manipulation/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "ARMADA: Augmented Reality for Robot Manipulation and Robot-Free Data Acquisition"
+zhname: "ARMADA：用增强现实做机器人操作与无机器人数据采集"
+category: "Manipulation"
+arxiv: "2412.10631"
+---
+
+# ARMADA: Augmented Reality for Robot Manipulation and Robot-Free Data Acquisition
+**遥操作采集机器人模仿数据受硬件可得性瓶颈——能否在没有实体机器人的情况下采到高质量机器人数据？ARMADA 把 Apple Vision Pro 与实时虚拟机器人反馈结合，让用户理解自己的动作如何转成机器人动作，从而采集「与实体机器人硬件限制兼容」的自然徒手人类数据；15 人、3 任务、3 种反馈条件的用户研究表明实时机器人反馈显著提升采集数据质量**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 增强现实 · 无机器人采集 · 虚拟反馈 · 徒手数据 · Vision Pro
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 12 月 |
+| arXiv | [2412.10631](https://arxiv.org/abs/2412.10631) · [PDF](https://arxiv.org/pdf/2412.10631) · [HTML](https://arxiv.org/html/2412.10631v1) |
+| 作者 | Nataliya Nechyporenko、Ryan Hoque、Christopher Webb、Mouli Sivapurapu、Jian Zhang（Apple） |
+| 主题 | cs.RO · 增强现实 / 数据采集 / 模仿学习 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 遥操作采集机器人模仿数据受**硬件可得性**瓶颈——问题是：**能否在没有实体机器人的情况下采到高质量机器人数据？** ARMADA 把 **Apple Vision Pro** 与**实时虚拟机器人反馈**结合：让用户**理解自己的动作如何转成机器人动作**，从而采集**与实体机器人硬件限制兼容**的**自然徒手（barehanded）人类数据**。**15 人、3 个任务、3 种反馈条件**的用户研究 + 在实体机器人上**直接轨迹回放**表明：**实时机器人反馈显著提升采集数据质量**，提示这是一条**无需机器人硬件**也能**可扩展采集人类数据**的路径。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| ARMADA | 本文系统名 |
+| AR | Augmented Reality 增强现实 |
+| Robot-Free | 无机器人（采集时不需实体机器人） |
+| Virtual Robot Feedback | 实时虚拟机器人反馈 |
+| Barehanded | 徒手（无设备）人类动作 |
+| Trajectory Replay | 轨迹回放到实体机器人 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+遥操作采集受**机器人硬件**限制：
+- 没有实体机器人就难采"机器人兼容"的数据；
+- 徒手人类数据**未必符合机器人硬件限制**（够不到/超限）。
+
+ARMADA 要：用 **AR + 虚拟机器人反馈**，让用户徒手采到**硬件兼容**的高质量数据。
+
+---
+
+## 🔧 方法详解
+
+### 1. Vision Pro + 实时虚拟机器人反馈
+用 **Apple Vision Pro**，在用户视野里实时显示**虚拟机器人**如何执行其动作——用户**即时理解**动作如何映射到机器人。
+
+### 2. 采集硬件兼容的徒手数据
+因为有反馈，用户会**自然地把动作约束在机器人硬件限制内**（工作空间、可达性），从而采到**兼容**的数据。
+
+### 3. 用户研究 + 轨迹回放验证
+- **15 人、3 任务、3 反馈条件**用户研究；
+- 在实体机器人上**直接轨迹回放**；
+- **实时反馈显著提升数据质量**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    U["🧑 徒手人类动作"] --> AR
+    subgraph AR["Vision Pro + 实时虚拟机器人反馈"]
+        F["看到动作→机器人动作映射<br/>(约束在硬件限制内)"]
+    end
+    AR --> DATA["硬件兼容的人类数据"]
+    DATA --> OUT["🤖 实体机器人轨迹回放<br/>实时反馈显著提升质量(15人研究)"]
+
+    style AR fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **无机器人数据采集**：AR + 虚拟机器人反馈，免实体机器人；
+2. **硬件兼容的徒手数据**：实时反馈把动作约束在机器人限制内；
+3. **用户研究验证**：15 人、3 任务、3 反馈条件；
+4. **实时反馈显著提升质量**：可扩展采集路径。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"实时反馈"是徒手采集兼容数据的关键**：否则人会做出机器人做不到的动作；
+- **无机器人采集**极大降低数据门槛，利于规模化；
+- 对人形（硬件贵、可达性受限）尤其有价值；
+- 与 EgoDex（Vision Pro 采集）同属 Apple 系数据工作。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2412.10631](https://arxiv.org/abs/2412.10631) | 论文正文（AR 反馈、用户研究、轨迹回放） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·数据采集**：[DexHub and DART（云仿真 + AR 众包采集）](../DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection.md) · [EgoDex（Vision Pro 数据集）](../EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md)。

--- a/papers/06_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.md
+++ b/papers/06_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "A Humanoid Visual-Tactile-Action Dataset for Contact-Rich Manipulation"
+zhname: "面向接触丰富操作的人形视觉-触觉-动作数据集"
+category: "Manipulation"
+arxiv: "2510.25725"
+---
+
+# A Humanoid Visual-Tactile-Action Dataset for Contact-Rich Manipulation
+**针对以往机器人学习数据集多聚焦刚体、少覆盖真实操作多样压力条件的不足，构建一个面向「可变形软物体」操作的人形视觉-触觉-动作数据集：用带灵巧手的人形以遥操作采集，含视觉与触觉多模态、覆盖不同压力条件，旨在推动能有效利用复杂多样触觉信号的模型研究**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 视触觉数据集 · 接触丰富 · 可变形物体 · 多模态 · 遥操作
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 10 月 |
+| arXiv | [2510.25725](https://arxiv.org/abs/2510.25725) · [PDF](https://arxiv.org/pdf/2510.25725) · [HTML](https://arxiv.org/html/2510.25725v1) |
+| 作者 | Eunju Kwon、Seungwon Oh、In-Chang Baek、Yunho Choi、Kyung-Joong Kim 等（GIST 等） |
+| 主题 | cs.RO · 视触觉数据集 / 接触丰富操作 / 可变形物体 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> **接触丰富操作**在机器人学习中越来越重要，但以往机器人学习数据集多聚焦**刚体**，**低估了真实操作中压力条件的多样性**。为填补此空白，本文提出一个面向**可变形软物体**操作的**人形视觉-触觉-动作数据集**。数据用**带灵巧手的人形**通过**遥操作**采集，包含**视觉与触觉多模态**信号，并覆盖**不同压力条件**。该工作旨在**激励**未来研究——开发**具备先进优化策略**、能**有效利用复杂多样触觉信号**的模型，而非在摘要中报告具体数值。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Visual-Tactile-Action | 视觉-触觉-动作多模态 |
+| Contact-Rich | 接触丰富（频繁/复杂接触） |
+| Deformable Object | 可变形软物体 |
+| Pressure Condition | 压力条件（按压力度等） |
+| Teleoperation | 遥操作采集 |
+| Dexterous Hand | 灵巧手 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+接触丰富操作的数据缺口：
+- 现有数据集多为**刚体**，少**可变形软物体**；
+- **压力条件多样性**被低估；
+- 缺**人形 + 灵巧手 + 视触觉**的多模态数据。
+
+论文要：构建一个**人形视触觉-动作数据集**，专门覆盖**软物体 + 多压力**的接触丰富操作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 人形 + 灵巧手 + 遥操作采集
+用**带灵巧手的人形**通过**遥操作**采集真实操作数据，保证动作真实可执行。
+
+### 2. 视觉 + 触觉多模态
+同步采集**视觉**与**触觉**信号，使数据能支撑"看 + 摸"的接触丰富操作学习。
+
+### 3. 覆盖可变形软物体与多压力条件
+聚焦**可变形软物体**，并覆盖**不同压力条件**，填补以往刚体/单一压力的空白。
+
+### 4. 目标
+**激励**未来开发能**有效利用复杂多样触觉信号**的模型与优化策略。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    H["🤖 人形 + 灵巧手(遥操作)"] --> DATA
+    subgraph DATA["视觉-触觉-动作数据集"]
+        V["视觉"]
+        T["触觉(多压力)"]
+        A["动作"]
+        SOFT["可变形软物体"]
+    end
+    DATA --> OUT["📊 接触丰富操作研究<br/>激励利用复杂触觉信号的模型"]
+
+    style DATA fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **人形视觉-触觉-动作数据集**：面向接触丰富操作；
+2. **可变形软物体 + 多压力条件**：填补刚体/单一压力的空白；
+3. **多模态 + 灵巧手遥操作采集**：真实可执行；
+4. **激励触觉模型研究**：推动有效利用复杂触觉信号。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **触觉是接触丰富/软物体操作的关键模态**，视觉常不足；
+- **可变形物体 + 多压力**更贴近真实家务/护理场景；
+- **数据集 + 灵巧手人形**为触觉学习提供稀缺资源；
+- 与 CHIP、HMC 等"柔顺/力"工作在"接触"主题上互补。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2510.25725](https://arxiv.org/abs/2510.25725) | 论文正文（数据集构成、采集、触觉信号分析） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·视触觉操作**：[Learning Visuotactile Skills with Two Multifingered Hands](../Learning_Visuotactile_Skills_with_Two_Multifingered_Hands/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.md)；
+- **柔顺/接触（本仓 04）**：[CHIP](../../04_Loco-Manipulation_and_WBC/CHIP__Adaptive_Compliance_for_Humanoid_Control_through_Hindsight_Perturbation/CHIP__Adaptive_Compliance_for_Humanoid_Control_through_Hindsight_Perturbation.md)。

--- a/papers/06_Manipulation/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models.md
+++ b/papers/06_Manipulation/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models.md
@@ -1,0 +1,133 @@
+---
+layout: paper
+title: "A Systematic Study of Data Modalities and Strategies for Co-training Large Behavior Models for Robot Manipulation"
+zhname: "面向机器人操作的大行为模型协同训练：数据模态与策略的系统研究"
+category: "Manipulation"
+arxiv: "2602.01067"
+---
+
+# A Systematic Study of Data Modalities and Strategies for Co-training Large Behavior Models for Robot Manipulation
+**系统研究「协同训练」用哪些异构数据模态、用什么策略最有效：在 4000 小时机器人/人类操作数据 + 5000 万视觉-语言样本上，跨 89 个策略、5.8 万次仿真 + 2835 次真机 rollout，比较视觉-语言、稠密语言标注、跨本体机器人数据、人类视频、离散动作 token 五类模态与单/多阶段策略——发现视觉-语言与跨本体机器人数据显著提升泛化，离散动作 token 收益甚微，组合有效模态可累加增益，纯机器人训练会损害视觉-语言能力而协同训练能恢复**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 协同训练 · 大行为模型 · 数据模态 · VLA · 系统研究
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2026 年 2 月 |
+| arXiv | [2602.01067](https://arxiv.org/abs/2602.01067) · [PDF](https://arxiv.org/pdf/2602.01067) · [HTML](https://arxiv.org/html/2602.01067v1) |
+| 作者 | Fanqi Lin、Kushal Arora、Jean Mercat、Haruki Nishimura、Paarth Shah、Jose Barreiros 等（Toyota Research Institute, TRI） |
+| 主题 | cs.RO · 协同训练 / 大行为模型 / VLA |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块（上游未给链接，已核对为 2602.01067）。
+
+---
+
+## 🎯 一句话总结
+
+> **大行为模型（Large Behavior Models）**把模仿学习扩展到**多任务机器人数据**的大规模训练，展现强**灵巧操作**能力，但**泛化**仍受限于**机器人数据覆盖不足**。为在**不昂贵额外采集**的前提下扩覆盖，近期工作依赖**协同训练（co-training）**：联合学习**目标机器人数据**与**异构数据模态**。但**不同协同训练数据模态与策略如何影响策略性能**仍**理解不足**。本文做**系统研究**：在 **4000 小时**机器人/人类操作数据 + **5000 万**视觉-语言样本上，跨 **89 个策略**、**5.8 万次仿真 + 2835 次真机 rollout**，比较**五类模态**（视觉-语言数据、稠密语言标注、跨本体机器人数据、人类视频、离散动作 token）与**单/多阶段训练策略**。主要发现：**视觉-语言与跨本体机器人数据显著提升**对分布偏移、新任务与语言理解的**泛化**；**离散动作 token 收益甚微**；**组合有效模态可累加增益**；**纯机器人训练会损害视觉-语言能力，而协同训练能恢复**；思维链（CoT）条件在其基准上**无性能增益**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| LBM | Large Behavior Model，大行为模型 |
+| Co-training | 协同训练，目标数据 + 异构模态联合学 |
+| Cross-Embodiment | 跨本体机器人数据 |
+| Action Token | 离散动作 token |
+| VLA | Vision-Language-Action |
+| CoT | Chain-of-Thought，思维链条件 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+大行为模型泛化受**机器人数据覆盖不足**所限：
+- 协同训练（加异构数据）能扩覆盖；
+- 但**哪些模态、哪种策略**有效**理解不足**，缺系统证据。
+
+论文要：用**大规模、系统化**实验，厘清**协同训练**的数据模态与策略选择。
+
+---
+
+## 🔧 方法详解
+
+### 1. 五类协同训练数据模态
+**视觉-语言数据、稠密语言标注、跨本体机器人数据、人类视频、离散动作 token**——系统比较各自作用。
+
+### 2. 单/多阶段训练策略 + VLA 架构
+比较**单阶段 vs 多阶段**训练策略，基于**VLA 策略架构**。
+
+### 3. 大规模评测
+**4000 小时**机器人/人类数据 + **5000 万**视觉-语言样本；**89 个策略**、**5.8 万仿真 + 2835 真机** rollout。
+
+### 4. 主要发现
+- **视觉-语言 + 跨本体机器人数据**显著提升泛化（分布偏移/新任务/语言理解）；
+- **离散动作 token 收益甚微**；
+- **组合有效模态累加增益**；
+- **纯机器人训练损害视觉-语言能力，协同训练恢复**；
+- **CoT 条件无增益**（在其基准）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    subgraph MOD["五类协同训练模态"]
+        M1["视觉-语言"]
+        M2["稠密语言标注"]
+        M3["跨本体机器人"]
+        M4["人类视频"]
+        M5["离散动作 token"]
+    end
+    MOD --> TRAIN["VLA 协同训练(单/多阶段)"]
+    TRAIN --> EVAL["89 策略 · 5.8万仿真 + 2835 真机"]
+    EVAL --> OUT["📊 视觉-语言/跨本体最有效<br/>token 甚微 · 组合累加 · 协同恢复 VL 能力"]
+
+    style MOD fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **协同训练的系统性研究**：五模态 × 单/多阶段策略，大规模评测；
+2. **关键结论**：视觉-语言 + 跨本体数据最有效，离散动作 token 收益小；
+3. **组合累加 + 协同恢复**：有效模态可叠加，协同训练修复纯机器人训练的视觉-语言退化；
+4. **CoT 无增益**：在其基准上的反直觉发现。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"加什么数据"比"加更多数据"更重要**：视觉-语言与跨本体最划算；
+- **纯机器人训练会损害通用视觉-语言能力**——协同训练是必要的"保养"；
+- **离散动作 token / CoT 未必有用**，提醒不要盲目堆技巧；
+- 对人形 VLA/大行为模型的数据配方有直接指导（TRI 大规模实证）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2602.01067](https://arxiv.org/abs/2602.01067) | 论文正文（五模态、策略、89 策略大规模评测） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要与公开检索信息整理；**逐项数值（4000h/50M/89/58000/2835）以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·协同训练/数据**：[Sim-and-Real Co-Training](../Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation.md) · [Humanoid Policy ~ Human Policy](../Humanoid_Policy__Human_Policy/Humanoid_Policy__Human_Policy.md) · [Being-H0](../Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md)。

--- a/papers/06_Manipulation/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md
+++ b/papers/06_Manipulation/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md
@@ -1,0 +1,132 @@
+---
+layout: paper
+title: "Being-H0: Vision-Language-Action Pretraining from Large-Scale Human Videos"
+zhname: "Being-H0：从大规模人类视频做视觉-语言-动作预训练"
+category: "Manipulation"
+arxiv: "2507.15597"
+---
+
+# Being-H0: Vision-Language-Action Pretraining from Large-Scale Human Videos
+**把人手当作「基础操作器」，从网络规模人类视频学一个灵巧 VLA：提出「物理指令微调」范式——大规模人类视频 VLA 预训练 + 3D 推理的物理空间对齐 + 面向机器人任务的后训练适配；用部件级运动 token 化达毫米级重建精度建模手部轨迹，并构建融合动捕/VR/RGB 的百万级运动指令数据集，在手部动作生成与指令跟随上表现优异、随模型/数据规模扩展，并在真机操作上见效**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · VLA 预训练 · 人类视频 · 物理指令微调 · 运动 token 化 · 灵巧
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 7 月 |
+| arXiv | [2507.15597](https://arxiv.org/abs/2507.15597) · [PDF](https://arxiv.org/pdf/2507.15597) · [HTML](https://arxiv.org/html/2507.15597v1) |
+| 作者 | Hao Luo、Yicheng Feng、Wanpeng Zhang、Sipeng Zheng、Haoqi Yuan、Qin Jin、Zongqing Lu 等（北大 / BAAI 等） |
+| 主题 | cs.RO · VLA / 人类视频预训练 / 灵巧操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> Being-H0 是一个在**大规模人类视频**上训练的**灵巧视觉-语言-动作模型（VLA）**。现有 VLA 在**高灵巧操作**上吃力、对新场景泛化差，主因是依赖**有 sim-to-real 差距的合成数据**或**缺规模与多样性的遥操作演示**。为破数据瓶颈，本文把**人手当作基础操作器（foundation manipulator）**，利用网络数据中丰富的**灵巧性与可扩展性**。方法核心是**物理指令微调（physical instruction tuning）**：结合**大规模人类视频 VLA 预训练**、**3D 推理的物理空间对齐**、以及**面向机器人任务的后训练适配**。还提出**部件级运动 token 化（part-level motion tokenization）**，达**毫米级重建精度**以建模精确手部轨迹；并构建融合**动捕、VR、RGB-only 视频**的**百万级运动指令**数据集。实验显示 Being-H0 在**手部动作生成与指令跟随**上优异，随**模型与数据规模良好扩展**，并在**真机操作**上随物理指令微调见效。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| VLA | Vision-Language-Action 模型 |
+| Physical Instruction Tuning | 物理指令微调（本文范式） |
+| Motion Tokenization | 运动 token 化（部件级，毫米级精度） |
+| Foundation Manipulator | 基础操作器（人手） |
+| Physical Space Alignment | 物理空间对齐（3D 推理） |
+| Post-training Adaptation | 后训练适配到机器人任务 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+VLA 高灵巧操作难、泛化差：
+- 合成数据有 **sim-to-real 差距**；
+- 遥操作演示**缺规模与多样性**。
+
+Being-H0 要：把**人手**当基础操作器，从**网络规模人类视频**学灵巧 VLA，破数据瓶颈。
+
+---
+
+## 🔧 方法详解
+
+### 1. 物理指令微调（核心范式）
+三件套：
+- **大规模人类视频 VLA 预训练**；
+- **物理空间对齐**：让模型做 **3D 推理**；
+- **后训练适配**：迁到机器人任务。
+
+### 2. 部件级运动 token 化（毫米级）
+**部件级运动 token 化**达**毫米级重建精度**，精确建模手部轨迹，供动作学习。
+
+### 3. 多源数据管线
+融合**动捕、VR、RGB-only 视频**，构建**百万级**运动指令实例的大规模数据集。
+
+### 4. 结果
+- 手部动作生成与指令跟随优异；
+- 随**模型/数据规模**良好扩展；
+- 真机操作随物理指令微调见效。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DATA["动捕/VR/RGB 视频<br/>百万级运动指令"] --> PIT
+    subgraph PIT["物理指令微调"]
+        P1["人类视频 VLA 预训练"]
+        P2["物理空间对齐(3D 推理)"]
+        P3["机器人后训练适配"]
+        TOK["部件级运动 token 化(mm 级)"]
+    end
+    PIT --> OUT["🤖 手部动作生成 + 指令跟随<br/>随规模扩展 · 真机见效"]
+
+    style PIT fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **人手作基础操作器**：从网络规模人类视频学灵巧 VLA；
+2. **物理指令微调**：VLA 预训练 + 物理空间对齐 + 机器人适配；
+3. **部件级运动 token 化**：毫米级精度建模手轨迹；
+4. **百万级多源数据 + 规模化**：动捕/VR/RGB，随规模扩展、真机见效。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"人手 = 基础操作器"**是把网络视频转成操作先验的有力视角；
+- **物理空间对齐**让 2D 视频学到 3D 可执行动作，弥合 sim-to-real；
+- **运动 token 化**把连续手轨离散化，便于 VLA 建模；
+- 与 H-RDT、In-N-On 等共同壮大"人类视频 → 灵巧操作"路线。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2507.15597](https://arxiv.org/abs/2507.15597) | 论文正文（物理指令微调、运动 token 化、数据管线、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·人类数据 VLA**：[H-RDT](../H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md) · [In-N-On·Human0](../In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md) · [EgoDex](../EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md)。

--- a/papers/06_Manipulation/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection.md
+++ b/papers/06_Manipulation/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "DexHub and DART: Towards Internet Scale Robot Data Collection"
+zhname: "DexHub 与 DART：迈向互联网规模的机器人数据采集"
+category: "Manipulation"
+arxiv: "2411.02214"
+---
+
+# DexHub and DART: Towards Internet Scale Robot Data Collection
+**构建通才机器人受制于数据稀缺；DART 是一个借云端仿真与增强现实做可扩展机器人数据采集的众包遥操作平台，数据自动存入意在成为公共仓库的云端数据库 DexHub；用户研究表明 DART 比真机遥操作吞吐更高、体力疲劳更低，并能成功 sim-to-real 迁移、对视觉扰动鲁棒**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 互联网规模采集 · 众包遥操作 · 云仿真 · AR · 公共数据库
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 11 月 |
+| arXiv | [2411.02214](https://arxiv.org/abs/2411.02214) · [PDF](https://arxiv.org/pdf/2411.02214) · [HTML](https://arxiv.org/html/2411.02214v1) |
+| 作者 | Younghyo Park、Jagdeep Singh Bhatia、Lars Ankile、Pulkit Agrawal（MIT） |
+| 主题 | cs.RO · 数据采集 / 云仿真 / 众包遥操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 构建**通才机器人系统**受制于**多样高质量数据的稀缺**。本文提出 **DART**：一个借**云端仿真**与**增强现实（AR）**做**可扩展机器人数据采集**的**众包遥操作平台**。采集的数据**自动存入** **DexHub** ——一个**云端托管数据库**，意在成为机器人学习的**公共仓库**。用户研究表明 DART 相比**真机遥操作**实现**更高采集吞吐、更低体力疲劳**，并能成功 **sim-to-real 迁移**、对**视觉扰动鲁棒**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| DART | 众包遥操作采集平台（云仿真 + AR） |
+| DexHub | 云端公共机器人数据仓库 |
+| Crowdsourcing | 众包 |
+| Cloud Simulation | 云端仿真 |
+| AR | 增强现实 |
+| Throughput | 采集吞吐量 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+通才机器人缺**互联网规模**数据：
+- 真机遥操作**吞吐低、疲劳高、难规模化**；
+- 缺**公共、可众包**的采集平台与仓库。
+
+DexHub/DART 要：用**云仿真 + AR 众包**采集，建**公共数据库**，迈向互联网规模。
+
+---
+
+## 🔧 方法详解
+
+### 1. DART：云仿真 + AR 众包遥操作
+**任何人**可经**云端仿真 + AR** 远程遥操作采集数据，不需本地机器人/仿真，天然可**众包、可扩展**。
+
+### 2. DexHub：云端公共数据库
+采集数据**自动入库 DexHub**，意在成为机器人学习的**公共仓库**。
+
+### 3. 验证
+- 用户研究：DART 比真机遥操作**吞吐更高、疲劳更低**；
+- **sim-to-real 迁移成功**、对**视觉扰动鲁棒**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    USERS["🌍 众包用户(AR)"] --> DART
+    subgraph DART["DART(云仿真 + AR)"]
+        T["可扩展遥操作采集"]
+    end
+    DART --> DEXHUB["DexHub 云端公共数据库"]
+    DEXHUB --> OUT["🤖 高吞吐/低疲劳<br/>sim-to-real + 视觉鲁棒"]
+
+    style DART fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **DART 众包采集平台**：云仿真 + AR，可扩展、低门槛；
+2. **DexHub 公共数据库**：意在成为机器人学习公共仓库；
+3. **优于真机遥操作**：吞吐更高、疲劳更低；
+4. **sim-to-real + 视觉鲁棒**：采集数据可迁移真机。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"云仿真 + AR 众包"是互联网规模采集的可行路径**，绕开本地硬件；
+- **公共数据库**对社区共享与基础模型训练意义重大；
+- 对人形（硬件稀缺）尤其友好；
+- 与 ARMADA（AR 无机器人采集）思路相通、规模更大。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2411.02214](https://arxiv.org/abs/2411.02214) | 论文正文（DART 平台、DexHub、用户研究） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·数据采集**：[ARMADA（AR 无机器人采集）](../ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition.md) · [TWIST2（本仓 07）](../../07_Teleoperation/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md)。

--- a/papers/06_Manipulation/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md
+++ b/papers/06_Manipulation/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "Dexterity from Smart Lenses: Multi-Fingered Robot Manipulation with In-the-Wild Human Demonstrations"
+zhname: "Dexterity from Smart Lenses：用智能眼镜的野外人类演示学多指操作"
+category: "Manipulation"
+arxiv: "2511.16661"
+---
+
+# Dexterity from Smart Lenses: Multi-Fingered Robot Manipulation with In-the-Wild Human Demonstrations
+**AINA 框架：用 Aria Gen 2 智能眼镜采集任何人、任何地点、任何环境的人类演示来学多指操作策略，无需机器人专属数据；借助眼镜的高清 RGB、机载 3D 头/手跟踪与立体深度，学一个基于 3D 点的策略，可直接部署（不需在线纠正、强化学习或仿真），对背景变化鲁棒，在 9 个日常操作任务上验证**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 多指操作 · 智能眼镜 · 野外人类演示 · 3D 点策略 · 直接部署
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 11 月 |
+| arXiv | [2511.16661](https://arxiv.org/abs/2511.16661) · [PDF](https://arxiv.org/pdf/2511.16661) · [HTML](https://arxiv.org/html/2511.16661v1) |
+| 作者 | Irmak Guzey、Haozhi Qi、Julen Urain、Lerrel Pinto、Jitendra Malik、Homanga Bharadhwaj 等（Meta / NYU / Berkeley） |
+| 主题 | cs.RO · 多指操作 / 第一视角人类演示 / 人到机器人 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文提出 **AINA** 框架，让机器人从 **Aria Gen 2 智能眼镜**采集的人类演示中学**操作策略**——核心主张是：现在可以**从任何人、任何地点、任何环境**采集的数据中学**多指策略**，**无需机器人专属数据**。借助 Aria Gen 2 的**高清 RGB 相机、机载 3D 头/手跟踪、立体深度估计**，AINA 学一个**基于 3D 点**的策略架构，可**直接部署**——**不需要在线纠正、强化学习或仿真**，且对**背景变化鲁棒**。在**9 个日常操作任务**上评测，与以往人到机器人策略学习方法对比并做设计消融：**仅用野外人类视频数据**训练的策略即可成功迁移到**多指机器人操作**，无需额外机器人训练数据。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| AINA | 本文框架名 |
+| Smart Lenses | 智能眼镜（Aria Gen 2） |
+| In-the-Wild | 野外，非受控的真实环境 |
+| Multi-Fingered | 多指（灵巧手） |
+| 3D Point Policy | 基于 3D 点的策略表示 |
+| Stereo Depth | 立体深度估计 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+多指操作数据贵：
+- 机器人专属采集成本高、难规模化；
+- 想**直接从野外人类演示**学，但有**具身差异**与**部署难**。
+
+AINA 要：用**智能眼镜**采集的**野外人类演示**学多指策略，**免机器人数据**、可**直接部署**。
+
+---
+
+## 🔧 方法详解
+
+### 1. Aria Gen 2 智能眼镜采集
+利用眼镜的**高清 RGB**、**机载 3D 头/手跟踪**、**立体深度**，从**任何人/地点/环境**采集人类演示——这是"野外可扩展"的来源。
+
+### 2. 基于 3D 点的策略
+学一个**基于 3D 点**的策略表示，把人手/物体的 3D 信息直接用于策略，缓解 2D 视角差异。
+
+### 3. 直接部署、对背景鲁棒
+**不需在线纠正、RL 或仿真**即可**直接部署**；对**背景变化鲁棒**。
+
+### 4. 评测
+- **9 个日常操作任务**；
+- 对比以往人到机器人方法 + 设计消融；
+- 仅用野外人类数据即成功迁移多指机器人。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    G["🕶️ Aria Gen 2 眼镜<br/>RGB + 3D 头/手 + 立体深度"] --> D["野外人类演示"]
+    D --> POL
+    subgraph POL["AINA：3D 点策略"]
+        P["3D 点表示"]
+    end
+    POL --> OUT["🤖 多指机器人直接部署<br/>免机器人数据 · 9 任务 · 背景鲁棒"]
+
+    style POL fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **智能眼镜野外演示学多指操作**：任何人/地点/环境，免机器人专属数据；
+2. **基于 3D 点的策略**：利用眼镜的 3D 头/手 + 深度缓解具身差异；
+3. **直接部署**：不需在线纠正、RL 或仿真，背景鲁棒；
+4. **9 任务验证**：仅野外人类数据即迁移多指机器人。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **智能眼镜把"人人可采"变为现实**：极大降低多指操作数据门槛；
+- **3D 点表示**是跨具身迁移的实用桥梁；
+- **免 RL/仿真直接部署**降低工程复杂度；
+- 与 In-N-On、EgoDex、EgoMI 等第一视角人类数据路线共同推进"从人类视频学操作"。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2511.16661](https://arxiv.org/abs/2511.16661) | 论文正文（AINA、3D 点策略、9 任务实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·第一视角人类数据学操作**：[In-N-On（野外 + 任务数据 Human0）](../In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md) · [EgoDex（大规模第一视角灵巧）](../EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md) · [EgoMI](../EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md)。

--- a/papers/06_Manipulation/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set.md
+++ b/papers/06_Manipulation/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "Dexterous Safe Control for Humanoids in Cluttered Environments via Projected Safe Set Algorithm"
+zhname: "用投影安全集算法实现杂乱环境中人形的灵巧安全控制"
+category: "Manipulation"
+arxiv: "2502.02858"
+---
+
+# Dexterous Safe Control for Humanoids in Cluttered Environments via Projected Safe Set Algorithm
+**在不牺牲性能的前提下确保人形安全：聚焦「灵巧安全」——用肢体级几何约束在杂乱环境中同时避外部碰撞与自碰撞；提出投影安全集算法 p-SSA 处理由此产生的大量约束，并以有原则的方式松弛冲突约束、最小化安全违例以保证可行控制；仿真与 Unitree G1 真机验证，能在挑战性场景中稳健运行、最小违例，且跨任务免调参泛化**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 安全控制 · 肢体级几何约束 · 自碰撞避免 · 杂乱环境 · Unitree G1
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 2 月 |
+| arXiv | [2502.02858](https://arxiv.org/abs/2502.02858) · [PDF](https://arxiv.org/pdf/2502.02858) · [HTML](https://arxiv.org/html/2502.02858v1) |
+| 作者 | Rui Chen、Yifan Sun、Changliu Liu（CMU） |
+| 主题 | cs.RO · 安全控制 / 碰撞避免 / 人形 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 在真实应用中**确保人形安全**且**不牺牲性能**至关重要。本文考虑**灵巧安全（dexterous safety）**问题，特点是**肢体级（limb-level）几何约束**，用于在**杂乱环境**中同时避免**外部碰撞与自碰撞**。为处理"确保碰撞避免"时产生的**大量约束**，提出**投影安全集算法（Projected Safe Set Algorithm, p-SSA）**；针对约束**不可行（infeasibility）**问题，以**有原则的方式松弛冲突约束**，**最小化安全违例**以**保证可行的机器人控制**。在仿真与 **Unitree G1** 真机上验证：p-SSA 能让人形在**挑战性场景中稳健运行、最小违例**，并能**跨任务免调参泛化**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| p-SSA | Projected Safe Set Algorithm，投影安全集算法 |
+| Dexterous Safety | 灵巧安全（肢体级几何约束） |
+| Limb-level | 肢体级，按各肢体几何建约束 |
+| Self-collision | 自碰撞（机体各部分相撞） |
+| Infeasibility | 约束不可行（冲突） |
+| Safety Violation | 安全违例 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形在**杂乱环境**操作要**安全**：
+- 需**肢体级**避**外部碰撞 + 自碰撞**；
+- 约束**数量巨大**且可能**互相冲突（不可行）**；
+- 安全不能太保守而**牺牲性能**。
+
+论文要：一个能处理**大量、可能冲突**约束、**最小违例**且**保性能**的安全控制算法。
+
+---
+
+## 🔧 方法详解
+
+### 1. 灵巧安全：肢体级几何约束
+按**各肢体几何**建立约束，在杂乱环境中同时避**外部碰撞**与**自碰撞**——比整体包络更精细。
+
+### 2. p-SSA：投影安全集算法
+扩展经典安全控制，**投影**到安全集处理**大量约束**。
+
+### 3. 有原则地松弛冲突约束
+当约束**不可行（冲突）**时，**有原则地松弛**冲突约束，**最小化安全违例**，从而**保证可行控制**（不会无解卡死）。
+
+### 4. 验证
+- 仿真 + **Unitree G1** 真机；
+- 挑战性场景**稳健、最小违例**；
+- **跨任务免调参泛化**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    ENV["🗂️ 杂乱环境 + 肢体级几何"] --> CONS["大量约束<br/>(避外碰 + 自碰)"]
+    CONS --> PSSA
+    subgraph PSSA["p-SSA 投影安全集"]
+        R["有原则松弛冲突约束<br/>最小化违例 → 保证可行"]
+    end
+    PSSA --> OUT["🤖 Unitree G1<br/>稳健 + 最小违例 · 跨任务免调参"]
+
+    style PSSA fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **灵巧安全问题**：肢体级几何约束，避外部 + 自碰撞；
+2. **p-SSA 算法**：投影安全集处理大量约束；
+3. **有原则松弛冲突约束**：最小化违例、保证可行控制；
+4. **真机验证 + 免调参泛化**：G1 杂乱场景稳健。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"约束太多会不可行"是安全控制的真问题**，有原则的松弛比硬失败更实用；
+- **肢体级几何**对高自由度人形的自碰撞避免必不可少；
+- **免调参跨任务**的安全层利于工程复用；
+- 与学习类控制互补：安全控制作"护栏"，学习作"性能"。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2502.02858](https://arxiv.org/abs/2502.02858) | 论文正文（灵巧安全、p-SSA、G1 实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **相关·安全/碰撞**：[Collision-Free Humanoid Traversal（本仓 04）](../../04_Loco-Manipulation_and_WBC/Collision-Free_Humanoid_Traversal_in_Cluttered_Indoor_Scenes/Collision-Free_Humanoid_Traversal_in_Cluttered_Indoor_Scenes.md)；
+- **安全门控（本仓 04）**：[SafeFlow](../../04_Loco-Manipulation_and_WBC/SafeFlow__Real-Time_Text-Driven_Humanoid_Whole-Body_Control_via_Physics-Guided_Rectified_Flow/SafeFlow__Real-Time_Text-Driven_Humanoid_Whole-Body_Control_via_Physics-Guided_Rectified_Flow.md)。

--- a/papers/06_Manipulation/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md
+++ b/papers/06_Manipulation/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md
@@ -1,0 +1,132 @@
+---
+layout: paper
+title: "DreamGen: Unlocking Generalization in Robot Learning through Video World Models"
+zhname: "DreamGen：用视频世界模型解锁机器人学习的泛化"
+category: "Manipulation"
+arxiv: "2505.12705"
+---
+
+# DreamGen: Unlocking Generalization in Robot Learning through Video World Models
+**一个简单而高效的四阶段流水线，用「视频世界模型」生成的「神经轨迹」训练能跨行为、跨环境泛化的机器人策略：把图像到视频生成模型适配到目标本体生成逼真合成视频，再用潜动作模型或逆动力学模型恢复伪动作序列，并提出 DreamGen Bench 评测视频生成；仅用单一取放任务的遥操作数据，就让人形在已见/未见环境完成 22 种新行为**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 视频世界模型 · 神经轨迹 · 合成数据 · 泛化 · 人形
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 5 月 |
+| arXiv | [2505.12705](https://arxiv.org/abs/2505.12705) · [PDF](https://arxiv.org/pdf/2505.12705) · [HTML](https://arxiv.org/html/2505.12705v1) |
+| 作者 | Joel Jang、Seonghyeon Ye、Ajay Mandlekar、Yuke Zhu、Linxi Fan、Dieter Fox、Jan Kautz 等（NVIDIA） |
+| 主题 | cs.RO · 视频世界模型 / 合成数据 / 泛化 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> DreamGen 是一个**简单而高效的四阶段流水线**，通过**神经轨迹（neural trajectories）**——由**视频世界模型**生成的**合成机器人数据**——训练能**跨行为、跨环境泛化**的机器人策略。流程：① 用**图像到视频生成模型**；② 把模型**适配到目标机器人本体**，生成**逼真合成视频**；③ 用**潜动作模型（latent action model）**或**逆动力学模型（inverse-dynamics model）**从视频中**恢复伪动作序列**；④ 用这些数据训练策略。还提出 **DreamGen Bench** 评测视频生成质量。实验中，仅用**单一取放任务、单一环境**的遥操作数据，DreamGen 就让**人形**在**已见与未见环境**完成 **22 种新行为**，展示强**行为与环境泛化**，为**超越人工采集**地扩展机器人学习开辟新路径。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Video World Model | 视频世界模型，生成未来视频 |
+| Neural Trajectory | 神经轨迹，生成的合成机器人数据 |
+| Latent Action Model | 潜动作模型，从视频推动作 |
+| Inverse-Dynamics | 逆动力学模型，从状态变化推动作 |
+| Pseudo-action | 伪动作，恢复出的动作标签 |
+| DreamGen Bench | 本文视频生成评测基准 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+机器人策略泛化差、数据采集贵：
+- 真实采集**少行为、少环境**；
+- 想**跨行为/跨环境泛化**，但缺数据。
+
+DreamGen 要：用**视频世界模型**生成**带动作标签**的合成数据，**最小真实采集**就解锁泛化。
+
+---
+
+## 🔧 方法详解
+
+### 1. 四阶段流水线
+| 阶段 | 内容 |
+|---|---|
+| ① | 用**图像到视频生成模型** |
+| ② | **适配到目标本体**，生成逼真合成视频 |
+| ③ | 用**潜动作/逆动力学模型恢复伪动作** |
+| ④ | 用"视频 + 伪动作"训练策略 |
+
+### 2. 神经轨迹 = 合成机器人数据
+视频世界模型生成的**神经轨迹**充当合成训练数据，带恢复出的**伪动作**。
+
+### 3. DreamGen Bench
+提出**DreamGen Bench**系统评测**视频生成**质量。
+
+### 4. 结果
+仅用**单任务单环境**遥操作数据，人形完成**22 种新行为**（已见 + 未见环境），强泛化。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    SEED["单任务单环境遥操作数据"] --> I2V
+    subgraph DG["DreamGen 四阶段"]
+        I2V["①②图像→视频生成 + 适配本体"]
+        ACT["③潜动作/逆动力学恢复伪动作"]
+        I2V --> ACT
+    end
+    ACT --> TRAIN["④训练策略(神经轨迹)"]
+    TRAIN --> OUT["🤖 人形 22 种新行为<br/>已见+未见环境泛化"]
+
+    style DG fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **视频世界模型生成神经轨迹**：合成机器人数据训练策略；
+2. **四阶段流水线**：生成→适配本体→恢复伪动作→训练；
+3. **DreamGen Bench**：评测视频生成质量；
+4. **强泛化**：单任务单环境数据 → 人形 22 种新行为。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"视频世界模型 + 伪动作恢复"是扩数据的新范式**：把生成视频变成可训练的动作数据；
+- **跨行为/跨环境泛化**直击机器人学习的核心痛点；
+- **最小真实数据 → 大量合成行为**性价比极高；
+- 与 Humanoid World Models、DexMimicGen 等生成/世界模型工作呼应（同 NVIDIA 系）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2505.12705](https://arxiv.org/abs/2505.12705) | 论文正文（四阶段、神经轨迹、DreamGen Bench、人形实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（22 行为）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块/相关·世界模型/数据生成**：[Humanoid World Models（本仓 11）](../../11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md) · [DexMimicGen](../../11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md)。

--- a/papers/06_Manipulation/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization.md
+++ b/papers/06_Manipulation/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization.md
@@ -1,0 +1,122 @@
+---
+layout: paper
+title: "EgoDemoGen: Egocentric Demonstration Generation for Viewpoint Generalization in Robotic Manipulation"
+zhname: "EgoDemoGen：为操作视角泛化生成第一视角演示"
+category: "Manipulation"
+arxiv: "2509.22578"
+---
+
+# EgoDemoGen: Egocentric Demonstration Generation for Viewpoint Generalization in Robotic Manipulation
+**模仿学习的视觉运动策略对第一视角视角变化敏感，EgoDemoGen 在不需多视角数据的情况下生成「新第一视角下的观测-动作配对演示」：EgoTrajTransfer 用运动技能分割 + 几何感知变换 + 逆运动学滤波把机器人轨迹迁到新第一视角，EgoViewTransfer 用条件视频生成融合新视角重投影场景与渲染机器人运动合成逼真观测；仿真成功率 +24.6/16.9%、真机 +16/23%**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 视角泛化 · 第一视角演示生成 · 轨迹迁移 · 视频生成
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 9 月 |
+| arXiv | [2509.22578](https://arxiv.org/abs/2509.22578) · [PDF](https://arxiv.org/pdf/2509.22578) · [HTML](https://arxiv.org/html/2509.22578v1) |
+| 作者 | Yuan Xu、Jiabing Yang、Xiaofeng Wang、Zheng Zhu、Yan Huang、Liang Wang 等 |
+| 主题 | cs.RO · 视角泛化 / 演示生成 / 视频合成 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 基于模仿学习的**视觉运动策略**表现强，但常对**第一视角视角变化（egocentric viewpoint shifts）敏感**。EgoDemoGen 是一个框架，在**无需多视角数据**的前提下，生成**新第一视角下的「观测-动作」配对演示**。它由两部分组成：① **EgoTrajTransfer**——用**运动技能分割 + 几何感知变换 + 逆运动学滤波**，把机器人轨迹**迁移到新第一视角帧**；② **EgoViewTransfer**——一个**条件视频生成模型**，把**新视角重投影的场景**与**渲染的机器人运动**融合，合成**逼真观测**。实验：仿真策略成功率绝对提升 **+24.6% 与 +16.9%**；真机在不同视角条件下提升 **+16.0% 与 +23.0%**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Viewpoint Generalization | 视角泛化，应对视角变化 |
+| EgoTrajTransfer | 轨迹迁移到新第一视角 |
+| EgoViewTransfer | 条件视频生成新视角观测 |
+| IK Filtering | 逆运动学滤波 |
+| Geometry-aware | 几何感知变换 |
+| Paired Demo | 观测-动作配对演示 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+视觉运动策略**对第一视角视角变化敏感**：
+- 头部/相机视角一变，策略就退化；
+- 采集**多视角数据**昂贵。
+
+EgoDemoGen 要：**无需多视角数据**，**生成**新视角下的配对演示来提升视角泛化。
+
+---
+
+## 🔧 方法详解
+
+### 1. EgoTrajTransfer：轨迹迁到新视角
+用**运动技能分割 + 几何感知变换 + 逆运动学滤波**，把机器人轨迹迁移到**新第一视角帧**，得到新视角下的动作。
+
+### 2. EgoViewTransfer：合成逼真新视角观测
+一个**条件视频生成模型**，融合**新视角重投影场景**与**渲染机器人运动**，合成**逼真观测**，与迁移的动作配对。
+
+### 3. 结果（无需多视角数据）
+- **仿真**：+24.6%、+16.9%；
+- **真机**：+16.0%、+23.0%（不同视角条件）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    ORIG["原视角机器人轨迹"] --> TT["EgoTrajTransfer<br/>(技能分割+几何变换+IK滤波)"]
+    TT --> VT["EgoViewTransfer<br/>(条件视频生成新视角观测)"]
+    VT --> PAIR["新视角观测-动作配对演示"]
+    PAIR --> OUT["🤖 视角泛化<br/>仿真 +24.6/16.9% · 真机 +16/23%"]
+
+    style TT fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style VT fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **无需多视角数据的视角泛化**：生成新第一视角配对演示；
+2. **EgoTrajTransfer**：技能分割 + 几何变换 + IK 滤波迁移轨迹；
+3. **EgoViewTransfer**：条件视频生成逼真新视角观测；
+4. **显著提升**：仿真 +24.6/16.9%、真机 +16/23%。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **视角敏感是视觉运动策略的通病**，尤其第一视角人形；
+- **"生成数据补视角"**比采集多视角更省；
+- **轨迹迁移 + 视频生成**组合是合成配对演示的有效范式；
+- 与 EgoMI（主动视觉）从不同角度解决视角问题。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2509.22578](https://arxiv.org/abs/2509.22578) | 论文正文（EgoTrajTransfer、EgoViewTransfer、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·视角/主动视觉**：[EgoMI（主动视觉头手协调）](../EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md) · [Masquerade（编辑人类视频）](../Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md)。

--- a/papers/06_Manipulation/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md
+++ b/papers/06_Manipulation/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "EgoDex: Learning Dexterous Manipulation from Large-Scale Egocentric Video"
+zhname: "EgoDex：从大规模第一视角视频学习灵巧操作"
+category: "Manipulation"
+arxiv: "2505.11709"
+---
+
+# EgoDex: Learning Dexterous Manipulation from Large-Scale Egocentric Video
+**用 Apple Vision Pro 采集迄今最大、最多样的人类灵巧操作数据集：829 小时第一视角视频，录制时即配 3D 手与手指跟踪（多标定相机 + 机载 SLAM 精确跟踪每个关节），覆盖 194 个桌面任务（从系鞋带到叠衣服）；并训练评测手部轨迹预测的模仿学习策略、建立度量与基准，数据集公开**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 第一视角数据集 · 灵巧操作 · Apple Vision Pro · 手姿跟踪 · 开源
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 5 月 |
+| arXiv | [2505.11709](https://arxiv.org/abs/2505.11709) · [PDF](https://arxiv.org/pdf/2505.11709) · [HTML](https://arxiv.org/html/2505.11709v1) |
+| 代码 | [github.com/apple/ml-egodex](https://github.com/apple/ml-egodex) |
+| 作者 | Ryan Hoque、Peide Huang、David J. Yoon、Mouli Sivapurapu、Jian Zhang（Apple） |
+| 主题 | cs.RO · 第一视角数据集 / 灵巧操作 / 模仿学习 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 操作模仿学习有**数据稀缺**问题：不像语言/2D 视觉有互联网规模语料，灵巧操作没有。**第一视角人类视频**是被动可扩展的诱人来源，但现有大数据集（如 Ego4D）**无原生手姿标注**、也**不聚焦物体操作**。为此，作者用 **Apple Vision Pro** 采集 **EgoDex** ——**迄今最大、最多样**的人类灵巧操作数据集：**829 小时**第一视角视频，**录制时即配 3D 手与手指跟踪**（多台**标定相机 + 机载 SLAM** 精确跟踪**每只手每个关节**的位姿）。数据覆盖**194 个桌面任务**（从**系鞋带**到**叠衣服**）的多样操作行为。作者还在该数据上**训练并系统评测**用于**手部轨迹预测**的模仿学习策略，引入**度量与基准**。数据集**公开下载**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| EgoDex | 本文数据集 |
+| Egocentric | 第一视角 |
+| 3D Hand/Finger Tracking | 3D 手与手指跟踪 |
+| SLAM | 同步定位与建图（机载） |
+| Hand Trajectory Prediction | 手部轨迹预测任务 |
+| Apple Vision Pro | 采集硬件 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+灵巧操作缺**互联网规模数据**：
+- Ego4D 等大数据集**无手姿标注、不聚焦操作**；
+- 缺**带精确 3D 手姿**的大规模灵巧操作数据。
+
+EgoDex 要：用 Vision Pro 采集**带 3D 手姿**的**大规模多样**灵巧操作数据集。
+
+---
+
+## 🔧 方法详解
+
+### 1. Apple Vision Pro 采集 + 精确手姿
+用 **Vision Pro**，**录制时即配 3D 手/手指跟踪**：多台**标定相机 + 机载 SLAM** 精确跟踪**每个关节**位姿——避免事后估计的误差。
+
+### 2. 规模与多样性
+**829 小时**视频、**194 个桌面任务**（系鞋带、叠衣服等），覆盖丰富日常操作行为。
+
+### 3. 基准：手部轨迹预测
+在数据上**训练并系统评测**模仿学习策略做**手部轨迹预测**，引入**度量与基准**。
+
+### 4. 开源
+数据集**公开**（apple/ml-egodex）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    VP["🥽 Apple Vision Pro<br/>多标定相机 + 机载 SLAM"] --> DATA
+    subgraph DATA["EgoDex 数据集"]
+        D["829h 视频 + 3D 手/指跟踪<br/>194 桌面任务"]
+    end
+    DATA --> BENCH["手部轨迹预测 IL 策略<br/>度量 + 基准"]
+    BENCH --> OUT["📊 最大灵巧操作数据集 · 公开"]
+
+    style DATA fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **迄今最大灵巧操作数据集**：829h、194 任务、3D 手姿；
+2. **录制即配精确手姿**：标定相机 + SLAM，免事后估计误差；
+3. **手部轨迹预测基准**：度量 + IL 策略评测；
+4. **开源**：推动机器人/视觉/基础模型。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **精确 3D 手姿是灵巧操作数据的金标准**，Vision Pro 让其规模化可行；
+- **数据集 + 基准**是子领域进步的基础设施；
+- 第一视角灵巧数据是人形操作的关键先验，与 Being-H0、H-RDT 等下游方法配套；
+- Apple 等大厂入场，提示该方向的工业关注。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2505.11709](https://arxiv.org/abs/2505.11709) | 论文正文（采集、数据集、轨迹预测基准） |
+| [github.com/apple/ml-egodex](https://github.com/apple/ml-egodex) | 公开数据集 |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（829h/194 任务）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·第一视角灵巧数据**：[Being-H0](../Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md) · [H-RDT](../H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md) · [Dexterity from Smart Lenses](../Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md)。

--- a/papers/06_Manipulation/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md
+++ b/papers/06_Manipulation/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "EgoMI: Learning Active Vision and Whole-Body Manipulation from Egocentric Human Demonstrations"
+zhname: "EgoMI：从第一视角人类演示学习主动视觉与全身操作"
+category: "Manipulation"
+arxiv: "2511.00153"
+---
+
+# EgoMI: Learning Active Vision and Whole-Body Manipulation from Egocentric Human Demonstrations
+**人在操作时会主动协调头与手、用动态视角变化与视觉搜索；EgoMI 捕捉同步的「末端 + 头部」轨迹并可迁移到半人形机器人，引入一个会选择性纳入历史观测的「记忆增强策略」来应对快速视角切换；在带可动相机头的双臂机器人上验证，显式建模头部运动的策略持续优于基线，有效弥合人-机具身差距**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 主动视觉 · 头手协调 · 记忆增强策略 · 第一视角 · 半人形
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 11 月 |
+| arXiv | [2511.00153](https://arxiv.org/abs/2511.00153) · [PDF](https://arxiv.org/pdf/2511.00153) · [HTML](https://arxiv.org/html/2511.00153v1) |
+| 作者 | Justin Yu、Yide Shentu、Di Wu、Pieter Abbeel、Ken Goldberg、Philipp Wu（UC Berkeley） |
+| 主题 | cs.RO · 主动视觉 / 全身操作 / 第一视角学习 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 机器人从人类视频学操作，要跨越**具身差距**。人在做任务时会**主动协调头与手**，用**动态视角变化**与**视觉搜索**策略。EgoMI 捕捉**同步的末端执行器与头部轨迹**，可**迁移到半人形机器人**；并引入一个**记忆增强策略（memory-augmented policy）**，**选择性纳入历史观测**以应对**视角切换**。在**带可动相机头的双臂机器人**上测试：**显式建模头部运动**的策略**持续优于**基线，说明**协调的手眼学习**能有效**弥合人-机具身差距**（针对半人形）。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Active Vision | 主动视觉，主动调整视角/搜索 |
+| Head-Hand Coordination | 头手协调 |
+| Memory-Augmented | 记忆增强，选择性用历史观测 |
+| Embodiment Gap | 具身差距，人与机器人形态差异 |
+| Actuated Camera Head | 可动相机头 |
+| Semi-humanoid | 半人形（双臂 + 可动头） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+从人类视频学操作有**具身差距**，且：
+- 人会**主动协调头与手**（动态视角、视觉搜索），机器人若忽略则学不好；
+- **视角快速切换**让策略难以利用历史观测。
+
+EgoMI 要：把**头部主动运动**显式建模，并用**记忆**应对视角切换，迁移到半人形。
+
+---
+
+## 🔧 方法详解
+
+### 1. 同步捕捉末端 + 头部轨迹
+捕捉**同步的末端执行器与头部轨迹**，把"手在哪 + 头看哪"一起记录，可**重定向到半人形**机器人。
+
+### 2. 记忆增强策略（应对视角切换）
+引入**记忆增强策略**，**选择性纳入历史观测**——当视角快速变化时，用历史帧补全信息，稳住决策。
+
+### 3. 显式头部运动建模
+在模仿学习中**显式建模头部运动**，而非只学手部动作。
+
+### 4. 评测
+- **带可动相机头的双臂机器人**；
+- 有/无头部运动建模对比；
+- **显式头部建模持续优于基线**，弥合具身差距。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    H["👁️🖐️ 第一视角人类演示<br/>同步末端 + 头部轨迹"] --> RT["重定向到半人形"]
+    RT --> POL
+    subgraph POL["记忆增强策略"]
+        M["选择性纳入历史观测<br/>(应对视角切换)"]
+        HD["显式头部运动建模"]
+    end
+    POL --> OUT["🤖 双臂+可动头机器人<br/>显式头部建模 > 基线"]
+
+    style POL fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **同步末端 + 头部轨迹捕捉**：把主动视觉纳入学习；
+2. **记忆增强策略**：选择性用历史观测应对视角切换；
+3. **显式头部运动建模**：弥合人-机具身差距；
+4. **半人形验证**：可动相机头双臂机器人上优于基线。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **主动视觉（头手协调）是人类操作的隐藏要素**，忽略它会限制从人类视频学习的上限；
+- **记忆增强**对视角动态变化的任务很关键；
+- **半人形（双臂 + 可动头）**是连接人类数据与人形的实用载体；
+- 与 Vision in Action、Learning to Look 等主动感知工作呼应。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2511.00153](https://arxiv.org/abs/2511.00153) | 论文正文（同步轨迹、记忆策略、头部建模实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·主动感知/第一视角**：[Vision in Action（从人类演示学主动感知）](../Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md) · [Learning to Look（信息寻求决策）](../Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.md)。

--- a/papers/06_Manipulation/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.md
+++ b/papers/06_Manipulation/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "Endowing GPT-4 with a Humanoid Body: Building the Bridge Between Off-the-Shelf VLMs and the Physical World"
+zhname: "给 GPT-4 一具人形身体：在现成 VLM 与物理世界间架桥"
+category: "Manipulation"
+arxiv: "2511.00041"
+---
+
+# Endowing GPT-4 with a Humanoid Body: Building the Bridge Between Off-the-Shelf VLMs and the Physical World
+**BiBo 系统让 GPT-4 这类视觉语言模型直接控制人形：不靠海量训练数据，而是借 VLM 的强开放世界泛化降低数据需求；由「具身指令编译器」把高层用户命令翻译成低层运动参数，再由「基于扩散的运动执行器」生成对环境反馈自适应的拟人动作；开放环境交互成功率 90.2%，文本引导动作执行精度较此前方法提升 16.3%**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 现成 VLM · 具身指令编译 · 扩散运动执行 · 开放世界 · 免大数据
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 11 月 |
+| arXiv | [2511.00041](https://arxiv.org/abs/2511.00041) · [PDF](https://arxiv.org/pdf/2511.00041) · [HTML](https://arxiv.org/html/2511.00041v1) |
+| 作者 | Yingzhao Jian、Zhongan Wang、Yi Yang、Hehe Fan（浙江大学） |
+| 主题 | cs.RO · 现成 VLM 控制 / 具身指令 / 扩散运动 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文提出 **BiBo** 系统，让 **GPT-4** 这类**视觉语言模型（VLM）**直接**控制人形机器人**。与其收集海量训练数据，BiBo 利用 VLM **强大的开放世界泛化**来**降低数据采集需求**。系统包含两部分：① **具身指令编译器（embodied instruction compiler）**——把**高层用户命令**翻译成**低层运动参数**；② **基于扩散的运动执行器（diffusion-based motion executor）**——生成**对环境反馈自适应**的**拟人动作**。结果：在开放环境的**交互任务成功率 90.2%**；**文本引导的动作执行精度**较此前方法**提升 16.3%**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| BiBo | 本文系统名 |
+| Off-the-shelf VLM | 现成视觉语言模型（如 GPT-4） |
+| Instruction Compiler | 指令编译器，高层命令→低层参数 |
+| Diffusion Executor | 扩散运动执行器 |
+| Open-world Generalization | 开放世界泛化 |
+| Adaptive Motion | 自适应（对环境反馈）动作 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+让 VLM 控制人形通常需**海量具身数据**，成本高。论文问：
+- 能否**直接用现成 VLM**（不微调大数据）控制人形？
+- 如何把 VLM 的**语义/规划**接到**低层物理动作**且**对环境自适应**？
+
+BiBo 要：用现成 VLM 的开放世界泛化 + 轻量桥接，**少数据**地驱动人形。
+
+---
+
+## 🔧 方法详解
+
+### 1. 具身指令编译器（高层→低层）
+把**高层用户命令**经 VLM 推理**翻译成低层运动参数**，作为"语义→控制"的桥。
+
+### 2. 基于扩散的运动执行器（自适应拟人）
+**扩散运动执行器**依据运动参数与**环境反馈**生成**自适应、拟人**的动作，保证物理可执行与自然。
+
+### 3. 借 VLM 开放世界泛化降数据
+依赖现成 VLM 的**开放世界泛化**，**不需大规模具身数据收集**。
+
+### 4. 结果
+- 开放环境**交互成功率 90.2%**；
+- 文本引导动作**精度 +16.3%**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    U["🗣️ 高层用户命令"] --> COMP
+    subgraph BIBO["BiBo"]
+        COMP["具身指令编译器<br/>(VLM: 命令→低层运动参数)"]
+        EXEC["扩散运动执行器<br/>(环境反馈自适应拟人动作)"]
+        COMP --> EXEC
+    end
+    ENV["🌍 环境反馈"] --> EXEC
+    EXEC --> OUT["🤖 开放环境交互 90.2%<br/>文本引导精度 +16.3%"]
+
+    style BIBO fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **现成 VLM 直接控人形**：借开放世界泛化，免大规模具身数据；
+2. **具身指令编译器**：高层命令→低层运动参数；
+3. **扩散运动执行器**：环境反馈自适应、拟人；
+4. **强结果**：开放环境交互 90.2%、文本引导精度 +16.3%。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"现成 VLM + 轻量桥接"是低数据落地的诱人路线**：把通用模型能力借给具身；
+- **编译器 + 扩散执行器**分工清晰：语义规划 vs 物理执行；
+- **环境反馈自适应**是从"开环生成"走向"闭环可用"的关键；
+- 与 SENTINEL、FRoM-W1 等语言-动作工作互为对照（端到端 vs 借现成 VLM）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2511.00041](https://arxiv.org/abs/2511.00041) | 论文正文（BiBo、指令编译器、扩散执行器、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（90.2%/16.3%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·VLM/语言驱动操作**：[Hierarchical Vision-Language Planning](../Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.md)；
+- **语言-动作（本仓 04）**：[SENTINEL](../../04_Loco-Manipulation_and_WBC/SENTINEL__A_Fully_End-to-End_Language-Action_Model_for_Humanoid_Whole_Body_Control/SENTINEL__A_Fully_End-to-End_Language-Action_Model_for_Humanoid_Whole_Body_Control.md)。

--- a/papers/06_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md
+++ b/papers/06_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "H-RDT: Human Manipulation Enhanced Bimanual Robotic Manipulation"
+zhname: "H-RDT：用人类操作增强的双臂机器人操作"
+category: "Manipulation"
+arxiv: "2507.23523"
+---
+
+# H-RDT: Human Manipulation Enhanced Bimanual Robotic Manipulation
+**针对机器人演示数据稀缺、跨本体统一训练难，提出用「人类操作数据」增强机器人操作：核心洞察是带配对 3D 手姿标注的大规模第一视角人类操作视频蕴含丰富行为先验；两阶段——先在大规模第一视角人类数据上预训练，再用模块化动作编/解码器在机器人数据上做跨本体微调；2B 参数扩散 Transformer + 流匹配，仿真/真机较从零训练分别 +13.9%/+40.5%，超 Pi0 与 RDT**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 人类数据增强 · 双臂操作 · 扩散 Transformer · 流匹配 · 跨本体
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 7 月 |
+| arXiv | [2507.23523](https://arxiv.org/abs/2507.23523) · [PDF](https://arxiv.org/pdf/2507.23523) · [HTML](https://arxiv.org/html/2507.23523v1) |
+| 作者 | Hongzhe Bi、Lingxuan Wu、Tianwei Lin、Hengkai Tan、Hang Su、Jun Zhu 等（清华 TSAIL / 地平线等） |
+| 主题 | cs.RO · 人类增强操作 / 双臂 / VLA |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 机器人操作模仿学习面临**大规模高质量机器人演示稀缺**的根本难题。近期机器人基础模型常在**跨本体机器人数据**上预训练以扩规模，但**不同本体的形态与动作空间差异大**，统一训练难。H-RDT（**Human to Robotics Diffusion Transformer**）用**人类操作数据**增强机器人操作：核心洞察是**带配对 3D 手姿标注的大规模第一视角人类操作视频**蕴含丰富**行为先验**，能惠及机器人策略学习。采用**两阶段**：① 在**大规模第一视角人类操作数据**上**预训练**；② 用**模块化动作编/解码器**在**机器人专属数据**上做**跨本体微调**。模型是 **2B 参数的扩散 Transformer**，用**流匹配**建模复杂动作分布。仿真/真机较从零训练分别 **+13.9% / +40.5%**，超过 **Pi0** 与 **RDT** 基线。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| H-RDT | Human to Robotics Diffusion Transformer |
+| Bimanual | 双臂 |
+| 3D Hand Pose | 3D 手姿标注 |
+| Cross-Embodiment | 跨本体 |
+| Modular Encoder/Decoder | 模块化动作编/解码器 |
+| Flow Matching | 流匹配 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+机器人演示数据稀缺，跨本体统一训练难：
+- 直接跨本体机器人预训练受**形态/动作空间差异**限制；
+- 需要更**可扩展**的先验来源。
+
+H-RDT 要：用**大规模人类操作视频（含 3D 手姿）**作行为先验，增强机器人双臂操作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 洞察：人类视频 + 3D 手姿 = 行为先验
+**第一视角人类操作视频 + 配对 3D 手姿**捕捉**自然操作策略**，是比跨本体机器人数据更易扩展的先验。
+
+### 2. 两阶段训练
+- **预训练**：在**大规模第一视角人类操作数据**上；
+- **跨本体微调**：用**模块化动作编/解码器**适配机器人专属数据/动作空间。
+
+### 3. 架构：2B 扩散 Transformer + 流匹配
+**2B 参数扩散 Transformer**，用**流匹配**建模复杂动作分布。
+
+### 4. 结果
+- 仿真 **+13.9%**、真机 **+40.5%**（相对从零训练）；
+- 超 **Pi0、RDT**；单任务/多任务/少样本/鲁棒性均评测。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    H["🎥 第一视角人类操作视频<br/>+ 3D 手姿"] --> PRE["①预训练(行为先验)"]
+    PRE --> FT["②跨本体微调<br/>(模块化动作编/解码器)"]
+    FT --> M["2B 扩散 Transformer + 流匹配"]
+    M --> OUT["🤖 双臂操作<br/>仿真+13.9% 真机+40.5% · 超 Pi0/RDT"]
+
+    style M fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **人类数据增强机器人操作**：人类视频 + 3D 手姿作行为先验；
+2. **两阶段训练**：人类预训练 + 模块化跨本体微调；
+3. **2B 扩散 Transformer + 流匹配**：建模复杂动作分布；
+4. **显著提升**：仿真 +13.9%、真机 +40.5%，超 Pi0/RDT。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **人类视频比跨本体机器人数据更易扩展**：用它作预训练先验是聪明的绕过数据稀缺之道；
+- **模块化动作编/解码器**是跨本体微调的实用结构；
+- **扩散 Transformer + 流匹配**是当前 VLA/操作模型的主流；
+- 与 Being-H0、In-N-On 等"人类数据驱动操作"路线一致。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2507.23523](https://arxiv.org/abs/2507.23523) | 论文正文（两阶段训练、扩散 Transformer、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·人类数据 VLA**：[Being-H0（人类视频 VLA 预训练）](../Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md) · [In-N-On](../In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md)。

--- a/papers/06_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.md
+++ b/papers/06_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Hierarchical Vision-Language Planning for Multi-Step Humanoid Manipulation"
+zhname: "面向多步人形操作的分层视觉-语言规划"
+category: "Manipulation"
+arxiv: "2506.22827"
+---
+
+# Hierarchical Vision-Language Planning for Multi-Step Humanoid Manipulation
+**面向工业/家庭里可靠执行复杂多步操作的三层规划-控制框架：底层是基于 RL 的全身动作目标跟踪控制器，中层是模仿学习训练、为任务各步产生动作目标的技能策略，高层是用预训练 VLM 决定执行哪个技能并实时监控其完成的视觉-语言规划模块；在 Unitree G1 上做非抓握式取放任务、40+ 次真机试验，完整序列成功率 73%**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 分层规划 · VLM 监控 · 技能策略 · 全身控制 · Unitree G1
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 6 月 |
+| arXiv | [2506.22827](https://arxiv.org/abs/2506.22827) · [PDF](https://arxiv.org/pdf/2506.22827) · [HTML](https://arxiv.org/html/2506.22827v1) |
+| 作者 | André Schakkal、Ben Zandonati、Zhutian Yang、Navid Azizan（MIT） |
+| 主题 | cs.RO · 分层规划 / 视觉-语言 / 多步操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 让人形可靠执行**复杂多步操作**对工业/家庭部署很关键。本文提出一个**分层规划与控制框架**，含三层：① **底层**——基于 **RL** 的控制器，负责**跟踪全身动作目标**；② **中层**——一组用**模仿学习**训练的**技能策略**，为任务各步产生**动作目标**；③ **高层**——一个**视觉-语言规划模块**，用**预训练 VLM** 决定**执行哪个技能**并**实时监控其完成**。在 **Unitree G1** 人形上做**非抓握式（non-prehensile）取放**任务、**40+ 次**真机试验，**完整序列成功率 73%**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Hierarchical | 分层（高/中/低三层） |
+| VLM | Vision-Language Model |
+| Skill Policy | 技能策略（中层，IL 训练） |
+| Whole-Body Tracking | 全身动作目标跟踪（底层 RL） |
+| Non-prehensile | 非抓握式（推/拨等） |
+| Real-time Monitoring | 实时监控技能完成 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形**多步操作**要可靠：
+- 单层端到端难覆盖**长序列**；
+- 需要**高层决策 + 中层技能 + 底层控制**协同；
+- 还要**实时知道某步是否完成**。
+
+论文要：一个**分层、可监控**的多步人形操作框架。
+
+---
+
+## 🔧 方法详解
+
+### 1. 三层架构
+| 层 | 内容 |
+|---|---|
+| 底层 | **RL 控制器**跟踪全身动作目标 |
+| 中层 | **IL 技能策略**为各步产生动作目标 |
+| 高层 | **VLM 规划**：选技能 + 实时监控完成 |
+
+### 2. VLM 高层：选技能 + 监控
+用**预训练 VLM** 决定**执行哪个技能**，并**实时监控**其**完成情况**——把"决策 + 进度感知"交给 VLM。
+
+### 3. 评测
+- **Unitree G1**、**非抓握式取放**；
+- **40+ 真机试验**；
+- 完整序列**成功率 73%**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    HI["高层：VLM 规划<br/>选技能 + 实时监控完成"] --> MID
+    MID["中层：IL 技能策略<br/>产生各步动作目标"] --> LOW
+    LOW["底层：RL 控制器<br/>跟踪全身动作目标"] --> OUT["🤖 Unitree G1 非抓握取放<br/>40+ 试验 · 序列成功率 73%"]
+
+    style HI fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style MID fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style LOW fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **三层规划-控制框架**：VLM 规划 + IL 技能 + RL 全身控制；
+2. **VLM 高层选技能 + 实时监控完成**；
+3. **多步可靠执行**：面向工业/家庭长序列任务；
+4. **真机验证**：G1 非抓握取放，序列成功率 73%。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **分层是多步长序列任务的可靠之道**：高层决策、中层技能、底层控制各司其职；
+- **VLM 实时监控"某步是否完成"**是闭环关键，避免盲目推进；
+- **非抓握操作**（推/拨）拓展了人形操作类型；
+- 与 Proprio-MLLM、BiBo 等 VLM 规划工作互补。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2506.22827](https://arxiv.org/abs/2506.22827) | 论文正文（三层框架、VLM 监控、G1 实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（73%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·VLM/规划**：[本体感受感知具身规划](../Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots.md) · [给 GPT-4 一具人形身体·BiBo](../Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.md)。

--- a/papers/06_Manipulation/Humanoid_Policy__Human_Policy/Humanoid_Policy__Human_Policy.md
+++ b/papers/06_Manipulation/Humanoid_Policy__Human_Policy/Humanoid_Policy__Human_Policy.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "Humanoid Policy ~ Human Policy"
+zhname: "Humanoid Policy ~ Human Policy：人形策略≈人类策略"
+category: "Manipulation"
+arxiv: "2503.13441"
+---
+
+# Humanoid Policy ~ Human Policy
+**把第一视角人类演示当作跨本体训练数据来学人形操作策略：构建与人形任务对齐的第一视角人类数据集 PH2D，提出 Human Action Transformer（HAT）统一人类与人形的状态-动作表示并支持可微重定向，再与机器人数据协同训练；相比只用机器人数据，人类数据显著提升泛化与鲁棒、并大幅提高数据采集效率**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 跨本体 · 第一视角人类数据 · 统一状态-动作 · 可微重定向 · 协同训练
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.13441](https://arxiv.org/abs/2503.13441) · [PDF](https://arxiv.org/pdf/2503.13441) · [HTML](https://arxiv.org/html/2503.13441v1) |
+| 作者 | Ri-Zhao Qiu、Shiqi Yang、Xuxin Cheng、Tairan He、Ryan Hoque、Guanya Shi、Xiaolong Wang 等（UCSD / CMU 等） |
+| 主题 | cs.RO · 跨本体 / 人类数据 / 人形操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 用**多样数据**训练人形操作策略能增强**鲁棒与跨任务/跨平台泛化**。但只从**机器人演示**学很费力——需昂贵遥操作、难规模化。本文研究一种更可扩展的数据源：**第一视角人类演示**，作为机器人学习的**跨本体训练数据**。工作从**数据采集与建模**两方面弥合**具身差距**：① 引入与人形任务对齐的第一视角人类数据集 **PH2D**；② 提出 **Human Action Transformer（HAT）**，**统一人类与人形的状态-动作表示**，并具备**可微重定向**能力；再**与机器人数据协同训练**。相比只用机器人数据，**人类数据显著提升泛化与鲁棒**，且**大幅提高数据采集效率**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Cross-Embodiment | 跨本体（人↔人形） |
+| PH2D | 与人形任务对齐的第一视角人类数据集 |
+| HAT | Human Action Transformer |
+| Unified State-Action | 统一状态-动作表示 |
+| Differentiable Retargeting | 可微重定向 |
+| Co-training | 协同训练（人类 + 机器人数据） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+只用机器人演示训练人形操作**费力难扩展**：
+- 遥操作贵；
+- 想用**第一视角人类数据**，但有**具身差距**（状态/动作空间不同）。
+
+论文要：用**第一视角人类演示**作跨本体数据，弥合具身差距、提升人形操作。
+
+---
+
+## 🔧 方法详解
+
+### 1. PH2D：与人形任务对齐的人类数据集
+构建**第一视角人类数据集 PH2D**，与目标**人形任务对齐**，作为跨本体训练源。
+
+### 2. HAT：统一状态-动作 + 可微重定向
+**Human Action Transformer（HAT）**把**人类与人形**的**状态-动作统一**表示，并支持**可微重定向**——让人类动作可端到端转成人形动作。
+
+### 3. 与机器人数据协同训练
+把人类数据与机器人数据**协同训练**，兼得规模与对齐。
+
+### 4. 结果
+- 相比仅机器人数据：**泛化与鲁棒显著提升**；
+- **数据采集效率大幅提高**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    PH2D["👁️ PH2D 第一视角人类数据"] --> HAT
+    ROBOT["🤖 机器人数据"] --> HAT
+    subgraph HAT["Human Action Transformer"]
+        U["统一人类↔人形状态-动作<br/>+ 可微重定向"]
+    end
+    HAT --> OUT["🤖 人形操作<br/>泛化/鲁棒↑ · 采集效率↑"]
+
+    style HAT fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **第一视角人类数据作跨本体训练源**：可扩展、采集高效；
+2. **PH2D 数据集**：与人形任务对齐；
+3. **HAT 统一状态-动作 + 可微重定向**：端到端弥合具身差距；
+4. **协同训练显著增益**：泛化与鲁棒提升。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"人形策略≈人类策略"是有力的跨本体假设**：统一表示让人类数据直接可用；
+- **可微重定向**把"人→人形"做成可学模块，优于手工重定向；
+- **协同训练**兼得人类规模与机器人对齐；
+- 与 H-RDT、Being-H0、In-N-On 共同构成"人类数据驱动人形操作"的方法簇（作者群高度重叠）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.13441](https://arxiv.org/abs/2503.13441) | 论文正文（PH2D、HAT、协同训练实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·人类数据跨本体**：[H-RDT](../H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md) · [Being-H0](../Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md) · [EgoDex](../EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md)。

--- a/papers/06_Manipulation/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions.md
+++ b/papers/06_Manipulation/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "Humanoids in Hospitals: A Technical Study of Humanoid Robot Surrogates for Dexterous Medical Interventions"
+zhname: "Humanoids in Hospitals：人形机器人替身做灵巧医疗干预的技术研究"
+category: "Manipulation"
+arxiv: "2503.12725"
+---
+
+# Humanoids in Hospitals: A Technical Study of Humanoid Robot Surrogates for Dexterous Medical Interventions
+**探索人形机器人经遥操作执行医疗任务以缓解医护人力短缺：为 Unitree G1 搭建带位姿跟踪、定制抓取与阻抗控制的双臂系统，跨七类医疗流程（体检、急救干预、通气、超声引导、精密穿针）评测，结果显示人形能复现关键医疗评估、在通气与超声引导任务上有可观定量表现，但受力限与传感灵敏度制约影响临床精度**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 → 06 · 医疗人形 · 遥操作替身 · 双臂 · 阻抗控制 · Unitree G1
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.12725](https://arxiv.org/abs/2503.12725) · [PDF](https://arxiv.org/pdf/2503.12725) · [HTML](https://arxiv.org/html/2503.12725v1) |
+| 作者 | Soofiyan Atar、Xiao Liang、Calvin Joyce、Florian Richter、Michael Yip 等（UC San Diego） |
+| 主题 | cs.RO · 医疗人形 / 遥操作 / 灵巧干预 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文探索用**人形机器人**经**遥操作**执行医疗任务，以缓解**医护人力短缺**。研究为 **Unitree G1** 搭建一套**双臂系统**，集成**高保真位姿跟踪、定制抓取配置、阻抗控制器**（用于工具操作）。跨**七类医疗流程**评测——**体检、急救干预、通气（ventilation）、超声引导（ultrasound-guided）、精密穿针**等。结果显示：人形能**复现关键医疗评估**，在**通气与超声引导**任务上有**可观的定量表现**，但仍面临**力限**与**传感灵敏度**带来的挑战，影响**临床精度**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Surrogate | 替身，远程代替医护操作 |
+| Impedance Control | 阻抗控制，柔顺工具操作 |
+| Pose Tracking | 位姿跟踪 |
+| Ventilation | 通气（医疗操作） |
+| Ultrasound-guided | 超声引导操作 |
+| Needle Task | 穿针/进针任务 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+医护**人力短缺**，能否用**人形替身**远程做医疗操作？
+- 医疗任务**灵巧、精密、需柔顺**；
+- 不清楚现有人形（G1）能做到什么程度、卡在哪。
+
+论文要：搭建医疗双臂遥操作系统并**系统评测**人形做医疗干预的能力与局限。
+
+---
+
+## 🔧 方法详解
+
+### 1. Unitree G1 双臂医疗遥操作系统
+集成**高保真位姿跟踪 + 定制抓取 + 阻抗控制器**，让操作者远程驱动 G1 做医疗工具操作（阻抗控制保证柔顺）。
+
+### 2. 七类医疗流程评测
+覆盖**体检、急救干预、通气、超声引导、精密穿针**等七类，系统量化表现。
+
+### 3. 发现
+- 能**复现关键医疗评估**；
+- **通气、超声引导**有可观定量表现；
+- **力限 + 传感灵敏度**制约**临床精度**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DOC["🧑‍⚕️ 远程操作者"] --> SYS
+    subgraph SYS["Unitree G1 双臂医疗系统"]
+        P["位姿跟踪 + 定制抓取 + 阻抗控制"]
+    end
+    SYS --> EVAL["7 类医疗流程评测"]
+    EVAL --> OUT["🏥 复现关键评估<br/>通气/超声有可观表现<br/>受力限/传感灵敏度制约"]
+
+    style SYS fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **医疗人形遥操作系统**：G1 双臂 + 位姿跟踪 + 定制抓取 + 阻抗控制；
+2. **七类医疗流程系统评测**：体检/急救/通气/超声/穿针；
+3. **能力与局限并陈**：通气/超声可观，力限/传感制约精度；
+4. **医疗替身可行性研究**：面向人力短缺场景。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **医疗是高价值但高要求的人形落地场景**：需灵巧 + 柔顺 + 精密；
+- **阻抗控制**对接触/工具医疗操作不可或缺；
+- **力限与传感灵敏度**是当前硬件瓶颈，提示本体改进方向；
+- 系统性技术研究为后续自主化/学习化医疗操作奠基。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.12725](https://arxiv.org/abs/2503.12725) | 论文正文（系统、七类流程、定量评测） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·遥操作医疗/接触**：[Humanoid Visual-Tactile-Action Dataset](../A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.md)；
+- **柔顺/阻抗（本仓 04）**：[HMC（异构元控制）](../../04_Loco-Manipulation_and_WBC/HMC__Learning_Heterogeneous_Meta-Control_for_Contact-Rich_Loco-Manipulation/HMC__Learning_Heterogeneous_Meta-Control_for_Contact-Rich_Loco-Manipulation.md)。

--- a/papers/06_Manipulation/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md
+++ b/papers/06_Manipulation/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "In-N-On: Scaling Egocentric Manipulation with in-the-wild and on-task Data"
+zhname: "In-N-On：用「野外 + 任务对齐」数据规模化第一视角操作"
+category: "Manipulation"
+arxiv: "2511.15704"
+---
+
+# In-N-On: Scaling Egocentric Manipulation with in-the-wild and on-task Data
+**给「用第一视角人类视频学操作」一套可扩展配方：把人类数据分成「野外（in-the-wild）」与「任务对齐（on-task）」两类并系统分析如何使用；构建 PHSD 数据集（1000+ 小时野外 + 20+ 小时任务对齐），训练语言条件流匹配策略 Human0，并用域适应缩小人到人形的差距，涌现出「仅凭人类数据就能听语言指令」「少样本学习」「任务数据增强鲁棒」等新性质**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 第一视角 · 野外/任务数据 · 流匹配策略 · 语言条件 · 域适应
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 11 月 |
+| arXiv | [2511.15704](https://arxiv.org/abs/2511.15704) · [PDF](https://arxiv.org/pdf/2511.15704) · [HTML](https://arxiv.org/html/2511.15704v1) |
+| 作者 | Xiongyi Cai、Ri-Zhao Qiu、Geng Chen、Lai Wei、Tianshu Huang、Xuxin Cheng、Xiaolong Wang（UC San Diego） |
+| 主题 | cs.RO · 第一视角操作 / 数据规模化 / 流匹配 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 第一视角（egocentric）视频是学操作策略的**宝贵可扩展**数据源，但**数据异质性大**，多数方法只把人类数据用于**简单预训练**，没释放全部潜力。本文先给出一套**可扩展配方**：把人类数据分成两类——**野外（in-the-wild）**与**任务对齐（on-task）**，并系统分析**如何使用**。作者整理出数据集 **PHSD**，含 **1000+ 小时**多样**野外**第一视角数据与 **20+ 小时**直接对齐目标任务的**任务数据**。据此训练一个大型**语言条件流匹配策略 Human0**；配合**域适应**技术，**Human0** 缩小**人到人形**的差距。实证表明，规模化人类数据带来若干**新性质**：**仅凭人类数据就能听从语言指令**、**少样本学习**、以及用**任务数据**提升的**鲁棒性**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Egocentric | 第一视角（头戴视角） |
+| In-the-wild / On-task | 野外 / 任务对齐数据 |
+| PHSD | 本文数据集（1000h 野外 + 20h 任务） |
+| Human0 | 语言条件流匹配策略 |
+| Flow Matching | 流匹配生成策略 |
+| Domain Adaptation | 域适应，缩小人↔人形差距 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+第一视角人类数据潜力大但用不好：
+- **异质性大**，多数只做**简单预训练**；
+- 缺**如何分类与使用**数据的系统配方；
+- 人到人形有**域差距**。
+
+In-N-On 要：一套**可扩展配方**（野外 + 任务对齐）+ 数据集 + 策略，释放第一视角数据潜力。
+
+---
+
+## 🔧 方法详解
+
+### 1. 数据分类：野外 + 任务对齐
+把人类第一视角数据分成**野外（in-the-wild）**（多样、规模大）与**任务对齐（on-task）**（少量、直接对齐目标任务），并系统分析各自作用。
+
+### 2. PHSD 数据集
+整理 **PHSD**：**1000+ 小时野外** + **20+ 小时任务对齐**。
+
+### 3. Human0：语言条件流匹配 + 域适应
+训练大型**语言条件流匹配策略 Human0**；用**域适应**缩小**人↔人形**差距。
+
+### 4. 涌现新性质
+- **仅人类数据**即可**听语言指令**；
+- **少样本学习**；
+- **任务数据**提升**鲁棒性**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    W["1000h+ 野外第一视角"] --> PHSD
+    T["20h+ 任务对齐"] --> PHSD
+    subgraph PHSD["PHSD 数据 + Human0"]
+        H["语言条件流匹配 + 域适应"]
+    end
+    PHSD --> OUT["🤖 人到人形<br/>语言跟随 / 少样本 / 任务数据增鲁棒"]
+
+    style PHSD fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **可扩展第一视角数据配方**：野外 + 任务对齐两类 + 使用分析；
+2. **PHSD 数据集**：1000h 野外 + 20h 任务对齐；
+3. **Human0 语言条件流匹配 + 域适应**：缩小人↔人形差距；
+4. **涌现新性质**：仅人类数据听指令、少样本、任务数据增鲁棒。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"野外 + 任务对齐"二分**是用好海量人类数据的关键洞见：规模来自野外、对齐来自少量任务数据；
+- **语言条件 + 流匹配**让策略可指令驱动且高效；
+- **域适应**是人到人形落地的必备环节；
+- 与 Dexterity from Smart Lenses、EgoDex 等共同推进第一视角数据规模化。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2511.15704](https://arxiv.org/abs/2511.15704) | 论文正文（数据配方、PHSD、Human0、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·第一视角数据规模化**：[Dexterity from Smart Lenses](../Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md) · [Being-H0（VLA 预训练）](../Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md)。

--- a/papers/06_Manipulation/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.md
+++ b/papers/06_Manipulation/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "Learning Visuotactile Skills with Two Multifingered Hands"
+zhname: "用两只多指手学习视触觉技能"
+category: "Manipulation"
+arxiv: "2404.16823"
+---
+
+# Learning Visuotactile Skills with Two Multifingered Hands
+**为复刻人类灵巧、感知与动作模式，用一套带多指手与视触觉数据的双手系统从人类演示学习：开发低成本遥操作系统 HATO，把义肢手改装并加装触觉传感器以应对采集硬件难题；在需多指灵巧的长时程高精度任务上做模仿学习，并消融研究数据规模、感知模态与视觉预处理的影响，证明视觉+触觉结合能让机器人学到复杂双手操作**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 视触觉 · 双手多指 · 低成本遥操作 HATO · 义肢手 · 模仿学习
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 4 月 |
+| arXiv | [2404.16823](https://arxiv.org/abs/2404.16823) · [PDF](https://arxiv.org/pdf/2404.16823) · [HTML](https://arxiv.org/html/2404.16823v1) |
+| 作者 | Toru Lin、Yu Zhang、Qiyang Li、Haozhi Qi、Brent Yi、Sergey Levine、Jitendra Malik（UC Berkeley） |
+| 主题 | cs.RO · 视触觉 / 双手多指 / 模仿学习 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 为**复刻人类的灵巧、感知体验与动作模式**，本文用一套带**多指手与视触觉数据**的**双手系统**，从**人类演示**学习。为解决采集训练数据的硬件难题，作者开发了**低成本遥操作系统 HATO**（用现成部件搭建，高效采集双手数据），并把**义肢手（prosthetic hands）改装、加装触觉传感器**。在需**多指灵巧**的**长时程、高精度**操作任务上做**模仿学习**，并通过**消融研究**考察**数据规模、感知模态（视觉/触觉）重要性、视觉预处理**的影响。结果证明：**结合视觉与触觉反馈**能让机器人从人类演示学到**复杂双手操作技能**，推进多指灵巧控制的可行性。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Visuotactile | 视触觉（视觉 + 触觉） |
+| Multifingered | 多指（灵巧手） |
+| HATO | 本文低成本双手遥操作系统 |
+| Prosthetic Hand | 义肢手（改装 + 触觉传感器） |
+| Imitation Learning | 模仿学习 |
+| Ablation | 消融研究 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+双手多指**视触觉**操作难采数据、难学：
+- 多指手 + 触觉传感**硬件贵、难搭**；
+- 缺**低成本**采集系统；
+- 不清楚**触觉/视觉/数据规模**各自的贡献。
+
+论文要：低成本双手视触觉系统 + 从人类演示学复杂操作，并厘清各模态贡献。
+
+---
+
+## 🔧 方法详解
+
+### 1. HATO 低成本双手遥操作 + 触觉义肢手
+**HATO** 用现成部件搭建，高效采集双手数据；把**义肢手改装并加触觉传感器**，解决硬件难题。
+
+### 2. 视触觉模仿学习
+在**长时程、高精度**多指任务上做**模仿学习**，多模态（视觉 + 触觉）策略训练。
+
+### 3. 消融研究
+系统考察**数据规模、感知模态（视觉/触觉）、视觉预处理**对性能的影响。
+
+### 4. 结论
+**视觉 + 触觉结合**让机器人学到复杂双手操作，推进多指灵巧控制可行性。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    HATO["🕹️ HATO 低成本双手遥操作<br/>义肢手 + 触觉传感器"] --> DATA["视触觉双手演示"]
+    DATA --> IL["视触觉模仿学习"]
+    IL --> ABL["消融：数据规模/模态/视觉预处理"]
+    ABL --> OUT["🤖 长时程高精度双手操作<br/>视觉+触觉结合见效"]
+
+    style IL fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **HATO 低成本双手遥操作系统**：现成部件 + 触觉义肢手；
+2. **视触觉模仿学习**：长时程高精度多指任务；
+3. **系统消融**：数据规模、视觉/触觉模态、视觉预处理；
+4. **视觉+触觉协同**：学到复杂双手操作技能。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **触觉对多指灵巧操作的贡献被消融量化**，为"该不该上触觉"提供证据；
+- **低成本硬件（义肢手 + 现成件）**降低双手灵巧研究门槛；
+- 对人形双手操作直接相关；
+- 与"人形视触觉数据集"等触觉工作共同强调触觉模态。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2404.16823](https://arxiv.org/abs/2404.16823) | 论文正文（HATO、视触觉 IL、消融实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·触觉/灵巧**：[Humanoid Visual-Tactile-Action Dataset](../A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.md) · [Object-Centric Dexterous Manipulation](../Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.md)。

--- a/papers/06_Manipulation/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.md
+++ b/papers/06_Manipulation/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "Learning to Look Around: Enhancing Teleoperation and Learning with a Human-like Actuated Neck"
+zhname: "Learning to Look Around：用拟人可动颈增强遥操作与学习"
+category: "Manipulation"
+arxiv: "2411.00704"
+---
+
+# Learning to Look Around: Enhancing Teleoperation and Learning with a Human-like Actuated Neck
+**一套集成 5 自由度可动颈的遥操作系统，复刻自然人类头部运动与感知：支持窥视、倾头等行为给操作者更好的环境视角、降低远程操作认知负荷；在七个遥操作任务上展示收益，并研究可动颈如何通过增强空间感知、减少分布偏移来改善模仿学习的自主策略训练**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 可动颈 · 主动视觉 · 遥操作 · 认知负荷 · 分布偏移
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 11 月 |
+| arXiv | [2411.00704](https://arxiv.org/abs/2411.00704) · [PDF](https://arxiv.org/pdf/2411.00704) · [HTML](https://arxiv.org/html/2411.00704v1) |
+| 作者 | Bipasha Sen、Michelle Wang、Nandini Thakur、Aditya Agarwal、Pulkit Agrawal（MIT） |
+| 主题 | cs.RO · 可动颈 / 主动视觉 / 遥操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文提出一套集成 **5 自由度（DOF）可动颈**的遥操作系统，复刻**自然人类头部运动与感知**。系统支持**窥视（peeking）、倾头（tilting）**等行为，给操作者**更好的环境视角**、**降低远程操作的认知负荷**。作者在**七个遥操作任务**上展示收益，并研究**可动颈**如何通过**增强空间感知**、**减少分布偏移（distribution shift）**来改善**模仿学习**的**自主策略训练**——相比固定广角相机基线，可动颈在遥操作任务表现、操作者认知负荷与自主学习上都有改善。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Actuated Neck | 可动颈（5 DOF） |
+| Peeking / Tilting | 窥视 / 倾头等头部行为 |
+| Cognitive Load | 认知负荷 |
+| Spatial Awareness | 空间感知 |
+| Distribution Shift | 分布偏移 |
+| Imitation Learning | 模仿学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+固定相机限制遥操作与学习：
+- 看不全、需操作者**脑补**，**认知负荷高**；
+- 固定视角导致**分布偏移**，自主策略难学。
+
+论文要：用**拟人可动颈**让"头会动"，改善遥操作体验与自主学习。
+
+---
+
+## 🔧 方法详解
+
+### 1. 5-DOF 拟人可动颈
+复刻自然人类头部运动，支持**窥视、倾头**等，给操作者**灵活视角**。
+
+### 2. 降低遥操作认知负荷
+更好的环境视角让操作者**少脑补**，**认知负荷下降**，在**七个任务**上展示收益。
+
+### 3. 改善模仿学习（空间感知 + 减分布偏移）
+研究可动颈如何通过**增强空间感知**、**减少分布偏移**改善**自主策略**的模仿学习（相比固定广角相机基线）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    OP["🧑 操作者"] --> NECK
+    subgraph NECK["5-DOF 可动颈"]
+        B["窥视/倾头(灵活视角)"]
+    end
+    NECK --> TELE["七个遥操作任务<br/>认知负荷↓"]
+    NECK --> IL["模仿学习<br/>空间感知↑ 分布偏移↓"]
+    TELE --> OUT["🤖 遥操作 + 自主学习双改善"]
+    IL --> OUT
+
+    style NECK fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **5-DOF 拟人可动颈遥操作系统**：窥视/倾头等自然头动；
+2. **降低操作者认知负荷**：七个任务展示收益；
+3. **改善模仿学习**：增强空间感知、减少分布偏移；
+4. **对照固定广角相机**：可动颈全面更优。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"会动的头"对遥操作与自主学习都有益**，与 ViA、EgoMI 主动视觉一脉；
+- **减少分布偏移**是固定相机难做到的，可动颈天然缓解；
+- **降低认知负荷**直接影响采集时长与数据质量；
+- 对人形（本就有颈/头）是自然的硬件配置。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2411.00704](https://arxiv.org/abs/2411.00704) | 论文正文（5-DOF 颈、七任务、IL 研究） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·主动视觉/可动头**：[Vision in Action（6-DoF 颈）](../Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md) · [Learning to Look（信息寻求）](../Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.md)。

--- a/papers/06_Manipulation/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.md
+++ b/papers/06_Manipulation/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "Learning to Look: Seeking Information for Decision Making via Policy Factorization"
+zhname: "Learning to Look：用策略因子化为决策寻求信息"
+category: "Manipulation"
+arxiv: "2410.18964"
+---
+
+# Learning to Look: Seeking Information for Decision Making via Policy Factorization
+**很多操作任务需要主动/交互式探索才能完成；本文把这类任务刻画为「因子化上下文马尔可夫决策过程」，提出 DISaM 双策略：一个「信息寻求策略」探索环境找到相关上下文信息、一个「信息接收策略」利用上下文达成操作目标；二者可分开训练（用接收策略给寻求策略提供奖励），测试时按操作策略对下一步动作的不确定性平衡探索与利用**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 信息寻求 · 策略因子化 · 双策略 · 主动探索 · 不确定性
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 10 月 |
+| arXiv | [2410.18964](https://arxiv.org/abs/2410.18964) · [PDF](https://arxiv.org/pdf/2410.18964) · [HTML](https://arxiv.org/html/2410.18964v1) |
+| 作者 | Shivin Dass、Jiaheng Hu、Ben Abbatematteo、Peter Stone、Roberto Martín-Martín（UT Austin） |
+| 主题 | cs.RO · 信息寻求 / 主动探索 / 策略因子化 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 许多操作任务需要**主动或交互式探索**才能成功——智能体要**主动寻找**每一阶段所需的信息（如**移动机器人的头**去找操作相关信息；或多机器人里一个侦察机器人为另一个找信息）。本文把这类任务刻画为一种新问题：**因子化上下文马尔可夫决策过程（factorized Contextual MDP）**，并提出 **DISaM** ——一个**双策略**解法：① **信息寻求策略（information-seeking）**探索环境找到相关**上下文信息**；② **信息接收策略（information-receiving）**利用上下文达成操作目标。这种**因子化**让两策略可**分开训练**（用接收策略给寻求策略**提供奖励**）。测试时，双智能体**按操作策略对"下一步最佳动作"的不确定性**来**平衡探索与利用**。在五个需信息寻求的操作任务（仿真 + 真机）上，DISaM **大幅优于**已有方法。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| DISaM | 双策略（信息寻求 + 接收）框架 |
+| Factorized Contextual MDP | 因子化上下文 MDP |
+| Information-Seeking | 信息寻求策略（探索） |
+| Information-Receiving | 信息接收策略（利用） |
+| Exploration/Exploitation | 探索 / 利用平衡 |
+| Uncertainty | 操作策略对动作的不确定性 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+许多操作要**先找信息再决策**：
+- 需**主动探索**（如转头找物体）；
+- 把"寻求信息"与"利用信息"混在一个策略里难学；
+- 测试时如何**平衡探索与利用**？
+
+论文要：把任务**因子化**，分别学**寻求**与**接收**策略，并在测试时合理切换。
+
+---
+
+## 🔧 方法详解
+
+### 1. 因子化上下文 MDP
+把"需主动找信息"的任务建模为**factorized Contextual MDP**：上下文信息是决策的关键变量。
+
+### 2. DISaM 双策略
+- **信息寻求策略**：探索环境**找上下文**；
+- **信息接收策略**：用上下文**达成操作目标**。
+
+**因子化**允许**分开训练**：用**接收策略**的表现给**寻求策略提供奖励**。
+
+### 3. 测试时按不确定性平衡探索/利用
+测试时，依**操作（接收）策略**对**下一步最佳动作的不确定性**，决定**继续探索**还是**执行操作**。
+
+### 4. 结果
+五个需信息寻求的操作任务（仿真 + 真机），DISaM **大幅优于**基线。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    SEEK["🔎 信息寻求策略<br/>(探索找上下文)"] --> CTX["上下文信息"]
+    CTX --> RECV["🎯 信息接收策略<br/>(利用上下文达成目标)"]
+    RECV -. 提供奖励训练 .-> SEEK
+    UNC["操作不确定性"] --> BAL["测试时平衡探索/利用"]
+    RECV --> OUT["🤖 5 个需信息寻求任务<br/>仿真+真机 大幅优于基线"]
+
+    style SEEK fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style RECV fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **因子化上下文 MDP**：刻画"需主动找信息"的操作任务；
+2. **DISaM 双策略**：信息寻求 + 信息接收，可分开训练；
+3. **跨策略奖励**：用接收策略给寻求策略提供奖励；
+4. **不确定性驱动探索/利用平衡**：五任务大幅优于基线。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"找信息"与"用信息"解耦**是处理主动探索任务的优雅归纳偏置；
+- **不确定性驱动的探索/利用平衡**是可迁移的测试时机制；
+- 与 ViA、Learning to Look Around 的"主动视觉"互补（这里更偏决策层）；
+- 对人形（转头/移动找信息）直接相关。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2410.18964](https://arxiv.org/abs/2410.18964) | 论文正文（因子化 MDP、DISaM、五任务实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·主动感知/信息寻求**：[Learning to Look Around（可动颈）](../Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.md) · [Vision in Action](../Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md)。

--- a/papers/06_Manipulation/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields.md
+++ b/papers/06_Manipulation/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Lightning Grasp: High Performance Procedural Grasp Synthesis with Contact Fields"
+zhname: "Lightning Grasp：用接触场做高性能程序化抓取合成"
+category: "Manipulation"
+arxiv: "2511.07418"
+---
+
+# Lightning Grasp: High Performance Procedural Grasp Synthesis with Contact Fields
+**面向灵巧手实时多样抓取合成这一长期难题，提出一个程序化算法：用一个简单高效的数据结构「接触场（Contact Field）」把复杂几何计算与搜索过程解耦，从而比 SOTA 快几个数量级、还能为不规则/工具类物体生成抓取，且无需精心调的能量函数与敏感初始化，开源**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 抓取合成 · 接触场 · 程序化 · 实时 · 不规则物体 · 开源
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 11 月 |
+| arXiv | [2511.07418](https://arxiv.org/abs/2511.07418) · [PDF](https://arxiv.org/pdf/2511.07418) · [HTML](https://arxiv.org/html/2511.07418v1) |
+| 作者 | Zhao-Heng Yin、Pieter Abbeel（UC Berkeley） |
+| 代码 | 开源 |
+| 主题 | cs.RO · 抓取合成 / 灵巧手 / 程序化算法 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 多年研究后，灵巧手的**实时多样抓取合成**仍是机器人与计算机图形学的**未解核心难题**。本文提出一个**程序化算法**，相比 SOTA 取得**数量级（orders-of-magnitude）的提速**，并能为**不规则物体**生成抓取。关键创新是：用一个**简单高效的数据结构——「接触场（Contact Field）」**，把**复杂几何计算**与**搜索过程解耦**。由此实现**快速抓取合成**，**无需精心调的能量函数**与**敏感的初始化**，并能在**不规则、工具类物体**上**无监督**生成。代码**开源**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Grasp Synthesis | 抓取合成，生成可行抓取姿态 |
+| Procedural | 程序化（基于规则/搜索而非学习） |
+| Contact Field | 接触场，解耦几何计算与搜索的数据结构 |
+| Energy Function | 能量函数（本文不需精调） |
+| Dexterous Hand | 灵巧手（多指） |
+| Tool-like Object | 工具类不规则物体 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+灵巧手**实时多样抓取合成**难：
+- 现有方法**慢**，难实时；
+- 依赖**精调能量函数**与**敏感初始化**；
+- 对**不规则/工具类物体**支持差。
+
+Lightning Grasp 要：**快几个数量级**、**免精调**、能处理不规则物体的抓取合成。
+
+---
+
+## 🔧 方法详解
+
+### 1. 接触场（Contact Field）解耦几何与搜索
+核心是一个**简单高效的数据结构 Contact Field**：把**复杂几何计算**从**搜索过程**中**解耦**出来——几何信息预先编码进接触场，搜索时直接查，避免重复昂贵计算，这是数量级提速的来源。
+
+### 2. 程序化搜索（免能量函数/初始化）
+基于接触场的**程序化搜索**生成抓取，**不需精调能量函数**、**不依赖敏感初始化**。
+
+### 3. 不规则/工具类物体、无监督
+能在**不规则、工具类物体**上**无监督**生成抓取，泛化性好。
+
+### 4. 结果
+- 相比 SOTA **数量级提速**；
+- 开源实现。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    OBJ["📦 物体几何(含不规则/工具)"] --> CF
+    subgraph CF["接触场 Contact Field"]
+        G["预编码几何 → 与搜索解耦"]
+    end
+    CF --> SEARCH["程序化搜索<br/>(免能量函数/初始化)"]
+    SEARCH --> OUT["🤚 实时多样抓取<br/>比 SOTA 快数量级 · 开源"]
+
+    style CF fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **接触场数据结构**：解耦几何计算与搜索，数量级提速；
+2. **程序化抓取合成**：免精调能量函数与敏感初始化；
+3. **不规则/工具类物体无监督生成**：泛化性好；
+4. **开源**：可复现的高性能抓取合成。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"解耦昂贵计算与搜索"是提速的通用思路**：用合适数据结构换速度；
+- **程序化方法**在抓取上仍极具竞争力，不必事事学习；
+- **实时多样抓取**对灵巧操作（含人形双手）是基础能力；
+- 开源利于作为抓取模块嫁接到更大系统。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2511.07418](https://arxiv.org/abs/2511.07418) | 论文正文（接触场、程序化搜索、提速实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·灵巧抓取/操作**：[Object-Centric Dexterous Manipulation from Human Motion Data](../Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.md) · [Learning Visuotactile Skills with Two Multifingered Hands](../Learning_Visuotactile_Skills_with_Two_Multifingered_Hands/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.md)。

--- a/papers/06_Manipulation/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md
+++ b/papers/06_Manipulation/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md
@@ -1,0 +1,132 @@
+---
+layout: paper
+title: "Masquerade: Learning from In-the-wild Human Videos using Data-Editing"
+zhname: "Masquerade：用数据编辑从野外人类视频学习"
+category: "Manipulation"
+arxiv: "2508.09976"
+---
+
+# Masquerade: Learning from In-the-wild Human Videos using Data-Editing
+**通过「数据编辑」闭合人-机视觉具身差距：把每段野外第一视角人类视频改造成机器人化演示——估计 3D 手姿、修复涂抹人臂、叠加跟踪末端轨迹的渲染双臂机器人；在 67.5 万帧编辑片段上预训练视觉编码器预测未来 2D 机器人关键点，再在每任务仅 50 条机器人演示上微调扩散策略头，三个长时程双手厨房任务、各三个未见场景上较基线提升 5–6 倍，性能随编辑视频量对数增长**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 数据编辑 · 视觉具身差距 · 机器人叠加 · 协同训练 · 双手厨房
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 8 月 |
+| arXiv | [2508.09976](https://arxiv.org/abs/2508.09976) · [PDF](https://arxiv.org/pdf/2508.09976) · [HTML](https://arxiv.org/html/2508.09976v1) |
+| 作者 | Marion Lepert、Jiaying Fang、Jeannette Bohg（Stanford） |
+| 主题 | cs.RO · 数据编辑 / 从人类视频学习 / 双手操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 机器人操作仍**数据稀缺**——最大的机器人数据集也比驱动语言/视觉突破的数据**小几个数量级**。Masquerade 通过**编辑野外第一视角人类视频**来**闭合人-机视觉具身差距**，再用编辑后的视频学**机器人策略**。流程把每段人类视频变成**机器人化演示**：① 估计 **3D 手姿**；② **修复涂抹（inpaint）人臂**；③ **叠加渲染的双臂机器人**，使其**跟踪恢复的末端轨迹**。在 **67.5 万帧**编辑片段上**预训练视觉编码器**以**预测未来 2D 机器人关键点**，并在**每任务仅 50 条机器人演示**上微调**扩散策略头**（继续保留该辅助损失），所得策略**泛化显著更好**。在**三个长时程双手厨房任务**、各**三个未见场景**上，Masquerade 较基线**高 5–6 倍**；消融显示**机器人叠加**与**协同训练**都不可或缺，性能随编辑人类视频量**对数增长**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Data-Editing | 数据编辑，把人类视频改造成机器人演示 |
+| Inpainting | 图像修复，涂掉人臂 |
+| Robot Overlay | 叠加渲染机器人 |
+| Co-training | 协同训练（辅助损失 + 策略） |
+| 2D Keypoints | 2D 机器人关键点 |
+| Visual Embodiment Gap | 视觉具身差距 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+机器人数据稀缺，人类视频海量但有**视觉具身差距**（看起来是人手不是机器人）：
+- 直接学人类视频，策略看到的视觉与机器人不一致；
+- 需要**闭合视觉差距**才能用好人类视频。
+
+Masquerade 要：用**数据编辑**把人类视频"机器人化"，从而利用海量人类视频。
+
+---
+
+## 🔧 方法详解
+
+### 1. 三步数据编辑（人类视频 → 机器人演示）
+- **估计 3D 手姿**；
+- **修复涂抹人臂**；
+- **叠加渲染双臂机器人**跟踪恢复的末端轨迹。
+
+视觉上"变成机器人在做"。
+
+### 2. 预训练 + 协同训练
+在 **67.5 万帧**编辑片段上**预训练视觉编码器**预测**未来 2D 机器人关键点**；微调时**继续保留该辅助损失**（co-training），只用**每任务 50 条机器人演示**微调**扩散策略头**。
+
+### 3. 结果
+- 三个长时程双手厨房任务、各三未见场景，较基线**5–6 倍**；
+- 消融：**机器人叠加**与**协同训练**缺一不可；
+- 性能随编辑视频量**对数增长**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    H["🎥 野外第一视角人类视频"] --> EDIT
+    subgraph EDIT["数据编辑"]
+        E1["3D 手姿估计"]
+        E2["修复涂抹人臂"]
+        E3["叠加渲染双臂机器人"]
+        E1 --> E2 --> E3
+    end
+    EDIT --> PRE["67.5万帧预训练<br/>预测未来 2D 关键点"]
+    PRE --> FT["+50 演示/任务微调扩散头(协同训练)"]
+    FT --> OUT["🤖 双手厨房任务 5–6×基线<br/>随数据对数增长"]
+
+    style EDIT fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **数据编辑闭合视觉具身差距**：手姿估计 + 涂臂 + 机器人叠加；
+2. **预训练 + 协同训练**：67.5 万帧预测 2D 关键点，仅 50 演示/任务微调；
+3. **显著泛化**：双手厨房任务较基线 5–6 倍；
+4. **可扩展**：性能随编辑视频量对数增长。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"把人类视频改造成机器人样子"是用好人类数据的关键洞见**：视觉一致才好学；
+- **机器人叠加 + 协同训练缺一不可**，提示视觉对齐与辅助监督的协同；
+- **少量机器人演示 + 海量编辑视频**是高性价比配方；
+- 与 MimicDroid、In-N-On 等共同推进从人类视频学操作。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2508.09976](https://arxiv.org/abs/2508.09976) | 论文正文（数据编辑、预训练、双手厨房实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（5–6×、67.5 万帧）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·从人类视频学操作**：[MimicDroid](../MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md) · [Dexterity from Smart Lenses](../Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md)。

--- a/papers/06_Manipulation/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md
+++ b/papers/06_Manipulation/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "MimicDroid: In-Context Learning for Humanoid Robot Manipulation from Human Play Videos"
+zhname: "MimicDroid：从人类玩耍视频做人形操作的上下文学习"
+category: "Manipulation"
+arxiv: "2509.09769"
+---
+
+# MimicDroid: In-Context Learning for Humanoid Robot Manipulation from Human Play Videos
+**让人形用上下文学习从少量视频快速学新操作任务：不靠费力的遥操作数据，而用「人类玩耍视频」这种连续无标注的自由交互视频做训练源；从中抽取行为相似的轨迹对、训练策略以一条轨迹为条件预测另一条的动作，从而获得测试时适应新物体/环境的 ICL 能力；用运动学相似性重定向人手腕姿态、训练时随机块遮挡降过拟合，真机成功率近两倍于 SOTA**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 上下文学习 ICL · 人类玩耍视频 · 少样本 · 重定向 · 真机
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 9 月 |
+| arXiv | [2509.09769](https://arxiv.org/abs/2509.09769) · [PDF](https://arxiv.org/pdf/2509.09769) · [HTML](https://arxiv.org/html/2509.09769v1) |
+| 作者 | Rutav Shah、Shuijing Liu、Zhenyu Jiang、Mingyo Seo、Roberto Martín-Martín、Yuke Zhu（UT Austin） |
+| 主题 | cs.RO · 上下文学习 / 人类玩耍视频 / 人形操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 目标是让人形从**少量视频示例**高效解决**新操作任务**。**上下文学习（ICL）**因**测试时数据高效、快速适应**而有前景，但现有 ICL 方法依赖**费力的遥操作数据**，难规模化。本文用**人类玩耍视频（human play videos）**——人们**自由与环境交互**的**连续、无标注**视频——作为**可扩展、多样**的训练源。提出 **MimicDroid**：仅用人类玩耍视频做训练，**抽取行为相似的轨迹对**，训练策略**以一条轨迹为条件预测另一条的动作**，从而获得**测试时适应新物体/环境**的 **ICL 能力**。为弥合具身差距，先用**运动学相似性**把 RGB 视频估计的**人手腕姿态重定向**到人形；训练时**随机块遮挡（patch masking）**降低对人类特有线索的过拟合、增强对视觉差异的鲁棒。作者还提出一个**开源仿真基准**（难度递增）评估少样本学习；MimicDroid **优于 SOTA**，真机成功率**近两倍**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| ICL | In-Context Learning，上下文学习 |
+| Play Video | 玩耍视频，自由交互的无标注视频 |
+| Trajectory Pair | 轨迹对，行为相似的两段 |
+| Retargeting | 重定向（人手腕→人形） |
+| Patch Masking | 随机块遮挡，防过拟合 |
+| Few-shot | 少样本 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+让人形**少样本快速学新任务**：
+- ICL 有前景，但**依赖遥操作数据**，难规模化；
+- 想用**人类玩耍视频**（海量、无标注），但有**具身差距**与**人类特有线索过拟合**。
+
+MimicDroid 要：**仅用人类玩耍视频**训练出有 ICL 能力的人形操作策略。
+
+---
+
+## 🔧 方法详解
+
+### 1. 从玩耍视频抽轨迹对、学 ICL
+抽取**行为相似的轨迹对**，训练策略**以一条为条件预测另一条的动作**——这赋予模型**测试时**对新物体/环境的**ICL 适应**能力。
+
+### 2. 重定向人手腕姿态
+用**运动学相似性**把 RGB 估计的**人手腕姿态重定向**到人形，弥合具身差距。
+
+### 3. 随机块遮挡防过拟合
+训练时**随机块遮挡**，减少对**人类特有视觉线索**的过拟合，增强对人-机视觉差异的鲁棒。
+
+### 4. 基准与结果
+- 开源**仿真基准**（难度递增）评估少样本；
+- **优于 SOTA**，真机成功率**近两倍**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    PLAY["🎥 人类玩耍视频(无标注)"] --> PAIR["抽取行为相似轨迹对"]
+    PAIR --> POL
+    subgraph POL["MimicDroid (ICL)"]
+        C["以一条轨迹为条件预测另一条动作"]
+        R["手腕重定向 + 随机块遮挡"]
+    end
+    POL --> OUT["🤖 测试时适应新物体/环境<br/>真机成功率≈2×SOTA"]
+
+    style POL fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **仅用人类玩耍视频的 ICL**：摆脱对遥操作数据的依赖；
+2. **轨迹对条件预测**：获得测试时少样本适应能力；
+3. **重定向 + 块遮挡**：弥合具身差距、防过拟合；
+4. **开源基准 + 真机≈2×SOTA**。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **人类玩耍视频是海量免费的 ICL 训练源**，比遥操作更可扩展；
+- **ICL 让人形"看几个例子就会"**，是快速适应的诱人范式；
+- **随机块遮挡**是缓解人-机视觉差异过拟合的简单有效技巧；
+- 与 In-N-On、Masquerade 等"从人类视频学操作"路线互补。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2509.09769](https://arxiv.org/abs/2509.09769) | 论文正文（ICL、轨迹对、重定向、基准实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·从人类视频学操作**：[Masquerade（编辑视频闭合视觉差距）](../Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md) · [In-N-On](../In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md)。

--- a/papers/06_Manipulation/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data.md
+++ b/papers/06_Manipulation/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "MobileH2R: Learning Generalizable Human to Mobile Robot Handover Exclusively from Scalable and Diverse Synthetic Data"
+zhname: "MobileH2R：仅用可扩展多样合成数据学习泛化的人到移动机器人递交"
+category: "Manipulation"
+arxiv: "2501.04595"
+---
+
+# MobileH2R: Learning Generalizable Human to Mobile Robot Handover Exclusively from Scalable and Diverse Synthetic Data
+**面向「人到移动机器人」递交：不同于固定底座递交，移动机器人要借移动性在大工作空间里可靠接物；MobileH2R 完全用可扩展多样的合成数据学习视觉递交技能——可扩展地生成多样全身人体运动数据、自动造安全且易模仿的演示、用高效 4D 模仿学习协调底盘与机械臂；仿真与真机较基线成功率至少 +15%**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 人机递交 · 移动机器人 · 合成数据 · 4D 模仿 · 底盘-臂协调
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 1 月 |
+| arXiv | [2501.04595](https://arxiv.org/abs/2501.04595) · [PDF](https://arxiv.org/pdf/2501.04595) · [HTML](https://arxiv.org/html/2501.04595v1) |
+| 作者 | Zifan Wang、Ziqing Chen、Junyu Chen、Yunze Liu、Xueyi Liu、He Wang、Li Yi 等（清华等） |
+| 主题 | cs.RO · 人机递交 / 移动操作 / 合成数据 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> MobileH2R 是一个学习**泛化的、基于视觉的「人到移动机器人（H2MR）递交」**技能的框架。不同于传统**固定底座**递交，该任务要求**移动机器人**借**移动性**在**大工作空间**里**可靠接物**。MobileH2R **完全用可扩展、多样的合成数据**学习，开发了三类技术：① **可扩展地生成多样的全身人体运动数据**；② **自动**造**安全、易模仿**的演示；③ **高效的 4D 模仿学习**，协调机器人**底盘与机械臂**的运动。在仿真与真实世界评测中，相比基线，各情形**成功率至少 +15%**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| H2MR | Human-to-Mobile-Robot 人到移动机器人 |
+| Handover | 递交，把物体交给机器人 |
+| Synthetic Data | 合成数据（全身人体运动） |
+| 4D Imitation | 4D 模仿学习（含时间的轨迹） |
+| Base-Arm Coordination | 底盘-机械臂协调 |
+| Mobile Robot | 移动机器人 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+**移动机器人接人递来的物体**比固定底座难：
+- 需在**大工作空间**移动接物，**底盘 + 臂**要协调；
+- 真实递交数据**难采**；
+- 要对**多样人类递交动作**泛化。
+
+MobileH2R 要：**仅用合成数据**学出泛化的视觉 H2MR 递交。
+
+---
+
+## 🔧 方法详解
+
+### 1. 可扩展合成全身人体运动数据
+**可扩展地生成多样的全身人体运动**（递交动作），免真实采集。
+
+### 2. 自动造安全易模仿的演示
+**自动**生成**安全、易模仿**的机器人演示（含底盘 + 臂协调），作为模仿目标。
+
+### 3. 高效 4D 模仿学习（底盘-臂协调）
+用**4D 模仿学习**协调**底盘与机械臂**，在大工作空间里可靠接物。
+
+### 4. 结果
+- 仿真 + 真机；
+- 相比基线**至少 +15%** 成功率。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    SYN["可扩展合成全身人体运动"] --> DEMO["自动安全易模仿演示"]
+    DEMO --> IL["4D 模仿学习<br/>(底盘-臂协调)"]
+    IL --> OUT["🤖 人到移动机器人递交<br/>仿真+真机 ≥ +15%"]
+
+    style IL fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **H2MR 递交框架**：移动机器人大工作空间可靠接物；
+2. **完全合成数据**：可扩展生成全身人体运动 + 自动安全演示；
+3. **4D 模仿学习**：协调底盘与机械臂；
+4. **≥ +15%**：仿真与真机均超基线。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **移动递交需底盘-臂协调**，对人形（移动 + 操作）直接相关；
+- **完全合成数据**是绕开真实采集的可扩展路线，呼应 DexMimicGen/DreamGen；
+- **自动造安全演示**降低数据工程；
+- 人机递交是人形服务场景的高频交互。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2501.04595](https://arxiv.org/abs/2501.04595) | 论文正文（合成数据、4D 模仿、递交实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（+15%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·合成数据/递交**：[DexMimicGen（本仓 11）](../../11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md) · [DreamGen](../DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md)。

--- a/papers/06_Manipulation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation.md
+++ b/papers/06_Manipulation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation.md
@@ -1,0 +1,131 @@
+---
+layout: paper
+title: "OKAMI: Teaching Humanoid Robots Manipulation Skills through Single Video Imitation"
+zhname: "OKAMI：通过单段视频模仿教人形机器人操作技能"
+category: "Manipulation"
+arxiv: "2410.11792"
+---
+
+# OKAMI: Teaching Humanoid Robots Manipulation Skills through Single Video Imitation
+**从单段 RGB-D 视频生成操作计划并导出可执行策略：核心是「物体感知重定向」——用开放世界视觉模型识别任务相关物体，分别重定向身体动作与手部姿态，让人形复现视频中的人类动作并在部署时适应不同物体位置；对视觉/空间条件强泛化、超越开放世界从观察模仿的 SOTA，并用其 rollout 轨迹训练闭环视觉运动策略，无需费力遥操作即达平均 79.2% 成功率**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 单视频模仿 · 物体感知重定向 · 开放世界视觉 · 人形 · 闭环策略
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 10 月 |
+| arXiv | [2410.11792](https://arxiv.org/abs/2410.11792) · [PDF](https://arxiv.org/pdf/2410.11792) · [HTML](https://arxiv.org/html/2410.11792v1) |
+| 作者 | Jinhan Li、Yifeng Zhu、Yuqi Xie、Zhenyu Jiang、Mingyo Seo、Georgios Pavlakos、Yuke Zhu（UT Austin） |
+| 主题 | cs.RO · 单视频模仿 / 人形操作 / 物体感知重定向 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 研究**从单段视频演示**模仿来教**人形机器人操作技能**。OKAMI 从**单段 RGB-D 视频**生成**操作计划**并导出**可执行策略**。其核心是**物体感知重定向（object-aware retargeting）**：让人形**复现视频中的人类动作**，同时在部署时**适应不同物体位置**。OKAMI 用**开放世界视觉模型**识别**任务相关物体**，并**分别重定向身体动作与手部姿态**。实验表明 OKAMI 在**多变视觉与空间条件**下**强泛化**，在**开放世界从观察模仿（imitation from observation）**上**超越 SOTA 基线**。进一步地，用 OKAMI 的 **rollout 轨迹**训练**闭环视觉运动策略**，在**无需费力遥操作**的情况下达**平均 79.2% 成功率**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| OKAMI | 本文方法名 |
+| Object-Aware Retargeting | 物体感知重定向 |
+| Single Video Imitation | 单段视频模仿 |
+| Open-world Vision | 开放世界视觉模型 |
+| Imitation from Observation | 从观察模仿（无动作标签） |
+| Closed-loop Visuomotor | 闭环视觉运动策略 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+教人形操作通常需大量演示/遥操作。能否**从单段视频**就学会？
+- 单视频缺动作标签，且**物体位置会变**；
+- 人-机具身差异需重定向。
+
+OKAMI 要：从**单段 RGB-D 视频**生成计划 + 策略，并能**适应不同物体位置**。
+
+---
+
+## 🔧 方法详解
+
+### 1. 单 RGB-D 视频 → 操作计划
+从**一段 RGB-D 视频**生成**操作计划**，再导出可执行策略。
+
+### 2. 物体感知重定向（核心）
+- 用**开放世界视觉模型**识别**任务相关物体**；
+- **分别重定向身体动作与手部姿态**；
+- 部署时**适应不同物体位置**——让"复现人类动作"对空间变化鲁棒。
+
+### 3. rollout 训练闭环策略
+用 OKAMI 的 **rollout 轨迹**训练**闭环视觉运动策略**，**无需遥操作**。
+
+### 4. 结果
+- 多变视觉/空间条件**强泛化**，超开放世界 imitation-from-observation SOTA；
+- 闭环策略**平均 79.2%** 成功率。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    V["🎥 单段 RGB-D 视频"] --> PLAN
+    subgraph PLAN["OKAMI 物体感知重定向"]
+        O["开放世界视觉识别物体"]
+        R["分别重定向身体 + 手部姿态"]
+        O --> R
+    end
+    PLAN --> ROLL["rollout 轨迹"]
+    ROLL --> POL["训练闭环视觉运动策略(无需遥操作)"]
+    POL --> OUT["🤖 强泛化 · 平均 79.2% 成功率"]
+
+    style PLAN fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **单视频模仿教人形操作**：从一段 RGB-D 视频生成计划 + 策略；
+2. **物体感知重定向**：开放世界识别物体、分别重定向身体/手部、适应物体位置；
+3. **超 SOTA 泛化**：开放世界 imitation-from-observation；
+4. **闭环策略 79.2%**：用 rollout 训练、无需遥操作。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"单视频 + 物体感知重定向"极大降低教学成本**：看一遍就会、还能适应物体位置；
+- **身体/手部分别重定向**是处理具身差异的实用拆分；
+- **用 rollout 自举训练闭环策略**免遥操作，是数据飞轮的一环；
+- 与 MimicDroid、Masquerade 等"从人类视频学操作"路线互补（同 UT/Yuke Zhu 系）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2410.11792](https://arxiv.org/abs/2410.11792) | 论文正文（物体感知重定向、单视频模仿、闭环策略实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（79.2%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·从视频/人类数据学操作**：[MimicDroid](../MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md) · [Masquerade](../Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md)。

--- a/papers/06_Manipulation/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.md
+++ b/papers/06_Manipulation/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "Object-Centric Dexterous Manipulation from Human Motion Data"
+zhname: "以物体为中心：从人类动作数据学习灵巧操作"
+category: "Manipulation"
+arxiv: "2411.04005"
+---
+
+# Object-Centric Dexterous Manipulation from Human Motion Data
+**把物体操控到目标状态是灵巧操作的基本技能，人手动作是宝贵数据；为弥合人-机手具身差距，提出分层策略：高层用大规模人手动捕训练的轨迹生成模型、依目标物体状态合成手腕运动，低层用深度强化学习在机器人本体上做手指操控；在 10 个家用物体上评测，对新几何与新目标状态泛化，并在双臂灵巧系统上完成 sim-to-real**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 以物体为中心 · 人手动捕 · 分层策略 · 手指 RL · Sim-to-Real
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 11 月 |
+| arXiv | [2411.04005](https://arxiv.org/abs/2411.04005) · [PDF](https://arxiv.org/pdf/2411.04005) · [HTML](https://arxiv.org/html/2411.04005v1) |
+| 作者 | Yuanpei Chen、Chen Wang、Yaodong Yang、C. Karen Liu（Stanford / 北大） |
+| 主题 | cs.RO · 灵巧操作 / 人手动捕 / 分层策略 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 把**物体操控到目标状态**是灵巧操作的基本而重要的技能。**人手动作**展现了高超操控力，是训练**多指手**机器人的宝贵数据。本文通过**分层策略**弥合**人手与机器人手的具身差距**：① **高层**——在**大规模人手动捕数据**上训练的**轨迹生成模型**，**依目标物体状态**合成**手腕运动**；② **低层**——用**深度强化学习**做**手指操控**控制器，**扎根于机器人本体**。在 **10 个家用物体**上评测，对**新物体几何与新目标状态**泛化，并在**双臂灵巧机器人**系统上完成 **sim-to-real**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Object-Centric | 以物体（目标状态）为中心 |
+| Hierarchical | 分层（高层轨迹 + 低层手指） |
+| Wrist Motion | 手腕运动（高层合成） |
+| Finger RL | 手指控制的深度强化学习 |
+| Embodiment Gap | 人-机手具身差距 |
+| Goal State | 物体目标状态 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+用人手动捕学机器人灵巧操作有**具身差距**：
+- 人手与机器人手**形态/自由度不同**；
+- 要**把物体操控到目标状态**，需手腕 + 手指协同；
+- 要对**新物体/新目标**泛化。
+
+论文要：**分层**地用人手动捕学**以物体为中心**的灵巧操作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 高层：人手动捕轨迹生成（合成手腕运动）
+在**大规模人手动捕**上训练**轨迹生成模型**，**依目标物体状态**合成**手腕运动**——管"手该往哪走"。
+
+### 2. 低层：手指操控 RL（扎根机器人本体）
+**深度强化学习**控制器做**手指操控**，**grounded 在机器人手本体**——管"手指怎么动"，弥合具身差距。
+
+### 3. 评测
+- **10 个家用物体**；
+- 对**新几何 + 新目标状态**泛化；
+- **双臂灵巧系统** sim-to-real。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    GOAL["🎯 目标物体状态"] --> HI
+    MOCAP["🖐️ 大规模人手动捕"] --> HI
+    subgraph HI["高层：轨迹生成"]
+        W["合成手腕运动"]
+    end
+    HI --> LOW["低层：手指 RL<br/>(机器人本体)"]
+    LOW --> OUT["🤖 10 家用物体<br/>新几何/新目标泛化 · 双臂 sim-to-real"]
+
+    style HI fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style LOW fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **以物体为中心的灵巧操作**：操控物体到目标状态；
+2. **分层策略弥合具身差距**：高层人手动捕轨迹 + 低层手指 RL；
+3. **泛化**：新物体几何与新目标状态；
+4. **双臂 sim-to-real**：10 家用物体真机验证。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"高层人类轨迹 + 低层机器人 RL"是弥合手部具身差距的经典分层**；
+- **以目标状态为中心**让任务定义清晰、便于泛化；
+- 人手动捕是灵巧操作的宝贵先验（与 EgoDex、Being-H0 同源思路）；
+- 对人形双手灵巧操作直接适用。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2411.04005](https://arxiv.org/abs/2411.04005) | 论文正文（分层策略、手指 RL、家用物体实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·灵巧/人手数据**：[Lightning Grasp（程序化抓取）](../Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields.md) · [EgoDex](../EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md)。

--- a/papers/06_Manipulation/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies.md
+++ b/papers/06_Manipulation/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies.md
@@ -1,0 +1,120 @@
+---
+layout: paper
+title: "Residual Off-Policy RL for Finetuning Behavior Cloning Policies"
+zhname: "用残差离策略 RL 微调行为克隆策略"
+category: "Manipulation"
+arxiv: "2509.19301"
+---
+
+# Residual Off-Policy RL for Finetuning Behavior Cloning Policies
+**用残差学习把行为克隆与强化学习的优点结合：把 BC 策略当黑盒基座，用样本高效的离策略 RL 学每步的轻量残差修正；只需稀疏二值奖励即可在高自由度系统上改进操作策略，并据作者所知首次在带灵巧手的人形真机上成功做 RL 训练，在多项视觉任务上取得 SOTA**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 残差学习 · BC+RL · 离策略 · 稀疏奖励 · 真机 RL · 灵巧手
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 9 月 |
+| arXiv | [2509.19301](https://arxiv.org/abs/2509.19301) · [PDF](https://arxiv.org/pdf/2509.19301) · [HTML](https://arxiv.org/html/2509.19301v2) |
+| 作者 | Lars Ankile、Zhenyu Jiang、Rocky Duan、Guanya Shi、Pieter Abbeel、Anusha Nagabandi |
+| 主题 | cs.RO · 残差 RL / BC 微调 / 真机灵巧操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> **行为克隆（BC）**能学到不错的视觉运动策略，但受限于**人类演示质量、采集人力、离线数据的边际收益递减**。**强化学习（RL）**靠自主交互、潜力大，但**直接在真机训 RL** 难——**样本低效、安全、稀疏奖励长时程**，对**高自由度（DoF）**系统尤甚。本文给出一个把 BC 与 RL 优点结合的**残差学习**配方：把 **BC 策略当黑盒基座**，用**样本高效的离策略 RL** 学**每步的轻量残差修正**。方法**只需稀疏二值奖励**，即可在**高自由度系统**（仿真与真机）上改进操作策略。尤其，作者据其所知**首次在带灵巧手的人形真机上成功进行 RL 训练**，在多项**视觉任务**上取得 **SOTA**，指向把 RL 真正部署到现实的可行路径。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| BC | Behavior Cloning，行为克隆 |
+| Off-Policy RL | 离策略强化学习（样本高效） |
+| Residual | 残差，对基座策略的逐步修正 |
+| Sparse Binary Reward | 稀疏二值奖励（成功/失败） |
+| High-DoF | 高自由度系统 |
+| Dexterous Hands | 灵巧手 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+BC 与 RL 各有短板：
+- **BC**：受演示质量限制、边际收益递减；
+- **真机 RL**：样本低效、安全难、稀疏奖励长时程难，高 DoF 更甚。
+
+论文要：把二者结合，**安全样本高效**地在**真机高 DoF**（含灵巧手人形）上改进策略。
+
+---
+
+## 🔧 方法详解
+
+### 1. 残差学习：BC 基座 + RL 修正
+把**BC 策略当黑盒基座**（提供合理初始动作），用 RL 只学**每步轻量残差**——大幅缩小探索空间、提升安全与样本效率。
+
+### 2. 样本高效离策略 RL + 稀疏二值奖励
+用**离策略 RL**（数据复用、样本高效），**仅需稀疏二值奖励**（成功/失败），免去稠密奖励工程。
+
+### 3. 真机灵巧手人形 RL（首次）
+据作者所知，**首次**在**带灵巧手的人形真机**上成功 RL 训练，在多项**视觉任务**上 SOTA。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    BC["🧊 BC 策略(黑盒基座)"] --> SUM
+    RL["离策略 RL 残差修正<br/>(稀疏二值奖励)"] --> SUM
+    SUM["每步动作 = 基座 + 残差"] --> OUT["🤖 高 DoF 真机改进<br/>首次灵巧手人形 RL · 视觉任务 SOTA"]
+
+    style RL fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **残差 BC+RL 配方**：BC 基座 + 离策略 RL 轻量残差，安全样本高效；
+2. **仅需稀疏二值奖励**：免稠密奖励工程；
+3. **首次灵巧手人形真机 RL**：据作者所知；
+4. **视觉任务 SOTA**：指向真机 RL 的可行路径。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"冻结基座 + 学残差"是真机 RL 的安全样本高效范式**，呼应 ResMimic、SteadyTray 的残差思路；
+- **稀疏二值奖励**降低奖励工程门槛，利于真机；
+- **首次灵巧手人形真机 RL**是里程碑，证明真机 RL 可行；
+- 对高 DoF 系统（人形）尤其有价值。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2509.19301](https://arxiv.org/abs/2509.19301) | 论文正文（残差框架、离策略 RL、真机灵巧手实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·残差/真机学习**：[MimicDroid（人类玩耍视频 ICL）](../MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md)；
+- **残差思路（本仓 04）**：[SteadyTray（残差 RL 托盘平衡）](../../04_Loco-Manipulation_and_WBC/SteadyTray__Learning_Object_Balancing_Tasks_in_Humanoid_Tray_Transport_via_Resid/SteadyTray__Learning_Object_Balancing_Tasks_in_Humanoid_Tray_Transport_via_Resid.md)。

--- a/papers/06_Manipulation/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming.md
+++ b/papers/06_Manipulation/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "Robot Drummer: Learning Rhythmic Skills for Humanoid Drumming"
+zhname: "Robot Drummer：为人形打鼓学习节奏技能"
+category: "Manipulation"
+arxiv: "2507.11498"
+---
+
+# Robot Drummer: Learning Rhythmic Skills for Humanoid Drumming
+**把人形打鼓表述成「节奏接触链（Rhythmic Contact Chain）」——一连串定时接触：从鼓谱推出接触链，把长时程乐曲分解成定长片段并行用 RL 训练；在 30+ 摇滚/金属/爵士曲目上取得高 F1，并涌现交叉臂击打与自适应鼓棒分配等拟人策略，完成数分钟级多肢协调演奏**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 人形打鼓 · 节奏接触链 · 定时接触 · 并行 RL · 表现性
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 7 月 |
+| arXiv | [2507.11498](https://arxiv.org/abs/2507.11498) · [PDF](https://arxiv.org/pdf/2507.11498) · [HTML](https://arxiv.org/html/2507.11498v1) |
+| 作者 | Asad Ali Shahid、Francesco Braghin、Loris Roveda（米兰理工 / IDSIA） |
+| 主题 | cs.RO · 人形表现性技能 / 打鼓 / RL |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人形在**灵巧、平衡、行走**上进步显著，但在**音乐表演**等**表现性领域**的角色仍少被探索。本文提出 **Robot Drummer**，通过一连串**定时接触**完成打鼓，把问题表述成**节奏接触链（Rhythmic Contact Chain）**。系统把**乐曲分解成定长片段**，**并行**用**强化学习**训练。在 **30+ 首**摇滚、金属、爵士曲目上测试，取得**高 F1 分数**，并**涌现**出**交叉臂击打（cross-arm strikes）**与**自适应鼓棒分配（adaptive stick assignments）**等行为，能完成**数分钟级**的**多肢协调**演奏。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Rhythmic Contact Chain | 节奏接触链，一连串定时接触 |
+| Timed Contact | 定时接触，在准确时刻击鼓 |
+| F1 Score | 衡量击打准确性的指标 |
+| Cross-Arm Strike | 交叉臂击打（涌现策略） |
+| Stick Assignment | 鼓棒分配（哪只手打哪面鼓） |
+| Parallel RL | 并行强化学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形**音乐表演（打鼓）**少被探索，难点：
+- 打鼓是**精确定时的多肢接触**序列；
+- 乐曲**长时程**，直接 RL 难；
+- 要**多肢协调**（双臂 + 鼓棒分配）。
+
+Robot Drummer 要：把打鼓建模成可学的**定时接触序列**，让人形演奏真实曲目。
+
+---
+
+## 🔧 方法详解
+
+### 1. 节奏接触链（Rhythmic Contact Chain）
+把打鼓表述成一连串**定时接触**：从**鼓谱**推出**接触链**（何时、用哪肢击哪面鼓），把音乐转成可执行的接触目标。
+
+### 2. 分段并行 RL
+把**长时程乐曲分解成定长片段**，**并行**用 RL 训练各段，破解长时程难题。
+
+### 3. 涌现拟人策略
+训练中**涌现**：**交叉臂击打**、**自适应鼓棒分配**等类人策略，实现高效多肢协调。
+
+### 4. 结果
+- **30+ 首**摇滚/金属/爵士；
+- **高 F1**，数分钟级多肢协调演奏。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    SCORE["🥁 鼓谱"] --> RCC["节奏接触链<br/>(定时接触序列)"]
+    RCC --> SEG["分解定长片段"]
+    SEG --> RL["并行 RL 训练"]
+    RL --> OUT["🤖 30+ 曲目高 F1<br/>涌现交叉臂/鼓棒分配 · 数分钟演奏"]
+
+    style RL fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **节奏接触链表述**：把打鼓转成定时接触序列；
+2. **分段并行 RL**：破解长时程乐曲；
+3. **涌现拟人策略**：交叉臂击打、自适应鼓棒分配；
+4. **真实曲目验证**：30+ 摇滚/金属/爵士高 F1。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **把表现性任务转成"定时接触序列"**是可学化的关键抽象；
+- **分段并行 RL**对长时程节奏任务有效；
+- **表现性领域（音乐）**是高动态多肢协调的新颖试金石，呼应羽毛球/足球等体育任务；
+- 涌现的拟人策略显示 RL 能发现高效协调方式。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2507.11498](https://arxiv.org/abs/2507.11498) | 论文正文（节奏接触链、分段 RL、曲目实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **相关·人形体育/表现性（本仓 04）**：[人形羽毛球](../../04_Loco-Manipulation_and_WBC/Humanoid_Whole-Body_Badminton_via_Multi-Stage_Reinforcement_Learning/Humanoid_Whole-Body_Badminton_via_Multi-Stage_Reinforcement_Learning.md) · [人形足球射门](../../04_Loco-Manipulation_and_WBC/Learning_Agile_Striker_Skills_for_Humanoid_Soccer_Robots_from_Noisy_Sensory_Input/Learning_Agile_Striker_Skills_for_Humanoid_Soccer_Robots_from_Noisy_Sensory_Input.md)。

--- a/papers/06_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation.md
+++ b/papers/06_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "Sim-and-Real Co-Training: A Simple Recipe for Vision-Based Robotic Manipulation"
+zhname: "Sim-and-Real 协同训练：基于视觉的机器人操作的简单配方"
+category: "Manipulation"
+arxiv: "2503.24361"
+---
+
+# Sim-and-Real Co-Training: A Simple Recipe for Vision-Based Robotic Manipulation
+**与其只做 sim-to-real 迁移，不如在训练时直接把仿真与真实数据混合协同训练；在机械臂与人形系统、多样操作任务上系统实验表明：即便仿真与真实数据差异明显，仿真数据也能把真实任务表现平均提升 38%**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 协同训练 · sim+real 混合 · 视觉操作 · 数据配方
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.24361](https://arxiv.org/abs/2503.24361) · [PDF](https://arxiv.org/pdf/2503.24361) · [HTML](https://arxiv.org/html/2503.24361v1) |
+| 作者 | Abhiram Maddukuri、Zhenyu Jiang、Soroush Nasiriany、Ken Goldberg、Ajay Mandlekar、Linxi Fan、Yuke Zhu 等（NVIDIA / Berkeley / UT） |
+| 主题 | cs.RO · 协同训练 / sim+real / 视觉操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 大规模真实机器人数据集潜力大，但**真实人类数据采集费时费力**。本文主张：**与其只做 sim-to-real 迁移，不如在训练时直接把「仿真」与「真实」数据集混合协同训练（co-training）**。通过在**机械臂与人形系统**、多样操作任务上的**系统实验**，作者证明：**即便仿真与真实数据有明显差异**，**仿真数据也能把真实任务表现平均提升 38%**。这给出一个**简单有效的视觉操作训练配方**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Co-Training | 协同训练，sim 与 real 数据混合训练 |
+| Sim-to-Real | 仿真到真机迁移（被对比对象） |
+| Vision-Based | 基于视觉的策略 |
+| Domain Gap | 域差距（sim 与 real 差异） |
+| Recipe | 配方，可复用的训练做法 |
+| Generalist | 通才机器人模型 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+真实数据采集贵，仿真数据多但有域差距：
+- 纯 **sim-to-real 迁移**常需精心对齐；
+- 想更**简单**地用上仿真数据提升真实表现。
+
+论文要：一个**简单配方**——直接 **sim + real 协同训练**，看仿真数据能否稳定帮真实任务。
+
+---
+
+## 🔧 方法详解
+
+### 1. 协同训练（sim + real 混合）
+**训练时混合**仿真与真实数据集，而非分两段做迁移——让模型同时见到两域数据。
+
+### 2. 系统实验（臂 + 人形）
+在**机械臂与人形系统**、多样视觉操作任务上**系统研究**最优训练配方（如混合比例等）。
+
+### 3. 结论
+- 即便 **sim 与 real 差异明显**，仿真数据**平均 +38%** 真实表现；
+- 给出简单可复用的配方。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    SIM["🌀 仿真数据"] --> CO
+    REAL["📷 真实数据"] --> CO
+    subgraph CO["协同训练(混合)"]
+        T["同时学 sim + real"]
+    end
+    CO --> OUT["🤖 臂 + 人形<br/>真实任务平均 +38%"]
+
+    style CO fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **sim+real 协同训练配方**：训练时混合，而非两段迁移；
+2. **系统实验（臂 + 人形）**：研究最优配方；
+3. **+38% 真实表现**：即便域差异明显；
+4. **简单可复用**：易嫁接到现有视觉操作流程。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"混合训练 > 两段迁移"是反直觉但实用的洞见**：让模型同时见两域更稳；
+- **仿真数据即便不完美也有用**，降低对昂贵真实数据的依赖；
+- 对人形（真实采集更难）尤其有价值；
+- 与 DreamGen、DexMimicGen 等"用仿真/合成数据扩规模"思路互补。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.24361](https://arxiv.org/abs/2503.24361) | 论文正文（协同训练配方、臂/人形实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（38%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块/相关·数据扩展**：[DreamGen](../DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md) · [Humanoid Policy ~ Human Policy](../Humanoid_Policy__Human_Policy/Humanoid_Policy__Human_Policy.md)。

--- a/papers/06_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation.md
+++ b/papers/06_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation.md
@@ -1,0 +1,130 @@
+---
+layout: paper
+title: "TOP: Time Optimization Policy for Stable and Accurate Standing Manipulation with Humanoid Robots"
+zhname: "TOP：面向人形稳定精确站立操作的时间优化策略"
+category: "Manipulation"
+arxiv: "2508.00355"
+---
+
+# TOP: Time Optimization Policy for Stable and Accurate Standing Manipulation with Humanoid Robots
+**人形多样操作依赖鲁棒精确的站立控制，但已有方法要么难精控高维上身关节、要么在上身快速运动时难兼顾鲁棒与精度；TOP 提出「调整上身动作的时间轨迹」而非一味强化下身抗扰：用 VAE 编码上身动作先验、解耦全身控制（上身 PD + 下身 RL），训练时间优化策略来减轻快速上身运动给平衡带来的负担，同时保证平衡、精度与时间效率**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 站立操作 · 时间优化 · 上下身解耦 · VAE 先验 · 平衡+精度
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 8 月 |
+| arXiv | [2508.00355](https://arxiv.org/abs/2508.00355) · [PDF](https://arxiv.org/pdf/2508.00355) · [HTML](https://arxiv.org/html/2508.00355v1) |
+| 作者 | Zhenghan Chen、Haocheng Xu、Haodong Zhang、Zhongxiang Zhou、Rong Xiong 等（浙江大学） |
+| 主题 | cs.RO · 站立操作 / 时间优化 / 全身控制 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人形能做多样操作，前提是**鲁棒精确的站立控制器**。已有方法**要么难精控高维上身关节、要么难同时保证鲁棒与精度**——尤其当**上身运动快**时。本文提出一个新颖的**时间优化策略（Time Optimization Policy, TOP）**，训练一个**站立操作控制模型**，**同时**保证**平衡、精度与时间效率**。核心思想是：**调整上身动作的时间轨迹**，而**不只是一味强化下身的抗扰能力**——让快速上身运动在时间上"错峰"，减轻对平衡的冲击。方法用 **VAE** 编码**上身动作先验**，并**解耦全身控制**（**上身 PD 控制器 + 下身 RL 控制器**）。仿真与真机实验表明，TOP 在站立操作上**稳定且精确**，优于已有方法。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| TOP | Time Optimization Policy，时间优化策略 |
+| Standing Manipulation | 站立操作 |
+| VAE | 变分自编码器（编码上身动作先验） |
+| Decoupled WBC | 解耦全身控制（上身 PD + 下身 RL） |
+| Time Trajectory | 时间轨迹（动作的时间安排） |
+| Disturbance Resistance | 抗扰能力 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+站立操作要**平衡 + 精度 + 时间效率**三者兼顾：
+- 难**精控高维上身关节**；
+- **上身快速运动**时，扰动大，难同时稳与准；
+- 一味强化下身抗扰**治标不治本**。
+
+TOP 要：通过**调上身动作时间轨迹**，从源头减轻平衡负担，兼顾稳、准、快。
+
+---
+
+## 🔧 方法详解
+
+### 1. 思想：调上身时间轨迹（而非只强化下身）
+不只让下身"硬扛"，而**优化上身动作的时间安排**，让快速运动错峰、降低对平衡的冲击——从源头减负。
+
+### 2. VAE 上身动作先验
+用 **VAE** 编码**上身动作先验**，给上身动作一个紧凑、可优化的表示。
+
+### 3. 解耦全身控制
+- **上身**：**PD 控制器**做精确控制；
+- **下身**：**RL 控制器**做鲁棒平衡。
+
+### 4. 时间优化策略训练
+训练 **TOP** 来调时间轨迹，**同时**保证**平衡、精度、时间效率**；仿真与真机验证优于已有方法。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    M["上身动作(VAE 先验)"] --> TOP
+    subgraph TOP["TOP 时间优化策略"]
+        T["调整上身动作时间轨迹<br/>(错峰减轻平衡负担)"]
+    end
+    TOP --> UP["上身 PD(精确)"]
+    TOP --> LOW["下身 RL(鲁棒平衡)"]
+    UP --> OUT["🤖 站立操作<br/>平衡+精度+时间效率"]
+    LOW --> OUT
+
+    style TOP fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **时间优化策略 TOP**：调上身动作时间轨迹，同时保证稳/准/快；
+2. **VAE 上身动作先验**：紧凑可优化表示；
+3. **解耦全身控制**：上身 PD 精控 + 下身 RL 鲁棒；
+4. **稳定精确站立操作**：仿真 + 真机优于已有方法。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"调时间"是平衡-精度权衡的新维度**：不止调空间动作，还可调时间安排；
+- **上身 PD + 下身 RL 解耦**契合"精确 vs 鲁棒"的不同需求，与 Mobile-TeleVision 思路相通；
+- **VAE 动作先验**是常用的紧凑表示手段；
+- 站立操作是人形干活的基础，稳准快都重要。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2508.00355](https://arxiv.org/abs/2508.00355) | 论文正文（TOP、VAE 先验、解耦控制、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块/相关·上下身解耦**：[Mobile-TeleVision（CVAE 上身先验 + RL 下身）](../../07_Teleoperation/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md)；
+- **站立/全身控制**：本仓 04 全身控制相关工作。

--- a/papers/06_Manipulation/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots.md
+++ b/papers/06_Manipulation/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Towards Proprioception-Aware Embodied Planning for Dual-Arm Humanoid Robots"
+zhname: "面向双臂人形的本体感受感知具身规划"
+category: "Manipulation"
+arxiv: "2510.07882"
+---
+
+# Towards Proprioception-Aware Embodied Planning for Dual-Arm Humanoid Robots
+**多模态大模型可做高层规划，但在双臂人形长时程任务上受限于仿真平台不足与「具身感知」欠缺；本文用带连续过渡与意外机制的双臂人形模拟器 DualTHOR，并提出 Proprio-MLLM——融合本体感受、基于运动的位置嵌入与跨空间编码器以增强具身感知，在该环境中规划性能平均提升 19.75%**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 具身规划 · 本体感受 · MLLM · 双臂人形 · DualTHOR
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 10 月 |
+| arXiv | [2510.07882](https://arxiv.org/abs/2510.07882) · [PDF](https://arxiv.org/pdf/2510.07882) · [HTML](https://arxiv.org/html/2510.07882v1) |
+| 作者 | Boyu Li、Siyuan He、Hang Xu、Haoqi Yuan、Börje F. Karlsson、Zongqing Lu 等 |
+| 主题 | cs.RO · 具身规划 / 本体感受 / 多模态大模型 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 近年**多模态大模型（MLLM）**能做**高层规划**，让机器人遵从复杂人类指令。但在涉及**双臂人形**的**长时程任务**上效果仍有限——原因是**仿真平台不足**与当前 MLLM 的**具身感知（embodiment awareness）欠缺**。本文用一个新的**双臂人形模拟器 DualTHOR**（带**连续过渡**与**意外机制**），并提出 **Proprio-MLLM**：一个融合**本体感受信息、基于运动的位置嵌入、跨空间编码器（cross-spatial encoder）**的增强模型，以提升**具身感知**。在 DualTHOR 环境中，**Proprio-MLLM 的规划性能平均提升 19.75%**（相比现有 MLLM）。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| MLLM | Multimodal Large Language Model |
+| Proprio-MLLM | 本文的本体感受感知 MLLM |
+| Embodiment Awareness | 具身感知，模型对自身身体状态的理解 |
+| DualTHOR | 双臂人形模拟器 |
+| Position Embedding | 位置嵌入（基于运动） |
+| Cross-Spatial Encoder | 跨空间编码器 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+MLLM 做双臂人形长时程规划受限：
+- **仿真平台不足**（缺连续过渡/意外）；
+- MLLM **缺具身感知**，不"知道"自己身体状态，规划脱离物理。
+
+论文要：① 更好的双臂人形仿真（DualTHOR）；② 让 MLLM **感知本体状态**以改进规划。
+
+---
+
+## 🔧 方法详解
+
+### 1. DualTHOR 双臂人形模拟器
+带**连续过渡**与**意外机制**，为长时程双臂人形规划提供贴近现实的测试床。
+
+### 2. Proprio-MLLM：注入本体感受
+增强 MLLM 的**具身感知**：
+- **本体感受信息**：让模型"知道"关节/姿态状态；
+- **基于运动的位置嵌入**；
+- **跨空间编码器**：融合空间信息。
+
+### 3. 结果
+在 DualTHOR 中，规划性能**平均 +19.75%**（相比现有 MLLM）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    INS["🗣️ 复杂指令"] --> PM
+    PROP["📟 本体感受"] --> PM
+    subgraph PM["Proprio-MLLM"]
+        E["运动位置嵌入 + 跨空间编码器"]
+    end
+    PM --> PLAN["长时程双臂规划"]
+    PLAN --> SIM["DualTHOR(连续过渡+意外)"]
+    SIM --> OUT["📊 规划性能 +19.75%"]
+
+    style PM fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **DualTHOR 双臂人形模拟器**：连续过渡 + 意外机制；
+2. **Proprio-MLLM**：注入本体感受、运动位置嵌入、跨空间编码器；
+3. **增强具身感知**：让高层规划"知道身体状态"；
+4. **+19.75% 规划性能**：相比现有 MLLM。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **高层规划需要"具身感知"**：纯语义 MLLM 不够，要注入本体状态；
+- **仿真平台是 MLLM 规划研究的前提**（与 DualTHOR 平台论文同源）；
+- **本体感受 + 跨空间编码**是把语言规划接到物理身体的桥；
+- 与 BiBo（现成 VLM 控人形）形成"增强 MLLM vs 借现成 VLM"的对照。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2510.07882](https://arxiv.org/abs/2510.07882) | 论文正文（DualTHOR、Proprio-MLLM、规划实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（19.75%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·VLM/规划**：[给 GPT-4 一具人形身体·BiBo](../Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.md) · [Hierarchical Vision-Language Planning](../Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.md)；
+- **DualTHOR 平台（本仓 11）**：[DualTHOR](../../11_Simulation_Benchmark/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning.md)。

--- a/papers/06_Manipulation/Unified_Video_Action_Model/Unified_Video_Action_Model.md
+++ b/papers/06_Manipulation/Unified_Video_Action_Model/Unified_Video_Action_Model.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Unified Video Action Model"
+zhname: "Unified Video Action Model：统一视频-动作模型"
+category: "Manipulation"
+arxiv: "2503.00200"
+---
+
+# Unified Video Action Model
+**视频给动作预测提供丰富场景信息、动作给视频预测提供动力学，统一二者对机器人很有价值，但以往视频生成类方法在动作精度与推理速度上不如直接策略学习；UVA 联合优化视频与动作预测，关键是学一个视频-动作联合潜表示并解耦视频-动作解码（两个轻量扩散头），从而推理时可绕过视频生成实现高速动作输出，并经掩码输入训练支持策略、正逆动力学、视频预测等多功能**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 视频-动作统一 · 联合潜表示 · 解耦解码 · 扩散头 · 高速推理
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 2 月 |
+| arXiv | [2503.00200](https://arxiv.org/abs/2503.00200) · [PDF](https://arxiv.org/pdf/2503.00200) · [HTML](https://arxiv.org/html/2503.00200v1) |
+| 作者 | Shuang Li、Yihuai Gao、Dorsa Sadigh、Shuran Song（Stanford） |
+| 主题 | cs.RO · 视频-动作统一 / 策略学习 / 扩散 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> **统一的视频-动作模型**对机器人很有价值：**视频**给动作预测提供丰富**场景信息**，**动作**给视频预测提供**动力学信息**。但有效结合视频生成与动作预测仍难——现有**视频生成类**方法在**动作精度与推理速度**上**不如直接策略学习**。为弥合此差距，本文提出 **Unified Video Action 模型（UVA）**，**联合优化**视频与动作预测，同时实现**高精度**与**高效动作推理**。关键在于：学一个**视频-动作联合潜表示**，并**解耦视频-动作解码**（用**两个轻量扩散头**）。这样**推理时可绕过视频生成**实现**高速动作输出**；并通过**掩码输入训练**支持**策略学习、正/逆动力学建模、视频观测预测**等多功能。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| UVA | Unified Video Action 模型 |
+| Joint Latent | 视频-动作联合潜表示 |
+| Decoupled Decoding | 解耦解码（视频/动作分头） |
+| Diffusion Head | 轻量扩散头 |
+| Masked Input | 掩码输入训练（多功能） |
+| Forward/Inverse Dynamics | 正/逆动力学 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+视频生成与动作预测各有所长但难统一：
+- 视频给场景、动作给动力学，统一有益；
+- 但**视频生成类**方法**动作不准、推理慢**，不如直接策略。
+
+UVA 要：**联合优化**视频 + 动作，**既准又快**，且**一模型多功能**。
+
+---
+
+## 🔧 方法详解
+
+### 1. 视频-动作联合潜表示
+学一个**联合潜表示**，把视频与动作统一编码，让二者互相提供信息（场景 ↔ 动力学）。
+
+### 2. 解耦解码 + 双轻量扩散头
+**解耦视频-动作解码**：用**两个轻量扩散头**分别解码。推理时**可只走动作头、绕过视频生成**，实现**高速动作输出**。
+
+### 3. 掩码输入训练（多功能）
+**掩码输入**训练让一个模型支持：**策略学习、正/逆动力学、视频观测预测**等。
+
+### 4. 结果
+在多样机器人任务上**精度不输任务专用方法**，且**动作推理高效**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    IN["📷 视频观测 + 动作"] --> LAT
+    subgraph UVA["UVA"]
+        LAT["视频-动作联合潜表示"]
+        VH["视频扩散头"]
+        AH["动作扩散头(可单独走)"]
+        LAT --> VH
+        LAT --> AH
+    end
+    AH --> OUT["🤖 高速动作推理(绕过视频生成)<br/>策略/正逆动力学/视频预测 多功能"]
+
+    style UVA fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **统一视频-动作模型 UVA**：联合优化、既准又快；
+2. **联合潜表示 + 解耦解码**：双轻量扩散头；
+3. **绕过视频生成的高速动作推理**；
+4. **掩码训练多功能**：策略、正/逆动力学、视频预测。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"联合潜 + 解耦解码"是统一生成与策略的关键设计**：训练时用视频信息、推理时绕过它保速度；
+- **一模型多功能**降低系统复杂度；
+- 对人形操作，视频世界知识 + 高速动作两者兼得很重要；
+- 与 DreamGen、Humanoid World Models 的"视频世界模型"路线在"视频↔动作"上呼应。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.00200](https://arxiv.org/abs/2503.00200) | 论文正文（联合潜表示、解耦解码、多功能实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块/相关·视频-动作/世界模型**：[DreamGen](../DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md) · [Humanoid World Models（本仓 11）](../../11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md)。

--- a/papers/06_Manipulation/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md
+++ b/papers/06_Manipulation/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "Vision in Action: Learning Active Perception from Human Demonstrations"
+zhname: "Vision in Action：从人类演示学习主动感知"
+category: "Manipulation"
+arxiv: "2506.15666"
+---
+
+# Vision in Action: Learning Active Perception from Human Demonstrations
+**面向双臂操作的主动感知系统 ViA：直接从人类演示学搜索/跟踪/聚焦等任务相关的主动感知策略；硬件上用一个简单有效的 6 自由度机器人颈实现灵活拟人头部运动，并设计基于 VR 的遥操作接口在人机间建立共享观测空间，用中间 3D 场景表征实时渲染视角、异步更新以缓解机器人物理运动延迟引发的 VR 眩晕；在三个含视觉遮挡的多阶段双臂任务上显著优于基线**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 06 Manipulation · 主动感知 · 6-DoF 机器人颈 · VR 遥操作 · 共享观测 · 遮挡
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 6 月 |
+| arXiv | [2506.15666](https://arxiv.org/abs/2506.15666) · [PDF](https://arxiv.org/pdf/2506.15666) · [HTML](https://arxiv.org/html/2506.15666v1) |
+| 作者 | Haoyu Xiong、Xiaomeng Xu、Jimmy Wu、Yifan Hou、Jeannette Bohg、Shuran Song（Stanford） |
+| 主题 | cs.RO · 主动感知 / 双臂操作 / VR 遥操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Manipulation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> Vision in Action（ViA）是面向**双臂机器人操作**的**主动感知系统**，直接**从人类演示**学**任务相关的主动感知策略**（如**搜索、跟踪、聚焦**）。硬件上，ViA 用一个**简单有效的 6 自由度机器人颈**实现**灵活、拟人**的头部运动。为捕捉人类主动感知策略，设计了**基于 VR 的遥操作接口**，在**机器人与操作者之间建立共享观测空间**。为缓解机器人**物理运动延迟**导致的**VR 眩晕**，接口用**中间 3D 场景表征**，在操作者端**实时渲染视角**、并**异步**用机器人最新观测更新场景。这些设计共同支撑了在**三个含视觉遮挡**的复杂**多阶段双臂操作**任务上学到鲁棒视觉运动策略，**显著优于基线**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| ViA | Vision in Action，主动感知系统 |
+| Active Perception | 主动感知（搜索/跟踪/聚焦） |
+| 6-DoF Neck | 6 自由度机器人颈 |
+| Shared Observation Space | 人机共享观测空间 |
+| 3D Scene Representation | 中间 3D 场景表征（缓解延迟/眩晕） |
+| Asynchronous Update | 异步更新 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+双臂操作中**视觉遮挡**常见，需**主动调整视角**：
+- 固定相机看不全，需**主动搜索/跟踪/聚焦**；
+- 想**从人类演示学**主动感知，但遥操作有**延迟**致**VR 眩晕**；
+- 缺**拟人头部硬件**与**共享观测**接口。
+
+ViA 要：硬件（6-DoF 颈）+ 接口（VR 共享观测 + 3D 表征缓延迟）+ 从人类演示学主动感知。
+
+---
+
+## 🔧 方法详解
+
+### 1. 6 自由度机器人颈（拟人头动）
+**简单有效的 6-DoF 颈**实现灵活、拟人的头部运动，支撑主动视角调整。
+
+### 2. VR 遥操作 + 共享观测空间
+**VR 接口**在人机间建立**共享观测空间**，让操作者"用机器人的眼睛"看，从而把人类**主动感知策略**采集下来。
+
+### 3. 3D 场景表征缓解延迟/眩晕
+用**中间 3D 场景表征**：操作者端**实时渲染**视角，**异步**用机器人最新观测更新——缓解物理运动延迟导致的 **VR 眩晕**。
+
+### 4. 结果
+- 三个含**视觉遮挡**的多阶段双臂任务；
+- 学到鲁棒视觉运动策略，**显著优于基线**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    OP["🧑 操作者(VR)"] --> SHARE
+    subgraph SHARE["VR 共享观测空间"]
+        S3D["中间 3D 场景表征<br/>实时渲染 + 异步更新(缓眩晕)"]
+    end
+    SHARE --> DEMO["人类主动感知演示<br/>(搜索/跟踪/聚焦)"]
+    NECK["🦒 6-DoF 机器人颈"] --> POL
+    DEMO --> POL["学主动感知策略"]
+    POL --> OUT["🤖 三个含遮挡双臂任务<br/>显著优于基线"]
+
+    style SHARE fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **主动感知系统 ViA**：从人类演示学搜索/跟踪/聚焦；
+2. **6-DoF 机器人颈**：灵活拟人头部运动；
+3. **VR 共享观测 + 3D 表征**：采集主动感知并缓解延迟/眩晕；
+4. **遮挡任务显著领先**：三个多阶段双臂任务优于基线。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **主动感知（会动的头）对遮挡任务是刚需**，固定相机看不全；
+- **共享观测空间 + 3D 表征**是高质量遥操作采集的关键工程；
+- **缓解 VR 眩晕**直接影响数据质量与采集时长；
+- 与 EgoMI（头手协调）共同强调"主动视觉"对操作的价值。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2506.15666](https://arxiv.org/abs/2506.15666) | 论文正文（6-DoF 颈、VR 接口、3D 表征、遮挡实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·主动感知**：[EgoMI（主动视觉头手协调）](../EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md) · [Learning to Look Around](../Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.md)。

--- a/papers/07_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md
+++ b/papers/07_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "ACE: A Cross-Platform Visual-Exoskeletons System for Low-Cost Dexterous Teleoperation"
+zhname: "ACE：面向低成本灵巧遥操作的跨平台视觉-外骨骼系统"
+category: "Teleoperation"
+arxiv: "2408.11805"
+---
+
+# ACE: A Cross-Platform Visual-Exoskeletons System for Low-Cost Dexterous Teleoperation
+**一套低成本、跨平台的视觉-外骨骼遥操作系统：用面向手的相机捕捉 3D 手部姿态、便携底座上的外骨骼实时精确捕捉手指与手腕姿态；不必为不同机器人定制硬件，单一系统即可泛化到拟人手、臂-手、臂-夹爪、四足-夹爪等多种末端，实现跨平台高精度遥操作，支撑复杂操作任务的模仿学习**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 视觉-外骨骼 · 跨平台 · 低成本 · 灵巧操作 · 模仿学习
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 8 月 |
+| arXiv | [2408.11805](https://arxiv.org/abs/2408.11805) · [PDF](https://arxiv.org/pdf/2408.11805) · [HTML](https://arxiv.org/html/2408.11805v1) |
+| 作者 | Shiqi Yang、Minghuan Liu、Yuzhe Qin、Runyu Ding、Jialong Li、Xuxin Cheng、Ruihan Yang、Sha Yi、Xiaolong Wang（UCSD 等） |
+| 主题 | cs.RO · 跨平台遥操作 / 视觉-外骨骼 / 灵巧操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 从演示学习对机器人操作很有效，跨平台高效遥操作系统因此愈发关键。但当前**缺少**面向不同末端（拟人手、夹爪）且能**跨平台**的**低成本、易用**遥操作系统。ACE 是一套**跨平台的视觉-外骨骼系统**，做**低成本灵巧遥操作**：用一个**面向手的相机**捕捉 **3D 手部姿态**，配一个**便携底座上的外骨骼**，**实时精确捕捉手指与手腕姿态**。相比以往常需**按机器人定制硬件**的系统，ACE 的**单一系统**即可泛化到**拟人手、臂-手、臂-夹爪、四足-夹爪**等多种构型，实现**高精度**遥操作，从而支撑多平台上**复杂操作任务的模仿学习**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Visual-Exoskeleton | 视觉 + 外骨骼混合捕捉 |
+| Cross-Platform | 跨平台，泛化到多种末端 |
+| Hand-facing Camera | 面向手的相机，捕 3D 手姿 |
+| Finger/Wrist Pose | 手指 / 手腕姿态 |
+| End-Effector | 末端执行器（手/夹爪） |
+| Imitation Learning | 模仿学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+跨平台遥操作缺**通用、低成本**方案：
+- 不同末端（拟人手 vs 夹爪）通常**各自定制硬件**；
+- 缺**单一系统跨多平台**的高精度遥操作。
+
+ACE 要：一套**低成本、跨平台**、能同时捕**手指 + 手腕**的灵巧遥操作系统。
+
+---
+
+## 🔧 方法详解
+
+### 1. 视觉 + 外骨骼混合捕捉
+- **面向手的相机**：捕捉 **3D 手部姿态**（手指）；
+- **便携底座上的外骨骼**：实时精确捕捉**手腕（及手指）姿态**。
+
+视觉 + 外骨骼互补，得到准确的手指 + 手腕实时姿态。
+
+### 2. 跨平台泛化（单一系统）
+不必按机器人定制硬件，**同一系统**泛化到**拟人手、臂-手、臂-夹爪、四足-夹爪**等多种构型。
+
+### 3. 支撑模仿学习
+高精度遥操作产出高质量演示，支撑**多平台复杂操作任务**的**模仿学习**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    CAM["📷 面向手相机<br/>3D 手部姿态"] --> CAP
+    EXO["🦾 便携外骨骼<br/>手指+手腕姿态"] --> CAP
+    subgraph CAP["ACE 混合捕捉"]
+        F["实时精确手指+手腕"]
+    end
+    CAP --> OUT["🤖 跨平台单一系统<br/>拟人手/臂-手/臂-夹爪/四足-夹爪<br/>→ 模仿学习"]
+
+    style CAP fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **跨平台视觉-外骨骼系统**：单一系统泛化到多种末端构型；
+2. **视觉 + 外骨骼混合捕捉**：相机捕手指、外骨骼捕手腕，实时高精度；
+3. **低成本、便携**：免按机器人定制硬件；
+4. **支撑模仿学习**：高质量演示用于复杂操作任务。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **跨平台单一系统**大幅降低多机型数据采集成本；
+- **视觉 + 外骨骼互补**是兼顾精度与成本的好折中；
+- **手指 + 手腕同时捕**对灵巧操作至关重要；
+- 与 Bunny-VisionPro、NuExo 等灵巧/外骨骼遥操作共同推进低成本数据采集。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2408.11805](https://arxiv.org/abs/2408.11805) | 论文正文（视觉-外骨骼、跨平台泛化、模仿学习） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·灵巧/外骨骼遥操作**：[Bunny-VisionPro（双手灵巧 VR 遥操作）](../Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning.md) · [NuExo（上肢外骨骼）](../NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md)。

--- a/papers/07_Teleoperation/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning.md
+++ b/papers/07_Teleoperation/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "Bunny-VisionPro: Real-Time Bimanual Dexterous Teleoperation for Imitation Learning"
+zhname: "Bunny-VisionPro：面向模仿学习的实时双手灵巧遥操作"
+category: "Teleoperation"
+arxiv: "2407.03162"
+---
+
+# Bunny-VisionPro: Real-Time Bimanual Dexterous Teleoperation for Imitation Learning
+**基于 VR 头显的实时双手灵巧遥操作系统：不同于以往纯视觉方案，设计低成本设备给操作者力触觉反馈以增强沉浸；内置碰撞与奇异点规避保安全、并保持实时；在标准任务集上成功率更高、用时更短，所采高质量演示提升下游模仿学习的泛化，并首次支持多阶段长时程双手灵巧操作任务的模仿学习**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 双手灵巧 · VR 头显 · 力触觉反馈 · 安全规避 · 模仿学习
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 7 月 |
+| arXiv | [2407.03162](https://arxiv.org/abs/2407.03162) · [PDF](https://arxiv.org/pdf/2407.03162) · [HTML](https://arxiv.org/html/2407.03162v1) |
+| 作者 | Runyu Ding、Yuzhe Qin、Jiyue Zhu、Chengzhe Jia、Shiqi Yang、Ruihan Yang、Xiaojuan Qi、Xiaolong Wang（HKU / UCSD） |
+| 主题 | cs.RO · 双手灵巧遥操作 / 力触觉 / 模仿学习 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 遥操作是采集人类演示的关键工具，但用**双手灵巧手**控制机器人很难——以往系统难以协调两只手做精细操作。Bunny-VisionPro 是一个**实时双手灵巧遥操作系统**，基于 **VR 头显**。不同于以往**纯视觉**方案，作者设计了**低成本设备**给操作者**力触觉反馈**，增强**沉浸感**。系统通过内置**碰撞规避**与**奇异点规避**优先保证**安全**，同时以创新设计保持**实时**。在**标准任务集**上，Bunny-VisionPro **成功率更高、用时更短**；其**高质量演示**提升下游**模仿学习**的表现与泛化；尤其首次支持具有**挑战性的多阶段、长时程双手灵巧操作**任务的模仿学习。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Bimanual | 双手 |
+| Dexterous | 灵巧（多指手操作） |
+| Haptic Feedback | 力触觉反馈 |
+| Singularity Avoidance | 奇异点规避 |
+| Collision Avoidance | 碰撞规避 |
+| Imitation Learning | 模仿学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+双手灵巧遥操作难点：
+- **协调两只灵巧手**做精细操作难；
+- 纯视觉方案**缺力反馈**、沉浸差；
+- 要兼顾**安全**（防碰撞/奇异）与**实时**。
+
+论文要：一个**实时、带力反馈、安全**的双手灵巧遥操作系统，并产出高质量演示供模仿学习。
+
+---
+
+## 🔧 方法详解
+
+### 1. VR 头显 + 低成本力触觉反馈
+基于 **VR 头显**做实时双手控制；设计**低成本设备**提供**力触觉反馈**，比纯视觉更沉浸。
+
+### 2. 安全：碰撞 + 奇异点规避
+内置**碰撞规避**与**奇异点规避**，在保证**实时**的同时优先**安全**。
+
+### 3. 高质量演示 → 模仿学习
+高质量双手演示提升下游**模仿学习**的成功率与**泛化**；首次支持**多阶段、长时程双手灵巧**任务的模仿学习。
+
+### 4. 结果
+- 标准任务集上**成功率更高、用时更短**；
+- 下游 IL 泛化更好。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    VR["🥽 VR 头显 + 低成本力触觉设备"] --> SYS
+    subgraph SYS["Bunny-VisionPro 实时双手遥操作"]
+        S["碰撞 + 奇异点规避(安全)"]
+    end
+    SYS --> DEMO["高质量双手演示"]
+    DEMO --> OUT["🤖 标准任务集成功率↑用时↓<br/>多阶段长时程双手 IL"]
+
+    style SYS fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **实时双手灵巧遥操作（VR）**：协调两只灵巧手做精细操作；
+2. **低成本力触觉反馈**：比纯视觉更沉浸；
+3. **安全 + 实时**：碰撞与奇异点规避；
+4. **促进模仿学习**：高质量演示提升泛化，首次支持多阶段长时程双手 IL。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **力触觉反馈显著提升灵巧遥操作质量**：操作者"感受到"接触才能做精细任务；
+- **安全规避内建**让遥操作既快又稳，利于规模化采集；
+- **长时程多阶段双手演示**是稀缺且珍贵的数据，对复杂操作策略至关重要；
+- 与 ACE、TeleOpBench 等共同构成灵巧遥操作的数据/系统生态。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2407.03162](https://arxiv.org/abs/2407.03162) | 论文正文（VR 系统、力反馈、安全规避、IL 实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·灵巧遥操作/基准**：[ACE（跨平台视觉-外骨骼）](../ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md) · [TeleOpBench（双臂遥操作基准）](../TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation.md)。

--- a/papers/07_Teleoperation/CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md
+++ b/papers/07_Teleoperation/CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "CHILD: a Whole-Body Humanoid Teleoperation System"
+zhname: "CHILD：全身人形遥操作系统"
+category: "Teleoperation"
+arxiv: "2508.00162"
+---
+
+# CHILD: a Whole-Body Humanoid Teleoperation System
+**一套紧凑可重构的关节级全身人形遥操作装置：能塞进标准婴儿背带，让操作者同时控制四肢，支持直接关节映射的全身控制与移动操作；内置自适应力反馈以提升体验并防止不安全关节运动；在人形与多款双臂系统上验证，并开源硬件设计**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 关节级全身 · 可穿戴可重构 · 力反馈 · 开源硬件
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 8 月 |
+| arXiv | [2508.00162](https://arxiv.org/abs/2508.00162) · [PDF](https://arxiv.org/pdf/2508.00162) · [HTML](https://arxiv.org/html/2508.00162v1) |
+| 作者 | Noboru Myers、Obin Kwon、Sankalp Yamsani、Joohyung Kim（UIUC） |
+| 代码 | 开源硬件设计 |
+| 主题 | cs.RO · 全身遥操作 / 关节级控制 / 可穿戴外骨骼 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 遥操作已能让机器人做复杂操作，但**很少支持人形的「全身关节级」遥操作**，限制了任务多样性。CHILD（Controller for Humanoid Imitation and Live Demonstration）是一套**紧凑、可重构**的遥操作系统，实现对人形的**关节级控制**。它能塞进**标准婴儿背带（baby carrier）**，让操作者**同时控制四肢**，并支持**直接关节映射**的**全身控制与移动操作**。系统内置**自适应力反馈**，提升操作体验并**防止不安全关节运动**。作者在一台人形与多款双臂系统上验证了移动操作与全身控制，并**开源硬件设计**以促进可及性与可复现性。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| CHILD | Controller for Humanoid Imitation and Live Demonstration |
+| Joint-level | 关节级，直接控制各关节 |
+| Reconfigurable | 可重构，适配不同机器人 |
+| Direct Joint Mapping | 直接关节映射，人关节→机器人关节 |
+| Adaptive Force Feedback | 自适应力反馈，防不安全运动 |
+| Loco-manipulation | 移动操作 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+现有遥操作**很少支持人形全身关节级控制**：
+- 多为末端/上身控制，丢失全身关节自由度；
+- 缺乏**可穿戴、可重构**且**安全**的关节级接口。
+
+CHILD 要：一套**便携可穿戴、关节级、带安全力反馈**的全身人形遥操作装置。
+
+---
+
+## 🔧 方法详解
+
+### 1. 紧凑可重构、可穿戴（婴儿背带形态）
+装置可塞进**标准婴儿背带**，操作者穿戴即可**同时控制四肢**，便携且可重构以适配不同机器人。
+
+### 2. 直接关节映射（全身 + 移动操作）
+支持**直接关节映射**，把操作者关节运动映到机器人关节，实现**全身控制**与**移动操作**。
+
+### 3. 自适应力反馈（安全）
+内置**自适应力反馈**：提升操作沉浸感，并**阻止不安全的关节运动**（如越限/碰撞）。
+
+### 4. 验证 + 开源
+在**人形**与**多款双臂系统**上做移动操作与全身控制演示；**开源硬件设计**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    OP["🧑 操作者(穿戴背带式装置)"] --> MAP
+    subgraph MAP["CHILD 关节级映射"]
+        J["四肢直接关节映射"]
+        FB["自适应力反馈(防不安全运动)"]
+    end
+    MAP --> OUT["🤖 人形 / 多双臂系统<br/>全身控制 + 移动操作 · 开源硬件"]
+
+    style MAP fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **关节级全身人形遥操作**：填补"很少支持全身关节级"的空白；
+2. **可穿戴可重构形态**：婴儿背带式，便携、同时控四肢、适配多机型；
+3. **自适应力反馈**：提升体验并防止不安全关节运动；
+4. **开源硬件**：促进可及性与可复现。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **关节级全身接口拓展任务多样性**：比末端控制能表达更丰富的全身行为；
+- **可穿戴 + 低门槛硬件**利于规模化数据采集，呼应 TWIST2、ACE 的低成本理念；
+- **力反馈做安全护栏**是遥操作的实用安全设计；
+- 开源硬件降低社区复现门槛。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2508.00162](https://arxiv.org/abs/2508.00162) | 论文正文（装置设计、关节映射、力反馈、验证） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·全身/可穿戴遥操作**：[TWIST2（便携免动捕采集）](../TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md) · [NuExo（上肢外骨骼）](../NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md) · [ACE（跨平台视觉-外骨骼）](../ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md)。

--- a/papers/07_Teleoperation/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid.md
+++ b/papers/07_Teleoperation/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Heavy lifting tasks via haptic teleoperation of a wheeled humanoid"
+zhname: "通过力触觉遥操作让轮式人形完成重物搬运"
+category: "Teleoperation"
+arxiv: "2505.19530"
+---
+
+# Heavy lifting tasks via haptic teleoperation of a wheeled humanoid
+**面向「动态移动操作（DMM）」——同时控制行走、操作与姿态以搬运重物——的力触觉遥操作框架：人机接口把人体动作重定向到可调高度的轮式人形并施加力反馈；操作者用身体姿态调节机器人姿态与移动、用手臂引导操作，实时反馈末端力旋量与平衡线索；并比较不同遥行走映射的平衡辅助程度，在抬举至多 2.5 kg（21% 自重）的杠铃/箱子上验证协调全身控制与抗扰**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 力触觉反馈 · 动态移动操作 · 轮式人形 · 重物搬运 · 平衡辅助
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 5 月 |
+| arXiv | [2505.19530](https://arxiv.org/abs/2505.19530) · [PDF](https://arxiv.org/pdf/2505.19530) · [HTML](https://arxiv.org/html/2505.19530v1) |
+| 作者 | Amartya Purushottam、Jack Yan、Christopher Yu、Joao Ramos（UIUC） |
+| 主题 | cs.RO · 力触觉遥操作 / 动态移动操作 / 轮式人形 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人形可在体力要求高的环境里支援人类，做需要**全身协调**的任务（抬运重物）。本文称之为**动态移动操作（Dynamic Mobile Manipulation, DMM）**——需要在**动态交互力**下**同时控制行走、操作与姿态**。论文提出在**可调高度的轮式人形**上做 DMM 的**遥操作框架**：一个**人机接口（HMI）**通过捕捉人体动作并施加**力触觉反馈**，把人体动作**全身重定向**到机器人。操作者用**身体姿态**调节机器人**姿态与移动**、用**手臂**引导**操作**；**实时力反馈**传递**末端力旋量**与**平衡线索**，闭合"人感知 ↔ 机器人环境交互"的回路。论文还比较了提供不同**平衡辅助**程度的**遥行走映射**，让操作者**手动或自动**调节机器人对**负载扰动**的倾斜。最终在抬举至多 **2.5 kg（机器人质量 21%）**的杠铃/箱子实验中验证了协调全身控制、变高度与抗扰。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| DMM | Dynamic Mobile Manipulation，动态移动操作 |
+| HMI | Human-Machine Interface，人机接口 |
+| Haptic Feedback | 力触觉反馈 |
+| Wrench | 力旋量（力 + 力矩） |
+| Telelocomotion | 遥行走，远程控制机器人行走 |
+| Balance Assistance | 平衡辅助，帮助操作者维持机器人平衡 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+搬重物的**动态移动操作**要**同时**控制行走、操作、姿态，且面对**负载扰动**：
+- 纯自主难、纯手动遥操作又难维持平衡；
+- 操作者需要**感知**末端力与平衡状态才能稳。
+
+论文要：一套**带力触觉反馈、可调平衡辅助**的轮式人形遥操作框架。
+
+---
+
+## 🔧 方法详解
+
+### 1. HMI 全身重定向 + 力反馈
+**人机接口**捕捉人体动作、施加**力触觉反馈**，把动作**全身重定向**到可调高度轮式人形。
+
+### 2. 身体管姿态/移动、手臂管操作
+- **身体姿态** → 调节机器人**姿态与移动（telelocomotion）**；
+- **手臂动作** → 引导**操作**。
+
+### 3. 实时力反馈闭环
+反馈**末端力旋量**与**平衡线索**，让操作者"感受到"机器人与环境的交互，闭合感知-动作回路。
+
+### 4. 可调平衡辅助 + 评测
+比较不同**遥行走映射**（手动/自动调节机器人倾斜以抵抗负载扰动）；在抬举至多 **2.5 kg（21% 自重）**杠铃/箱子上验证协调全身控制、变高度与抗扰。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    PILOT["🧑‍✈️ 操作者<br/>身体→姿态/移动, 手臂→操作"] --> HMI
+    subgraph HMI["HMI(力触觉反馈)"]
+        RT["全身重定向"]
+        FB["末端力旋量 + 平衡线索反馈"]
+    end
+    HMI --> BAL["可调平衡辅助<br/>(手动/自动调倾斜)"]
+    BAL --> OUT["🤖 轮式人形抬 ≤2.5kg(21%自重)<br/>协调全身控制 + 抗扰"]
+
+    style HMI fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **DMM 遥操作框架**：力触觉 HMI 把人体动作全身重定向到轮式人形；
+2. **分工映射**：身体管姿态/移动、手臂管操作；
+3. **实时力旋量 + 平衡反馈**：闭合感知-交互回路；
+4. **可调平衡辅助**：手动/自动抗负载扰动，2.5 kg（21% 自重）重物验证。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **力触觉反馈是重载遥操作的关键**：让操作者"感受到"负载与平衡才能稳；
+- **平衡辅助可调**兼顾操作者掌控与系统稳定；
+- **轮式人形**在重载移动操作上是务实平台（与同组的物体参数估计工作互补）；
+- DMM 的"同时控行走+操作+姿态"是全身控制的硬命题。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2505.19530](https://arxiv.org/abs/2505.19530) | 论文正文（HMI、力反馈、平衡辅助、重物实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·轮式/重载遥操作**：[Whole-Body Bilateral Teleop（多阶段物体参数估计）](../Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation.md)；
+- **负载搬运**：[SplitAdapter](../../04_Loco-Manipulation_and_WBC/SplitAdapter__Load-Aware_Humanoid_Loco-Manipulation_via_Factorized_Adaptation/SplitAdapter__Load-Aware_Humanoid_Loco-Manipulation_via_Factorized_Adaptation.md)。

--- a/papers/07_Teleoperation/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots.md
+++ b/papers/07_Teleoperation/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "High-Speed and Impact Resilient Teleoperation of Humanoid Robots"
+zhname: "人形机器人的高速且抗冲击遥操作"
+category: "Teleoperation"
+arxiv: "2409.04639"
+---
+
+# High-Speed and Impact Resilient Teleoperation of Humanoid Robots
+**面向高速、抗冲击的人形遥操作的软硬件一体方案：免标定动捕与重定向（仅用 7 个 IMU 生成全身机器人参考）、低延迟的快速全身运动学流式工具箱、以及高带宽摆线执行器三者结合；在人形 Nadia 上验证，展示遥操作的前所未有性能**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 高速 · 抗冲击 · 免标定动捕 · 低延迟流式 · 摆线执行器
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 9 月 |
+| arXiv | [2409.04639](https://arxiv.org/abs/2409.04639) · [PDF](https://arxiv.org/pdf/2409.04639) · [HTML](https://arxiv.org/html/2409.04639v1) |
+| 作者 | Sylvain Bertrand、Luigi Penco、Dexton Anderson、Duncan Calvert、Jerry Pratt、Robert Griffin 等（IHMC / Boardwalk Robotics） |
+| 主题 | cs.RO · 高速遥操作 / 抗冲击 / 硬件 + 控制 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人形遥操作长期是难题，需要**软硬件协同进步**才能实现无缝直观的控制。本文提出一个**集成方案**，由几大要素构成：① **免标定（calibration-free）的动作捕捉与重定向**——仅用 **7 个 IMU** 即可生成**全身机器人参考**；② **低延迟的快速全身运动学流式工具箱**，降低端到端延迟；③ **高带宽摆线执行器（cycloidal actuators）**，使机器人能**高速且抗冲击**。在人形机器人 **Nadia** 上验证，通过**感知、控制与驱动**的协同进步，展示了遥操作的**前所未有的性能**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Calibration-free | 免标定，无需繁琐标定流程 |
+| IMU | 惯性测量单元（本文仅用 7 个） |
+| Kinematics Streaming | 运动学流式传输，低延迟下发参考 |
+| Cycloidal Actuator | 摆线执行器，高带宽、抗冲击 |
+| Impact Resilient | 抗冲击，承受碰撞不损坏 |
+| Retargeting | 动作重定向 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形遥操作要做到**高速、抗冲击、低延迟**，需软硬件同步突破：
+- **动捕标定**繁琐、传感器多；
+- **延迟**高导致控制不跟手；
+- **执行器**带宽不足，难高速/抗冲击。
+
+论文要：一套**感知 + 控制 + 驱动**协同的集成方案。
+
+---
+
+## 🔧 方法详解
+
+### 1. 免标定动捕 + 重定向（仅 7 IMU）
+**免标定**的动捕与重定向，仅用 **7 个 IMU** 就能生成**全身机器人参考**，大幅简化穿戴/标定。
+
+### 2. 低延迟全身运动学流式工具箱
+一个**快速全身运动学流式工具箱**，**降低端到端延迟**，让遥操作更跟手。
+
+### 3. 高带宽摆线执行器（高速 + 抗冲击）
+**高带宽摆线执行器**赋予机器人**高速运动**与**抗冲击**能力——这是硬件侧的关键。
+
+### 4. 验证
+在人形 **Nadia** 上验证，三者协同实现**前所未有的遥操作性能**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    IMU["📡 7 IMU 免标定动捕"] --> RT["重定向 → 全身参考"]
+    RT --> STREAM["低延迟运动学流式工具箱"]
+    STREAM --> ACT["高带宽摆线执行器<br/>(高速 + 抗冲击)"]
+    ACT --> OUT["🤖 人形 Nadia<br/>高速抗冲击遥操作"]
+
+    style STREAM fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style ACT fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **软硬件一体的高速抗冲击遥操作**：感知 + 控制 + 驱动协同；
+2. **免标定动捕（7 IMU）**：简化穿戴/标定即得全身参考；
+3. **低延迟运动学流式**：提升跟手性；
+4. **高带宽摆线执行器**：使高速与抗冲击成为可能（Nadia 验证）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **遥操作性能受限于"最慢的一环"**：动捕、延迟、执行器需同步优化；
+- **硬件（摆线执行器）是高速/抗冲击的物理前提**，提醒算法之外的本体重要性；
+- **免标定 + 少传感器**降低使用门槛，利于现场部署；
+- 高速抗冲击能力为采集"动态/接触丰富"演示提供条件。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2409.04639](https://arxiv.org/abs/2409.04639) | 论文正文（免标定动捕、流式工具箱、摆线执行器、Nadia 实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·遥操作系统/硬件**：[NuExo（上肢外骨骼）](../NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md) · [CHILD（关节级全身）](../CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md)。

--- a/papers/07_Teleoperation/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots.md
+++ b/papers/07_Teleoperation/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "Human-Robot Collaboration for the Remote Control of Mobile Humanoid Robots with Torso-Arm Coordination"
+zhname: "面向移动人形远程控制的人机协作躯干-手臂协调"
+category: "Teleoperation"
+arxiv: "2505.05773"
+---
+
+# Human-Robot Collaboration for the Remote Control of Mobile Humanoid Robots with Torso-Arm Coordination
+**面向医院/养老等场景里被远程操控的移动人形，针对其运动学冗余带来的躯干-手臂协调难题，提出在「自主」与「人控」之间取平衡的人机协作方法：既有人发起（手动控躯干）、也有机器人发起（依可达性、任务目标与推断的人类意图自主协调）的躯干-手臂宏-微结构协调；17 人用户研究在任务表现、可操作度与能效上比较，给出操作者更偏好的策略**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 人机协作 · 躯干-手臂协调 · 运动学冗余 · 用户研究 · ICRA 2025
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 5 月 |
+| arXiv | [2505.05773](https://arxiv.org/abs/2505.05773) · [PDF](https://arxiv.org/pdf/2505.05773) · [HTML](https://arxiv.org/html/2505.05773v1) |
+| 会议 | ICRA 2025 |
+| 作者 | Nikita Boguslavskii、Lorena Maria Genua、Zhi Li（WPI） |
+| 主题 | cs.RO · 人机协作 / 躯干-手臂协调 / 远程控制 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 越来越多人形被部署到**医院、养老**等场所，常由人**远程操控**。本文针对**运动学冗余**的**移动人形**的**躯干-手臂协调**难题，提出在**自主与人控之间取平衡**的人机协作方法：① **人发起（human-initiated）**——操作者**手动控制躯干**运动；② **机器人发起（robot-initiated）**——机器人依据**可达性、任务目标与推断的人类意图**做**自主协调**。围绕**躯干-手臂宏-微（macro-micro）结构**设计协调机制。通过 **N=17** 的用户研究，在**任务表现、可操作度（manipulability）与能效**等多指标上比较，分析参与者偏好，给出"如何平衡自主与人输入以提升效率与任务执行"的结论。已被 **ICRA 2025** 接收。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Torso-Arm Coordination | 躯干-手臂协调 |
+| Kinematic Redundancy | 运动学冗余，自由度多于任务所需 |
+| Human/Robot-Initiated | 人发起 / 机器人发起的协调 |
+| Macro-Micro | 宏-微结构（躯干大范围 + 手臂精细） |
+| Manipulability | 可操作度，末端灵活性度量 |
+| User Study | 用户研究（N=17） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+远程操控**移动人形**（医院/养老场景）时：
+- 机器人**运动学冗余**（躯干 + 手臂），**协调难**；
+- 全自主不够灵活、全手动负担重；
+- 不清楚**哪种自主/人控平衡**操作者更偏好、更高效。
+
+论文要：设计并比较**躯干-手臂协调**的人机协作策略，找到好的"自主 ↔ 人控"平衡。
+
+---
+
+## 🔧 方法详解
+
+### 1. 两类协调策略
+- **人发起**：操作者**手动控制躯干**，主导大范围运动；
+- **机器人发起**：机器人依据**可达性 + 任务目标 + 推断的人类意图**做**自主躯干协调**。
+
+### 2. 躯干-手臂宏-微结构
+把**躯干**当**宏（macro）**大范围调位、**手臂**当**微（micro）**精细操作，二者协调利用冗余。
+
+### 3. 用户研究（N=17）
+跨**任务表现、可操作度、能效**多指标比较两类策略，分析**参与者偏好**，给出自主/人控平衡的建议。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    OP["🧑 远程操作者"] --> COORD
+    subgraph COORD["躯干-手臂协调(宏-微)"]
+        HI["人发起：手动控躯干"]
+        RI["机器人发起：依可达性/任务/意图自主协调"]
+    end
+    COORD --> STUDY["N=17 用户研究<br/>任务表现/可操作度/能效"]
+    STUDY --> OUT["📊 操作者偏好 + 自主↔人控平衡建议<br/>(ICRA 2025)"]
+
+    style COORD fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **躯干-手臂协调的人机协作方法**：人发起 + 机器人发起两类策略；
+2. **宏-微结构利用运动学冗余**：躯干大范围、手臂精细；
+3. **机器人发起协调**：依可达性、任务目标与推断意图自主协调；
+4. **N=17 用户研究**：多指标比较、给出自主/人控平衡建议（ICRA 2025）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"自主 ↔ 人控"平衡**是辅助/医护场景遥操作的核心设计问题；
+- **意图推断驱动的机器人发起协调**减轻操作者负担，是共享自主的方向；
+- **以人为本的用户研究**对遥操作系统评价不可或缺（不止任务成功率）；
+- 躯干-手臂冗余协调对所有移动人形操作都有借鉴。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2505.05773](https://arxiv.org/abs/2505.05773) | 论文正文（协调策略、用户研究、ICRA 2025） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·遥操作/共享自主**：[CHILD（关节级全身遥操作）](../CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md) · [Mobile-TeleVision](../Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md)。

--- a/papers/07_Teleoperation/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md
+++ b/papers/07_Teleoperation/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Mobile-TeleVision: Predictive Motion Priors for Humanoid Whole-Body Control"
+zhname: "Mobile-TeleVision：面向人形全身控制的预测式运动先验"
+category: "Teleoperation"
+arxiv: "2412.07773"
+---
+
+# Mobile-TeleVision: Predictive Motion Priors for Humanoid Whole-Body Control
+**把上身控制与行走解耦：上身用逆运动学 + 动作重定向做精确操作，RL 专注鲁棒下身行走；提出用条件变分自编码器（CVAE）训练的预测式运动先验 PMP 来表示上身动作，并让行走策略以该上身表征为条件，从而在操作与行走时都保持鲁棒；CVAE 特征对稳定性至关重要，在精确操作上显著优于纯 RL 全身控制**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 上下身解耦 · CVAE 运动先验 · IK 重定向 · 精确操作 · ICRA 2025
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 12 月 |
+| arXiv | [2412.07773](https://arxiv.org/abs/2412.07773) · [PDF](https://arxiv.org/pdf/2412.07773) · [HTML](https://arxiv.org/html/2412.07773v2) |
+| 会议 | ICRA 2025 |
+| 作者 | Chenhao Lu、Xuxin Cheng、Jialong Li、Shiqi Yang、Mazeyu Ji、Chengjing Yuan、Ge Yang、Sha Yi、Xiaolong Wang（UCSD / MIT 等） |
+| 主题 | cs.RO · 全身控制 / 上下身解耦 / 遥操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人形需要**鲁棒下身行走**与**精确上身操作**。近期 RL 给出全身 loco-manip 策略，但对**高自由度手臂的精确操作**不足。本文**解耦上身控制与行走**：**上身**用**逆运动学（IK）+ 动作重定向**做**精确操作**，**RL** 专注**鲁棒下身行走**。提出 **PMP（Predictive Motion Priors）**，用**条件变分自编码器（CVAE）**训练以**有效表示上身动作**；**行走策略以该上身动作表征为条件**，确保操作与行走**同时鲁棒**。实验表明 **CVAE 特征**对**稳定性与鲁棒性至关重要**，在**精确操作**上**显著优于纯 RL 全身控制**。借助精确上身 + 鲁棒下身，操作者可远程控制人形**走动探索不同环境**并执行多样操作任务。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| PMP | Predictive Motion Priors，预测式运动先验 |
+| CVAE | 条件变分自编码器 |
+| IK | Inverse Kinematics，逆运动学 |
+| Decoupled Control | 解耦控制（上身/下身分开） |
+| Retargeting | 动作重定向 |
+| Whole-Body | 全身 loco-manip |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形全身控制的两难：
+- 纯 **RL 全身**策略**精确操作不足**（高 DoF 手臂难精控）；
+- 但操作与行走又要**同时鲁棒**。
+
+论文要：既要**上身精确操作**、又要**下身鲁棒行走**，且二者协调不互相破坏。
+
+---
+
+## 🔧 方法详解
+
+### 1. 上下身解耦
+- **上身**：用 **IK + 动作重定向**做**精确操作**（高 DoF 手臂精控）；
+- **下身**：用 **RL** 学**鲁棒行走**。
+
+### 2. PMP：CVAE 上身运动先验
+用 **CVAE** 训练 **PMP** 来**表示上身动作**，给上身动作一个紧凑、可预测的表征。
+
+### 3. 行走以上身表征为条件
+**行走策略条件于 PMP 上身表征**：下身"知道"上身在干什么，从而在操作时仍**保持鲁棒**。CVAE 特征对**稳定性**至关重要。
+
+### 4. 结果
+- 精确操作**显著优于纯 RL 全身控制**；
+- 操作者可远程控制人形**走动 + 多样操作**（ICRA 2025）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    UP["🖐️ 上身：IK + 重定向<br/>精确操作"] --> PMP
+    subgraph PMP["PMP (CVAE 上身运动先验)"]
+        Z["上身动作表征"]
+    end
+    PMP --> LOW["🦿 下身：RL 行走<br/>(以上身表征为条件)"]
+    LOW --> OUT["🤖 精确操作 + 鲁棒行走<br/>远程走动探索 (ICRA 2025)"]
+
+    style PMP fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **上下身解耦**：上身 IK+重定向精操作、下身 RL 鲁棒行走；
+2. **PMP（CVAE 运动先验）**：紧凑表示上身动作；
+3. **行走条件于上身表征**：操作与行走同时鲁棒；
+4. **精操作领先**：显著优于纯 RL 全身控制（ICRA 2025）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **解耦是"精确 vs 鲁棒"两难的有效解**：让 IK 管精度、RL 管稳健；
+- **CVAE 运动先验**给行走提供"上身意图"上下文，避免互相破坏；
+- **遥操作 + 行走探索**拓展了人形可达任务空间；
+- 与 TWIST（统一控制器）形成"解耦 vs 统一"的对照。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2412.07773](https://arxiv.org/abs/2412.07773) | 论文正文（解耦、PMP/CVAE、行走条件、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·全身遥操作**：[TWIST（统一控制器全身模仿）](../TWIST__Teleoperated_Whole-Body_Imitation_System/TWIST__Teleoperated_Whole-Body_Imitation_System.md) · [Human-Robot Collaboration（躯干-手臂协调）](../Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots.md)。

--- a/papers/07_Teleoperation/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md
+++ b/papers/07_Teleoperation/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "NuExo: A Wearable Exoskeleton Covering all Upper Limb ROM for Outdoor Data Collection and Teleoperation of Humanoid Robots"
+zhname: "NuExo：覆盖全上肢活动范围的可穿戴外骨骼，用于户外数据采集与人形遥操作"
+category: "Teleoperation"
+arxiv: "2503.10554"
+---
+
+# NuExo: A Wearable Exoskeleton Covering all Upper Limb ROM for Outdoor Data Collection and Teleoperation of Humanoid Robots
+**一套同时满足准确、舒适、通用、便携四目标的可穿戴上肢外骨骼：靠同步连杆 + 同步带传动的新型肩部机构适配复合肩部运动、100% 覆盖自然上肢活动范围；仅 5.2 kg 可背包式户外日常使用；配统一直观遥操作框架与多模态（含力）数据采集，兼容多款人形，跨平台跨用户验证其运动范围、灵活性与动态场景下的采集/遥操作稳定性**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 上肢外骨骼 · 全活动范围 · 户外便携 · 多模态采集 · 力数据
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.10554](https://arxiv.org/abs/2503.10554) · [PDF](https://arxiv.org/pdf/2503.10554) · [HTML](https://arxiv.org/html/2503.10554v1) |
+| 作者 | Rui Zhong、Chuang Cheng、Junpeng Xu、Yantong Wei、Ce Guo、Daoxun Zhang、Wei Dai、Huimin Lu（国防科大等） |
+| 主题 | cs.RO · 可穿戴外骨骼 / 数据采集 / 人形遥操作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 从动捕/遥操作到机器人技能学习的演进，是具身智能的关键路径。但现有系统难**同时**达成四目标：**准确**（长时间精确跟踪全上肢）、**舒适**（贴合人体生物力学）、**通用**（多模态采集如力数据、兼容人形）、**便携**（轻量户外日用）。NuExo 是一套**可穿戴上肢外骨骼**，配**沉浸式直观遥操作**与**多模态感知采集**来弥合此差距。凭借**带同步连杆与同步带传动的新型肩部机构**，它能很好地适配**复合肩部运动**，**100% 覆盖**自然上肢活动范围；整机仅 **5.2 kg**，支持**背包式**户外日常使用。作者还开发了**统一直观的遥操作框架**与**多模态数据采集系统**，兼容多款人形。跨平台、跨用户实验验证了其在**运动范围与灵活性**上的优势，以及在**动态场景**下数据采集与遥操作精度的**稳定性**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| ROM | Range of Motion，活动范围 |
+| Exoskeleton | 外骨骼，可穿戴机械结构 |
+| Synchronized Linkage | 同步连杆，适配复合肩部运动 |
+| Timing Belt | 同步带传动 |
+| Multi-modal Sensing | 多模态感知（含力数据） |
+| Backpack-type | 背包式，便携户外 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+上肢遥操作/采集设备难**同时**满足：
+- **准确**（长时间全上肢精确跟踪）；
+- **舒适**（贴合生物力学）；
+- **通用**（多模态采集 + 兼容人形）；
+- **便携**（轻量户外）。
+
+尤其**肩部复合运动**难覆盖。NuExo 要：一套四目标兼顾的可穿戴上肢外骨骼。
+
+---
+
+## 🔧 方法详解
+
+### 1. 新型肩部机构（全 ROM）
+**同步连杆 + 同步带传动**的肩部机构适配**复合肩部运动**，实现自然上肢活动范围的 **100% 覆盖**——这是"准确 + 舒适"的关键。
+
+### 2. 轻量便携（5.2 kg 背包式）
+整机 **5.2 kg**，**背包式**穿戴，可在**户外日常**场景便捷使用（便携）。
+
+### 3. 统一遥操作框架 + 多模态采集
+配**统一直观遥操作框架**与**多模态感知采集**（含**力数据**），兼容多款人形（通用）。
+
+### 4. 跨平台跨用户验证
+在不同人形平台与多用户上验证**运动范围、灵活性**与**动态场景**下采集/遥操作的**稳定性与精度**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    OP["🧑 操作者(穿戴 5.2kg 背包式外骨骼)"] --> EXO
+    subgraph EXO["NuExo"]
+        SH["新型肩部机构<br/>(同步连杆+同步带, 100% ROM)"]
+        MM["多模态采集(含力)"]
+    end
+    EXO --> FW["统一直观遥操作框架"]
+    FW --> OUT["🤖 多款人形<br/>跨平台/跨用户 · 动态场景稳定"]
+
+    style EXO fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **全上肢 ROM 外骨骼**：新型肩部机构 100% 覆盖自然上肢活动范围；
+2. **四目标兼顾**：准确、舒适、通用、便携（5.2 kg 背包式户外）；
+3. **多模态采集（含力）+ 统一遥操作框架**：兼容多款人形；
+4. **跨平台/跨用户验证**：运动范围、灵活性、动态稳定性。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **肩部复合运动是上肢外骨骼的难点**：新机构覆盖全 ROM 提升采集质量；
+- **力等多模态数据**对接触/灵巧操作学习价值大；
+- **便携户外**让数据采集走出实验室，扩大数据多样性；
+- 与 ACE、CHILD 等可穿戴/外骨骼遥操作工作互补。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.10554](https://arxiv.org/abs/2503.10554) | 论文正文（肩部机构、多模态采集、跨平台实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·外骨骼/可穿戴遥操作**：[ACE（跨平台视觉-外骨骼）](../ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md) · [CHILD（关节级全身）](../CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md)。

--- a/papers/07_Teleoperation/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md
+++ b/papers/07_Teleoperation/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md
@@ -1,0 +1,130 @@
+---
+layout: paper
+title: "TWIST2: Scalable, Portable, and Holistic Humanoid Data Collection System"
+zhname: "TWIST2：可扩展、便携、整体式的人形数据采集系统"
+category: "Teleoperation"
+arxiv: "2511.02832"
+---
+
+# TWIST2: Scalable, Portable, and Holistic Humanoid Data Collection System
+**针对人形缺少高效数据采集框架（现有要么解耦控制、要么依赖昂贵动捕）的问题，提出便携、免动捕的整体式遥操作与数据采集系统：用 PICO4U VR 实时获取全身人体动作、配约 250 美元的 2 自由度机器人颈部提供第一视角视觉，实现整体「人到人形」控制，并配分层视觉运动策略；15 分钟采 100 条演示、近 100% 成功率，全开源**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 数据采集 · 免动捕 · VR 遥操作 · 第一视角 · 分层视觉运动 · 开源
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 11 月 |
+| arXiv | [2511.02832](https://arxiv.org/abs/2511.02832) · [PDF](https://arxiv.org/pdf/2511.02832) · [HTML](https://arxiv.org/html/2511.02832v1) |
+| 作者 | Yanjie Ze、Siheng Zhao、Weizhuo Wang、Angjoo Kanazawa、Rocky Duan、Pieter Abbeel、Guanya Shi、Jiajun Wu、C. Karen Liu（Stanford / Berkeley / CMU 等） |
+| 代码 | 全开源（系统 + 数据集） |
+| 主题 | cs.RO · 人形遥操作 / 数据采集 / 第一视角 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 大规模数据驱动了机器人突破，但**人形缺少同样有效的数据采集框架**：现有人形遥操作要么用**解耦控制**、要么依赖**昂贵动捕**。TWIST2 提出一个**便携、免动捕（mocap-free）**的人形**遥操作与数据采集系统**，在推进**可扩展性**的同时**保留完整全身控制**。系统用 **PICO4U VR** 实时获取**全身人体动作**，配一个**自制 2 自由度机器人颈部（约 250 美元）**提供**第一视角视觉**，实现整体的**人到人形**控制；并配一个**分层视觉运动策略**框架做自主全身控制。实测：**15 分钟采集 100 条演示**、**近 100% 成功率**；视觉运动策略能用第一视角控制整机；系统**完全可复现、开源**并附数据集。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Mocap-free | 免动捕，不依赖昂贵动作捕捉设备 |
+| Holistic | 整体式，保留完整全身控制 |
+| Egocentric Vision | 第一视角视觉（机器人头部相机） |
+| PICO4U VR | 用于捕捉全身人体动作的 VR 设备 |
+| 2-DoF Neck | 2 自由度机器人颈部（约 $250） |
+| Visuomotor Policy | 视觉运动策略，从视觉到动作 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形要做大规模学习，缺**高效数据采集**：
+- **解耦控制**：上下身/手分开，丢失整体协调；
+- **昂贵动捕**：成本高、不便携、难规模化。
+
+TWIST2 要：一套**便携、低成本、免动捕**且**保留全身控制**的人形遥操作 + 数据采集系统。
+
+---
+
+## 🔧 方法详解
+
+### 1. 免动捕全身动作捕捉（PICO4U VR）
+用 **PICO4U VR** 实时获取操作者**全身人体动作**，免去昂贵动捕房，便携可移动。
+
+### 2. 低成本第一视角颈部
+自制 **2 自由度机器人颈部（约 $250）**提供**第一视角视觉**，让操作者与策略都能"用机器人的眼睛"看，支撑视觉运动学习。
+
+### 3. 整体人到人形控制 + 分层视觉运动策略
+把人体动作整体映射到人形（保全身控制），并训练**分层视觉运动策略**做**自主全身控制**。
+
+### 4. 结果
+- **15 分钟采 100 条演示**、**近 100% 成功率**；
+- 任务覆盖长时程灵巧操作、移动技能、全身灵巧操作、动态踢腿；
+- **完全开源、可复现**，附数据集。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    VR["🥽 PICO4U VR<br/>全身人体动作"] --> MAP
+    NECK["🦒 2-DoF 颈部($250)<br/>第一视角视觉"] --> MAP
+    subgraph MAP["整体人到人形控制"]
+        H["保留完整全身控制"]
+    end
+    MAP --> DATA["📦 15 min / 100 演示<br/>~100% 成功"]
+    DATA --> POL["分层视觉运动策略<br/>自主全身控制"]
+    POL --> OUT["🤖 长时程灵巧 / 移动 / 动态踢腿<br/>全开源"]
+
+    style MAP fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **便携免动捕的整体式采集系统**：保留全身控制，推进可扩展性；
+2. **低成本第一视角颈部**：约 $250 的 2-DoF 颈，提供 egocentric 视觉；
+3. **高效采集**：15 分钟 100 条演示、近 100% 成功率；
+4. **开源可复现**：系统 + 数据集 + 分层视觉运动策略全开源。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **降低数据采集门槛是人形规模化的关键**：免动捕 + 低成本硬件让"人人可采"；
+- **第一视角是视觉运动策略的天然接口**，呼应 ZeroWBC、EgoHumanoid、HEAD；
+- **整体（holistic）控制 > 解耦**：保全身协调对长时程灵巧任务很重要；
+- 作者群（含 Yanjie Ze，本仓上游维护者）开源生态友好，利于社区复现。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2511.02832](https://arxiv.org/abs/2511.02832) | 论文正文（系统、分层策略、数据集、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·遥操作系统**：[TWIST（遥操作全身模仿系统）](../TWIST__Teleoperated_Whole-Body_Imitation_System/TWIST__Teleoperated_Whole-Body_Imitation_System.md) · [CHILD（关节级全身遥操作）](../CHILD__a_Whole-Body_Humanoid_Teleoperation_System/CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md) · [Mobile-TeleVision](../Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md)。

--- a/papers/07_Teleoperation/TWIST__Teleoperated_Whole-Body_Imitation_System/TWIST__Teleoperated_Whole-Body_Imitation_System.md
+++ b/papers/07_Teleoperation/TWIST__Teleoperated_Whole-Body_Imitation_System/TWIST__Teleoperated_Whole-Body_Imitation_System.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "TWIST: Teleoperated Whole-Body Imitation System"
+zhname: "TWIST：遥操作全身模仿系统"
+category: "Teleoperation"
+arxiv: "2505.02833"
+---
+
+# TWIST: Teleoperated Whole-Body Imitation System
+**通过全身动作模仿做人形遥操作：先把人类动捕重定向成机器人参考动作片段，再用 RL+BC 训一个鲁棒、自适应、响应快的全身控制器；系统分析表明加入特权未来动作帧与真实动捕数据可提升跟踪精度；单一统一神经网络控制器即可做全身操作、腿部操作、行走与表现性动作**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 全身模仿 · RL+BC · 动捕重定向 · 统一控制器 · 协调全身
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 5 月 |
+| arXiv | [2505.02833](https://arxiv.org/abs/2505.02833) · [PDF](https://arxiv.org/pdf/2505.02833) · [HTML](https://arxiv.org/html/2505.02833v1) |
+| 作者 | Yanjie Ze、Zixuan Chen、João Pedro Araújo、Zi-ang Cao、Xue Bin Peng、Jiajun Wu、C. Karen Liu（Stanford / SFU 等） |
+| 主题 | cs.RO · 全身遥操作 / 动作模仿 / RL+BC |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 以**全身方式遥操作**人形，是通向通用机器人智能的关键一步——**人类动作**是控制所有自由度的理想接口。但多数人形遥操作系统**做不到协调的全身行为**，只能做孤立的行走或操作。TWIST（Teleoperated Whole-Body Imitation System）通过**全身动作模仿**实现人形遥操作：先把**人类动捕数据**重定向成机器人**参考动作片段**；再用 **RL+BC（强化学习 + 行为克隆）**组合训练一个**鲁棒、自适应、响应快**的**全身控制器**。系统分析表明：引入**特权未来动作帧（privileged future motion frames）**与**真实动捕数据**能提升跟踪精度。TWIST 让真实人形用**单一统一神经网络控制器**实现**前所未有、通用且协调**的全身运动技能——涵盖**全身操作、腿部操作、行走与表现性动作**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| TWIST | Teleoperated Whole-Body Imitation System |
+| RL+BC | 强化学习 + 行为克隆联合训练 |
+| Retargeting | 动捕重定向到机器人形态 |
+| Privileged Future Frames | 特权未来动作帧，训练期可见未来参考 |
+| Whole-Body | 全身协调控制 |
+| Unified Controller | 单一统一神经网络控制器 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形遥操作的理想是**全身、协调**，但现状：
+- 多数系统只做**孤立**的行走或操作，**缺协调全身**；
+- 想用**人类动作**作统一接口控制所有自由度，但难训出又鲁棒又准的全身控制器。
+
+TWIST 要：一个**统一控制器**，靠全身动作模仿实现协调、通用的人形遥操作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 动捕重定向 → 参考动作片段
+把**人类动捕**重定向到人形，生成**参考动作片段**作为模仿目标。
+
+### 2. RL+BC 全身控制器
+用 **RL + BC** 组合训练一个**鲁棒、自适应、响应快**的全身控制器，兼顾 BC 的拟人与 RL 的稳健。
+
+### 3. 特权未来帧 + 真实动捕提升跟踪
+系统分析显示：加入**特权未来动作帧**与**真实动捕数据**显著提升**跟踪精度**。
+
+### 4. 单一统一控制器、多技能
+**一个神经网络**即可做：**全身操作、腿部操作、行走、表现性动作**，在真实人形上实现协调全身技能。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    MOCAP["🕺 人类动捕"] --> RT["重定向 → 参考动作片段"]
+    RT --> CTRL
+    subgraph CTRL["RL+BC 全身控制器"]
+        F["特权未来帧 + 真实动捕<br/>提升跟踪"]
+    end
+    CTRL --> OUT["🤖 单一统一控制器<br/>全身操作/腿部操作/行走/表现性"]
+
+    style CTRL fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **全身模仿遥操作系统 TWIST**：人类动作作统一接口控制所有自由度；
+2. **RL+BC 控制器**：鲁棒、自适应、响应快；
+3. **特权未来帧 + 真实动捕**：提升跟踪精度的关键配方；
+4. **单一统一控制器多技能**：全身/腿部操作、行走、表现性动作。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"全身协调"是遥操作的高地**：单一控制器统揽多技能比拼接多个控制器更优雅；
+- **RL+BC 融合**兼顾拟人与稳健，是全身控制的常用强力组合；
+- **特权未来帧**是提升跟踪的实用技巧（与 General Motion Tracking 类方法呼应）；
+- TWIST2 在此基础上进一步做便携免动捕数据采集，构成系列工作。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2505.02833](https://arxiv.org/abs/2505.02833) | 论文正文（重定向、RL+BC、特权帧、多技能实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同系列/同模块**：[TWIST2（便携免动捕数据采集）](../TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md) · [Mobile-TeleVision（解耦上下身 + CVAE 先验）](../Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md)。

--- a/papers/07_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation.md
+++ b/papers/07_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "TeleOpBench: A Simulator-Centric Benchmark for Dual-Arm Dexterous Teleoperation"
+zhname: "TeleOpBench：以仿真为中心的双臂灵巧遥操作基准"
+category: "Teleoperation"
+arxiv: "2505.12748"
+---
+
+# TeleOpBench: A Simulator-Centric Benchmark for Dual-Arm Dexterous Teleoperation
+**统一的、以仿真为中心的双臂灵巧遥操作基准：含 30 个高保真任务环境（取放、工具使用、协作操作），实现四种遥操作模态（动捕、VR、外骨骼、单目视觉跟踪）并配统一协议与指标；在物理双臂平台上做 10 个留出任务交叉验证，发现仿真表现与真机行为强相关，证明基准的外部效度**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 遥操作基准 · 仿真为中心 · 四模态 · 双臂灵巧 · 外部效度
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 5 月 |
+| arXiv | [2505.12748](https://arxiv.org/abs/2505.12748) · [PDF](https://arxiv.org/pdf/2505.12748) · [HTML](https://arxiv.org/html/2505.12748v1) |
+| 作者 | Hangyu Li、Qin Zhao、Haoran Xu、Xinyu Jiang、Qingwei Ben、Feiyu Jia 等（上海 AI Lab 等） |
+| 主题 | cs.RO · 遥操作基准 / 双臂灵巧 / 仿真评测 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 遥操作是具身机器人学习的基石，**双臂灵巧遥操作**尤其能提供自主系统难得的丰富演示。TeleOpBench 是一个**统一的、以仿真为中心**的基准：包含 **30 个高保真任务环境**，涵盖**取放、工具使用、协作操作**。它实现了**四种遥操作模态**——**动捕、VR 设备、外骨骼、单目视觉跟踪**——并提供**统一协议与指标**；在一个**物理双臂平台**上跨验证。通过 **10 个留出（held-out）真实任务**做仿真↔硬件交叉验证，发现**仿真表现与真机行为强相关**，确认了该基准作为可靠评测平台的**外部效度**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Simulator-Centric | 以仿真为中心的基准 |
+| Modality | 遥操作模态（动捕/VR/外骨骼/视觉） |
+| Held-out Task | 留出任务，用于验证泛化 |
+| External Validity | 外部效度，仿真结论对真机的可推广性 |
+| Dual-Arm Dexterous | 双臂灵巧（操作） |
+| Protocol/Metric | 统一协议与评测指标 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+遥操作研究缺**统一、可复现**的评测：
+- 不同**模态**（动捕/VR/外骨骼/视觉）难公平比较；
+- 真机评测**贵、难复现**；
+- 不清楚**仿真结论能否推广到真机**。
+
+TeleOpBench 要：一个**仿真为中心**、**多模态**、**统一指标**且**经真机验证外部效度**的遥操作基准。
+
+---
+
+## 🔧 方法详解
+
+### 1. 30 个高保真仿真任务
+覆盖**取放、工具使用、协作操作**，任务在**运动学/力复杂度**上各异。
+
+### 2. 四种遥操作模态 + 统一协议
+实现**动捕、VR、外骨骼、单目视觉跟踪**四种接口，配**统一协议与指标**，便于公平横比。
+
+### 3. 仿真↔真机交叉验证（外部效度）
+在**物理双臂平台**上用 **10 个留出真实任务**交叉验证；发现**仿真表现与真机强相关**，证明基准可靠。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    subgraph MOD["四种遥操作模态"]
+        M1["动捕"]
+        M2["VR"]
+        M3["外骨骼"]
+        M4["单目视觉"]
+    end
+    MOD --> SIM["30 仿真任务<br/>统一协议+指标"]
+    SIM --> XVAL["10 真实留出任务交叉验证"]
+    XVAL --> OUT["📊 仿真↔真机强相关<br/>→ 基准外部效度成立"]
+
+    style SIM fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **统一仿真为中心的遥操作基准**：30 任务 + 统一协议/指标；
+2. **四模态实现**：动捕/VR/外骨骼/单目视觉，公平横比；
+3. **外部效度验证**：10 真实留出任务交叉验证，仿真↔真机强相关；
+4. **可靠评测平台**：为遥操作研究提供可复现基准。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **遥操作需要统一基准**：否则不同模态/系统难公平比较，TeleOpBench 填补此空白；
+- **"仿真↔真机强相关"是关键卖点**：让低成本仿真评测可信，加速迭代；
+- **多模态统一**便于研究"哪种接口更适合哪类任务"；
+- 对人形双臂灵巧数据采集与策略评测有直接价值，呼应本仓 11 仿真基准板块。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2505.12748](https://arxiv.org/abs/2505.12748) | 论文正文（任务集、四模态、交叉验证） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·遥操作系统/数据**：[TWIST2](../TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md) · [TeleOp 模态：动捕/VR/外骨骼/视觉]；
+- **仿真基准**：本仓 11 Simulation Benchmark 板块。

--- a/papers/07_Teleoperation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation.md
+++ b/papers/07_Teleoperation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation.md
@@ -1,0 +1,132 @@
+---
+layout: paper
+title: "Whole-Body Bilateral Teleoperation with Multi-Stage Object Parameter Estimation for Wheeled Humanoid Locomanipulation"
+zhname: "面向轮式人形移动操作的多阶段物体参数估计全身双边遥操作"
+category: "Teleoperation"
+arxiv: "2508.09846"
+---
+
+# Whole-Body Bilateral Teleoperation with Multi-Stage Object Parameter Estimation for Wheeled Humanoid Locomanipulation
+**面向轮式人形移动操作的「物体感知」全身双边遥操作：把遥操作与在线参数估计结合——先用视觉估物体尺寸、再用大型视觉语言模型给初始参数猜测、最后用解耦的分层采样（先质量/质心、再惯量）多假设鲁棒估计；据此实时更新机器人的平衡点，从而在搬运约 1/3 自重负载时保持柔顺并改善操作跟踪**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 07 Teleoperation · 双边遥操作 · 物体参数估计 · VLM 先验 · 轮式人形 · 平衡点补偿
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 8 月 |
+| arXiv | [2508.09846](https://arxiv.org/abs/2508.09846) · [PDF](https://arxiv.org/pdf/2508.09846) · [HTML](https://arxiv.org/html/2508.09846v1) |
+| 作者 | Donghoon Baek、Amartya Purushottam、Jason J. Choi、Joao Ramos（UIUC） |
+| 主题 | cs.RO · 双边遥操作 / 物体参数估计 / 轮式人形 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Teleoperation 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文提出一个面向**轮式人形移动操作**的**物体感知全身双边遥操作（object-aware whole-body bilateral teleoperation）**框架，把**遥操作**与**在线参数估计**结合。它**顺序整合**：① **基于视觉的物体尺寸估计**；② 由**大型视觉语言模型（VLM）**生成的**初始参数猜测**；③ 一个**解耦的分层采样策略**（先估**质量/质心**、再推**惯量**）。估出的参数用于**实时更新机器人的平衡点（equilibrium point）**。在搬运约**机器人体重 1/3** 的负载（抬、送、放）时，框架实现更**动态**的全身遥操作，同时保持**柔顺**，并通过**物体动力学补偿**改善**操作跟踪**；在自制轮式人形 + 夹爪上实时验证。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Bilateral Teleop | 双边遥操作，力/位双向反馈 |
+| Object-Aware | 物体感知，估计被操作物体参数 |
+| VLM | Vision-Language Model，视觉语言模型 |
+| Equilibrium Point | 平衡点，控制中维持平衡的参考 |
+| CoM / Inertia | 质心 / 惯量，物体动力学参数 |
+| Wheeled Humanoid | 轮式人形 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+轮式人形搬运未知重物时：
+- 物体的**质量/质心/惯量未知**，会扰动全身平衡；
+- 遥操作若不补偿物体动力学，操作**跟踪差、易失稳**。
+
+论文要：**在线估计物体参数**并补偿，让双边遥操作在搬重物时**动态、柔顺、跟踪准**。
+
+---
+
+## 🔧 方法详解
+
+### 1. 多阶段物体参数估计
+顺序整合三步：
+- **视觉物体尺寸估计**：先看物体多大；
+- **VLM 初始参数猜测**：用视觉语言模型给质量等初值先验；
+- **解耦分层采样**：先估**质量/质心**、再推**惯量**，用**多假设**方案提升鲁棒。
+
+### 2. 实时更新平衡点
+把估出的物体参数用于**实时更新机器人平衡点**，补偿负载对全身平衡的影响。
+
+### 3. 双边遥操作 + 并行仿真/硬件
+全身**双边**遥操作（力反馈），并**并行**在仿真与硬件上执行验证。
+
+### 4. 结果
+- 负载约**机器人体重 1/3**；
+- 抬/送/放操作中更**动态**、保持**柔顺**、**跟踪改善**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    V["📷 视觉物体尺寸"] --> EST
+    VLM["🧠 VLM 初始参数猜测"] --> EST
+    subgraph EST["多阶段参数估计"]
+        S["分层采样：质量/质心 → 惯量<br/>(多假设鲁棒)"]
+    end
+    EST --> EQ["实时更新平衡点"]
+    PILOT["🧑‍✈️ 操作者(双边力反馈)"] --> EQ
+    EQ --> OUT["🤖 轮式人形搬 1/3 自重<br/>动态 + 柔顺 + 跟踪改善"]
+
+    style EST fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **物体感知双边遥操作**：把在线物体参数估计纳入全身遥操作；
+2. **多阶段估计**：视觉尺寸 → VLM 先验 → 分层采样（质量/质心→惯量）多假设；
+3. **平衡点实时补偿**：用估出的参数补偿负载对全身平衡的影响；
+4. **重载验证**：约 1/3 自重负载下更动态、柔顺、跟踪更好。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **遥操作 + 在线辨识**是搬未知重物的务实组合：估出物性才能稳；
+- **VLM 给物理参数先验**是新颖用法，把语义视觉接到动力学估计；
+- **分层估计（先质量/质心再惯量）**降低辨识难度；
+- 与 SplitAdapter、Heavy-Lifting 等负载/重物工作呼应，强调"物体动力学"建模。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2508.09846](https://arxiv.org/abs/2508.09846) | 论文正文（多阶段估计、平衡点补偿、轮式人形实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·重载/轮式遥操作**：[Heavy Lifting Tasks via Haptic Teleoperation of a Wheeled Humanoid](../Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid.md)；
+- **负载/物体动力学**：[SplitAdapter（负载自适应）](../../04_Loco-Manipulation_and_WBC/SplitAdapter__Load-Aware_Humanoid_Loco-Manipulation_via_Factorized_Adaptation/SplitAdapter__Load-Aware_Humanoid_Loco-Manipulation_via_Factorized_Adaptation.md)。

--- a/papers/11_Simulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.md
+++ b/papers/11_Simulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "BiGym: A Demo-Driven Mobile Bi-Manual Manipulation Benchmark"
+zhname: "BiGym：演示驱动的移动双手操作基准"
+category: "Simulation Benchmark"
+arxiv: "2407.07788"
+---
+
+# BiGym: A Demo-Driven Mobile Bi-Manual Manipulation Benchmark
+**面向移动双手、演示驱动操作的新基准与学习环境：含 40 个家居任务（从简单到达到复杂厨房清洁），为每个任务提供人类采集的演示以反映真实轨迹的多样模态；支持本体感受与 3 视角 RGB/深度观测，并系统评测了当前最佳模仿学习与演示驱动强化学习算法**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 移动双手 · 演示驱动 · 家居任务 · 多视角观测
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 7 月 |
+| arXiv | [2407.07788](https://arxiv.org/abs/2407.07788) · [PDF](https://arxiv.org/pdf/2407.07788) · [HTML](https://arxiv.org/html/2407.07788v1) |
+| 作者 | Nikita Chernyadev、Nicholas Backshall、Xiao Ma、Yunfan Lu、Younggyo Seo、Stephen James（Dyson Robot Learning Lab） |
+| 主题 | cs.RO · 移动双手操作 / 演示驱动 / 基准 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> BiGym 是一个面向**移动双手、演示驱动**机器人操作的新**基准与学习环境**。它含 **40 个家居任务**，从**简单到达**到**复杂厨房清洁**。为准确反映真实表现，BiGym 为**每个任务**提供**人类采集的演示**，体现真实机器人轨迹的**多样模态**。它支持多种观测，包括**本体感受**与**视觉输入**（**3 个相机视角**的 **RGB 与深度**）。为验证可用性，作者在环境中**充分评测**了当前最佳的**模仿学习**与**演示驱动强化学习**算法，并讨论了未来机会。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Demo-Driven | 演示驱动，依赖人类演示 |
+| Bi-Manual | 双手 |
+| Mobile Manipulation | 移动操作 |
+| Proprioception | 本体感受 |
+| RGB-D | 彩色 + 深度（3 视角） |
+| IL / Demo-Driven RL | 模仿学习 / 演示驱动强化学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+移动双手操作缺**演示驱动**的统一基准：
+- 现有基准少覆盖**移动 + 双手 + 家居多样任务**；
+- 缺**人类演示**反映真实轨迹多样性；
+- 缺统一环境评测 IL 与演示驱动 RL。
+
+BiGym 要：一个**演示驱动、移动双手、家居多任务**的基准与环境。
+
+---
+
+## 🔧 方法详解
+
+### 1. 40 家居任务 + 人类演示
+覆盖**简单到达 → 复杂厨房清洁**的 **40 个任务**，每个任务配**人类采集演示**，反映真实轨迹的**多样模态**。
+
+### 2. 多模态观测
+支持**本体感受** + **3 视角 RGB/深度**视觉输入，贴近真实机器人感知。
+
+### 3. 系统评测 IL / 演示驱动 RL
+在环境中**充分基准**当前最佳**模仿学习**与**演示驱动强化学习**算法，给出参考与未来方向。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DEMO["🙋 人类演示(每任务)"] --> BG
+    subgraph BG["BiGym 环境"]
+        T["40 家居任务(到达→厨房清洁)"]
+        O["本体感受 + 3 视角 RGB/深度"]
+    end
+    BG --> EVAL["评测 IL / 演示驱动 RL"]
+    EVAL --> OUT["📊 移动双手操作基准<br/>未来机会讨论"]
+
+    style BG fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **演示驱动移动双手基准**：40 家居任务，覆盖难度谱；
+2. **人类演示**：每任务配演示，反映真实轨迹多样性；
+3. **多模态观测**：本体感受 + 3 视角 RGB/深度；
+4. **系统评测**：IL 与演示驱动 RL 基线。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **移动 + 双手**是人形家务的核心，BiGym 提供演示驱动评测床；
+- **人类演示反映真实多样模态**对模仿学习评测很重要；
+- **演示驱动 RL** 是 IL 与 RL 的折中，值得在人形任务上探索；
+- 与 RoboCasa、ManiSkill-HAB 等家居基准互补。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2407.07788](https://arxiv.org/abs/2407.07788) | 论文正文（40 任务、人类演示、IL/RL 基准） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；本基准以移动双手机器人为主，因收录于上游而纳入；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·家居/双手基准**：[RoboCasa](../RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md) · [ManiSkill-HAB](../ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md)。

--- a/papers/11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md
+++ b/papers/11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "DexMimicGen: Automated Data Generation for Bimanual Dexterous Manipulation via Imitation Learning"
+zhname: "DexMimicGen：经由模仿学习的双手灵巧操作自动数据生成"
+category: "Simulation Benchmark"
+arxiv: "2410.24185"
+---
+
+# DexMimicGen: Automated Data Generation for Bimanual Dexterous Manipulation via Imitation Learning
+**针对模仿学习「数据采集是瓶颈」，提出大规模自动数据生成系统：在仿真里从极少量人类演示合成出大量轨迹，面向带灵巧手的人形机器人；从 60 条源演示生成 2.1 万条演示，覆盖多种双手操作行为，并在真实人形的易拉罐分拣任务上部署验证**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 自动数据生成 · 双手灵巧 · 模仿学习 · 真机部署
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 10 月 |
+| arXiv | [2410.24185](https://arxiv.org/abs/2410.24185) · [PDF](https://arxiv.org/pdf/2410.24185) · [HTML](https://arxiv.org/html/2410.24185v1) |
+| 作者 | Zhenyu Jiang、Yuqi Xie、Kevin Lin、Zhenjia Xu、Weikang Wan、Ajay Mandlekar、Linxi Fan、Yuke Zhu（UT Austin / NVIDIA） |
+| 主题 | cs.RO · 自动数据生成 / 双手灵巧 / 模仿学习 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 从人类演示**模仿学习**能有效教机器人操作，但**数据采集是主要瓶颈**。在**仿真**里**自动生成数据**是有吸引力、可扩展的替代。为此提出 **DexMimicGen**：一个**大规模自动数据生成系统**，从**少量人类演示**为**带灵巧手的人形机器人**合成出大量轨迹。系统包含一组覆盖多种**双手操作行为**的仿真环境，能从 **60 条源人类演示**生成 **21,000 条演示**；并在**真实人形**的**易拉罐分拣（can sorting）**任务上部署验证，评估了数据生成与策略学习的多种设计选择。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| DexMimicGen | 本文的双手灵巧数据生成系统 |
+| Bimanual Dexterous | 双手灵巧（多指手）操作 |
+| Trajectory Synthesis | 轨迹合成，从少量演示扩出大量 |
+| Source Demo | 源演示，人类提供的少量样本 |
+| Real-to-Sim-to-Real | 真实↔仿真↔真实流程 |
+| Imitation Learning | 模仿学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+模仿学习**数据采集贵**，对**双手灵巧人形**尤甚：
+- 人类演示**难采、量小**；
+- 双手灵巧协调复杂；
+- 需可扩展的数据来源。
+
+DexMimicGen 要：从**极少量人类演示**在仿真里**自动合成大规模**双手灵巧演示。
+
+---
+
+## 🔧 方法详解
+
+### 1. 少演示 → 大规模轨迹合成
+从**少量人类演示**出发，在**仿真**中**自动合成大量轨迹**，面向**带灵巧手的人形**。
+
+### 2. 覆盖多种双手行为的仿真环境
+提供一组仿真环境，覆盖多样**双手操作行为**，作为生成与评测的载体。
+
+### 3. 真实→仿真→真实
+采用 real-to-sim-to-real 思路，生成数据用于训练策略，再回到真机。
+
+### 4. 结果
+- 从 **60 条源演示** → **21,000 条演示**；
+- 真实人形**易拉罐分拣**任务部署验证；
+- 评估数据生成与策略学习的设计选择。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    H["🙋 60 条人类源演示"] --> GEN
+    subgraph GEN["DexMimicGen 自动生成"]
+        S["仿真合成 21,000 演示<br/>多种双手行为"]
+    end
+    GEN --> POL["模仿学习策略"]
+    POL --> OUT["🤖 真实人形易拉罐分拣<br/>部署验证"]
+
+    style GEN fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **大规模自动数据生成系统**：少演示合成海量双手灵巧轨迹；
+2. **面向灵巧手人形**：覆盖多种双手操作行为；
+3. **60 → 21,000 演示**：极高的数据放大比；
+4. **真机部署**：人形易拉罐分拣验证。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **自动数据生成是模仿学习规模化的关键**：把少量人类演示放大成海量训练数据；
+- **双手灵巧**是数据最稀缺、最该自动化的方向；
+- **real-to-sim-to-real**闭环让合成数据落到真机；
+- 与 HumanoidGen、Mimicking-Bench 等共同壮大人形操作数据生态（同出 NVIDIA/UT 系）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2410.24185](https://arxiv.org/abs/2410.24185) | 论文正文（数据生成系统、仿真环境、真机分拣） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（60→21,000）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·数据生成**：[HumanoidGen（LLM 推理生成双手数据）](../HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md) · [RoboCasa（自动轨迹生成）](../RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md)。

--- a/papers/11_Simulation_Benchmark/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning.md
+++ b/papers/11_Simulation_Benchmark/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning.md
@@ -1,0 +1,131 @@
+---
+layout: paper
+title: "DualTHOR: A Dual-Arm Humanoid Simulation Platform for Contingency-Aware Planning"
+zhname: "DualTHOR：面向意外感知规划的双臂人形仿真平台"
+category: "Simulation Benchmark"
+arxiv: "2506.16012"
+---
+
+# DualTHOR: A Dual-Arm Humanoid Simulation Platform for Contingency-Aware Planning
+**在扩展版 AI2-THOR 上构建的双臂人形物理仿真平台：含真实机器人资产、双臂协作任务套件、面向人形的逆运动学求解器，并引入纳入执行失败的「意外（contingency）」机制；用于评测 VLM 在家务任务上的双臂协调与抗意外鲁棒性，发现当前 VLM 在双臂协调与现实意外下能力有限**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 双臂人形 · AI2-THOR · 意外感知规划 · VLM 评测 · IK
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 6 月 |
+| arXiv | [2506.16012](https://arxiv.org/abs/2506.16012) · [PDF](https://arxiv.org/pdf/2506.16012) · [HTML](https://arxiv.org/html/2506.16012v1) |
+| 作者 | Boyu Li、Siyuan He、Hang Xu、Haoqi Yuan、Junpeng Yue、Börje F. Karlsson、Zongqing Lu 等 |
+| 主题 | cs.RO · 双臂人形仿真 / 意外感知规划 / VLM 评测 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+>
+> ⚠️ 备注：该 arXiv 条目的 v2 已被作者**撤稿（withdrawn, 2025-10）**；本笔记按上游收录与 v1 摘要整理，使用时请留意其状态。
+
+---
+
+## 🎯 一句话总结
+
+> 开发能在真实场景做**复杂交互任务**的具身智能体，仍是具身 AI 的根本挑战。DualTHOR 是一个面向**复杂双臂人形机器人**的**物理仿真平台**，构建在**扩展版 AI2-THOR** 之上。它包含：**真实世界机器人资产**、**双臂协作任务套件**、以及面向**人形形态**优化的**逆运动学（IK）求解器**；并引入一个**纳入执行失败的「意外（contingency）」机制**，让仿真更贴近现实的不确定性。论文用它评测**视觉语言模型（VLM）**在**家务任务**上的表现，发现当前 VLM 在**双臂协调**上能力**有限**、面对现实**意外**时**鲁棒性下降**，凸显该平台对发展更强具身 AI 的价值。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| AI2-THOR | 一个具身 AI 室内仿真环境 |
+| Dual-Arm Humanoid | 双臂人形 |
+| Contingency | 意外/突发，含执行失败 |
+| IK | Inverse Kinematics，逆运动学 |
+| VLM | Vision-Language Model |
+| Task Suite | 任务套件 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+具身 AI 缺**双臂人形 + 贴近现实意外**的仿真：
+- 多数平台面向单臂/简化抓取；
+- 缺**执行失败/意外**建模，与真实差距大；
+- 不清楚 VLM 在双臂协调与意外下表现如何。
+
+DualTHOR 要：一个**双臂人形、含意外机制**的物理仿真平台 + VLM 评测。
+
+---
+
+## 🔧 方法详解
+
+### 1. 扩展 AI2-THOR 的双臂人形物理仿真
+在 **AI2-THOR** 上扩展，加入**真实机器人资产**、**双臂协作任务套件**与面向**人形**的 **IK 求解器**。
+
+### 2. 意外（contingency）机制
+显式**纳入执行失败**等**意外**，让仿真涵盖现实不确定性，支持**意外感知规划**的研究。
+
+### 3. VLM 评测
+用平台评测 **VLM** 在**家务任务**上的**双臂协调**与**抗意外鲁棒性**。
+
+### 4. 发现
+当前 VLM **双臂协调能力有限**、面对现实**意外鲁棒性下降**——平台揭示了改进空间。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    THOR["AI2-THOR 扩展"] --> PLAT
+    subgraph PLAT["DualTHOR 平台"]
+        A["真实机器人资产"]
+        T["双臂协作任务套件"]
+        IK["人形 IK 求解器"]
+        C["意外机制(执行失败)"]
+    end
+    PLAT --> EVAL["VLM 评测(家务任务)"]
+    EVAL --> OUT["📊 VLM 双臂协调有限<br/>意外下鲁棒性↓"]
+
+    style PLAT fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **双臂人形物理仿真平台**：扩展 AI2-THOR，含真实资产、双臂任务、人形 IK；
+2. **意外机制**：纳入执行失败，支持意外感知规划研究；
+3. **VLM 评测**：揭示当前 VLM 双臂协调与抗意外的不足；
+4. **研究资源**：为更强具身 AI 提供测试床。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"意外感知"是从仿真走向现实的关键缺口**：现实充满执行失败，仿真应建模之；
+- **双臂人形平台**填补单臂仿真的空白；
+- **VLM 仍难做双臂协调**，提示高层规划与底层执行的鸿沟；
+- 与本仓 11 其它仿真/基准平台共同丰富评测生态。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2506.16012](https://arxiv.org/abs/2506.16012) | 论文正文（平台、意外机制、VLM 评测）；注意 v2 已撤稿 |
+
+> ℹ️ 备注：本笔记依据 arXiv v1 摘要整理；该条目 v2 已撤稿，**细节与状态以原文为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·仿真平台/基准**：[ManiSkill-HAB（家务重排低层操作）](../ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md) · [RoboCasa（日常任务大规模仿真）](../RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md)。

--- a/papers/11_Simulation_Benchmark/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md
+++ b/papers/11_Simulation_Benchmark/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "HumanoidGen: Data Generation for Bimanual Dexterous Manipulation via LLM Reasoning"
+zhname: "HumanoidGen：用大模型推理为双手灵巧操作生成数据"
+category: "Simulation Benchmark"
+arxiv: "2507.00833"
+---
+
+# HumanoidGen: Data Generation for Bimanual Dexterous Manipulation via LLM Reasoning
+**针对人形双臂灵巧手缺仿真任务与高质量演示的问题，提出自动化任务创建与演示采集框架：基于原子灵巧操作给资产与灵巧手做空间标注，用 LLM 规划器依物体可供性与场景生成可执行的空间约束链，并用蒙特卡洛树搜索变体增强长时程推理与稀疏标注；新建增强场景基准评估数据质量，2D/3D 扩散策略性能随生成数据规模提升**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 数据生成 · 双手灵巧 · LLM 规划 · MCTS · 扩散策略
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 7 月 |
+| arXiv | [2507.00833](https://arxiv.org/abs/2507.00833) · [PDF](https://arxiv.org/pdf/2507.00833) · [HTML](https://arxiv.org/html/2507.00833v1) |
+| 作者 | Zhi Jing、Siyuan Yang、Jicong Ao、Ting Xiao、Yu-Gang Jiang、Chenjia Bai |
+| 主题 | cs.RO · 数据生成 / 双手灵巧操作 / LLM 规划 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 现有机器人数据集与仿真基准多面向**机械臂**平台；对装备**双臂 + 灵巧手**的**人形**，仿真任务与高质量演示**明显匮乏**。双手灵巧操作更复杂——需**协调臂运动与手操作**，自主采集难。HumanoidGen 是一个**自动化任务创建与演示采集框架**，利用**原子灵巧操作**与 **LLM 推理**生成**关系约束**。具体：基于原子操作为**资产与灵巧手**提供**空间标注**，再用 **LLM 规划器**依据**物体可供性（affordance）与场景**生成一串**可执行的臂运动空间约束**；并用**蒙特卡洛树搜索（MCTS）变体**增强 LLM 在**长时程任务与标注不足**下的推理。实验里新建一个含**增强场景**的基准评估数据质量，结果显示 **2D 与 3D 扩散策略**的性能可**随生成数据规模提升**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Bimanual Dexterous | 双手灵巧（操作） |
+| Atomic Operation | 原子操作，可复用的基本灵巧动作 |
+| Affordance | 可供性，物体可被如何操作 |
+| LLM Planner | 大模型规划器，生成空间约束链 |
+| MCTS | 蒙特卡洛树搜索，增强长时程推理 |
+| Diffusion Policy | 扩散策略（2D/3D） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形**双手灵巧操作**缺数据：
+- 现有数据/基准多为**单臂**；
+- 双手灵巧需**协调臂 + 手**，**自主采集难**；
+- 缺高质量演示来训策略。
+
+HumanoidGen 要：**自动**生成双手灵巧任务与高质量演示。
+
+---
+
+## 🔧 方法详解
+
+### 1. 原子操作 + 空间标注
+基于**原子灵巧操作**，为**资产与灵巧手**提供**空间标注**，作为生成约束的基础。
+
+### 2. LLM 规划器生成空间约束链
+**LLM 规划器**依据**物体可供性与场景**，生成一串**可执行的臂运动空间约束（relational constraints）**，把"怎么双手协作"显式化。
+
+### 3. MCTS 增强长时程推理
+用**蒙特卡洛树搜索变体**增强 LLM，在**长时程任务**与**标注不足**时仍能稳健规划。
+
+### 4. 基准与结果
+新建含**增强场景**的基准评估数据质量；**2D/3D 扩散策略**性能**随生成数据规模提升**——证明生成数据有效。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    A["原子灵巧操作<br/>+ 资产/手空间标注"] --> LLM
+    subgraph LLM["LLM 规划器(+MCTS)"]
+        C["依可供性/场景生成<br/>可执行空间约束链"]
+    end
+    LLM --> GEN["自动演示采集"]
+    GEN --> OUT["📊 增强场景基准<br/>2D/3D 扩散策略随数据规模↑"]
+
+    style LLM fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **人形双手灵巧数据生成框架**：自动任务创建 + 演示采集；
+2. **LLM 规划生成空间约束链**：依可供性/场景把双手协作显式化；
+3. **MCTS 增强**：应对长时程与稀疏标注；
+4. **数据有效性**：新基准上 2D/3D 扩散策略随数据规模提升。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **自动数据生成是双手灵巧操作的关键瓶颈解法**：自主采集难，LLM 规划 + 仿真生成是出路；
+- **可供性 + 空间约束**把语义规划接到底层动作；
+- **MCTS 补 LLM 长时程推理**是实用组合；
+- 与 DexMimicGen、HumanoidGen 等数据生成工作共同壮大人形操作数据。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2507.00833](https://arxiv.org/abs/2507.00833) | 论文正文（原子操作、LLM 规划、MCTS、基准实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·数据生成/基准**：[DexMimicGen（自动双手灵巧数据生成）](../DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md) · [Mimicking-Bench](../Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning.md)。

--- a/papers/11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md
+++ b/papers/11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "Humanoid World Models: Open World Foundation Models for Humanoid Robotics"
+zhname: "Humanoid World Models：面向人形机器人的开放世界基础模型"
+category: "Simulation Benchmark"
+arxiv: "2506.01182"
+---
+
+# Humanoid World Models: Open World Foundation Models for Humanoid Robotics
+**轻量开源的人形世界模型：以人形控制输入为条件预测未来第一视角视频，训练两类生成模型（掩码 Transformer 与流匹配）于 100 小时演示；参数共享技术在性能几乎无损下把模型缩小 33–53%，可在 1–2 张 GPU 的有限算力上部署，面向学术与小实验室**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 世界模型 · 第一视角视频预测 · 掩码 Transformer · 流匹配 · 轻量
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 6 月 |
+| arXiv | [2506.01182](https://arxiv.org/abs/2506.01182) · [PDF](https://arxiv.org/pdf/2506.01182) · [HTML](https://arxiv.org/html/2506.01182v2) |
+| 作者 | Muhammad Qasim Ali、Aditya Sridhar、Shahbuland Matiana、Alex Wong、Mohammad Al-Sharman |
+| 主题 | cs.RO · 世界模型 / 视频预测 / 人形基础模型 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人形以**类人形态**特别适合在为人设计的环境里交互，但让它在复杂**开放世界**里**推理、规划、行动**仍难。本文提出**轻量、开源**的**人形世界模型**：以**人形控制输入**为条件，**预测未来的第一视角视频**。作者训练**两类生成模型**——**掩码 Transformer（Masked Transformers）**与**流匹配（Flow-Matching）**——于 **100 小时**演示数据；并通过**参数共享**技术，在**性能与视觉保真几乎无损**的前提下把**模型缩小 33–53%**，使其能部署在**1–2 张 GPU** 的**有限算力**上，面向**学术与小实验室**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| World Model | 世界模型，预测未来观测 |
+| Egocentric Video | 第一视角视频 |
+| Masked Transformer | 掩码 Transformer 生成模型 |
+| Flow-Matching | 流匹配生成模型 |
+| Parameter Sharing | 参数共享，压缩模型 |
+| Foundation Model | 基础模型 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形要在**开放世界**推理/规划/行动，世界模型有用但：
+- 大模型**算力门槛高**，小实验室难用；
+- 缺**轻量、开源**、以**控制输入为条件**的人形世界模型。
+
+论文要：一个**轻量、可在 1–2 GPU 上跑**的开源人形世界模型。
+
+---
+
+## 🔧 方法详解
+
+### 1. 控制条件的第一视角视频预测
+以**人形控制输入（control tokens）**为条件，**预测未来第一视角视频**——把"我这样动，会看到什么"建模出来。
+
+### 2. 两类生成架构
+- **掩码 Transformer**；
+- **流匹配（Flow-Matching）**。
+
+在 **100 小时**演示上训练，并比较不同注意力机制的变体。
+
+### 3. 参数共享做轻量化
+**参数共享**策略把模型**缩小 33–53%**，**性能/视觉保真几乎无损**，可在 **1–2 GPU** 部署。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    CTRL["🎮 人形控制输入"] --> WM
+    subgraph WM["人形世界模型(100h 训练)"]
+        MT["掩码 Transformer"]
+        FM["流匹配"]
+        PS["参数共享 -33~53%"]
+    end
+    WM --> OUT["🎥 预测未来第一视角视频<br/>1–2 GPU 可部署 · 开源"]
+
+    style WM fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **轻量开源人形世界模型**：控制条件的第一视角视频预测；
+2. **两类生成架构**：掩码 Transformer 与流匹配，100h 训练；
+3. **参数共享轻量化**：缩小 33–53%、性能几乎无损；
+4. **低算力可部署**：1–2 GPU，面向学术/小实验室。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **世界模型让人形"想象后果"**，是规划与数据增广的有力工具；
+- **轻量化 + 开源**降低门槛，惠及算力受限的研究者；
+- **第一视角条件预测**与 ZeroWBC/EgoHumanoid 的 egocentric 路线呼应；
+- 流匹配/掩码 Transformer 是当前生成式世界模型的主流选择。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2506.01182](https://arxiv.org/abs/2506.01182) | 论文正文（世界模型、两类架构、参数共享、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（33–53%）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·仿真/世界模型**：[Learning with pyCub](../Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics.md)；
+- **世界模型 + 控制**：[HAIC（动力学感知世界模型）](../../04_Loco-Manipulation_and_WBC/HAIC__Humanoid_Agile_Object_Interaction_Control_via_Dynamics-Aware_World_Model/HAIC__Humanoid_Agile_Object_Interaction_Control_via_Dynamics-Aware_World_Model.md)。

--- a/papers/11_Simulation_Benchmark/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics.md
+++ b/papers/11_Simulation_Benchmark/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics.md
@@ -1,0 +1,127 @@
+---
+layout: paper
+title: "Learning with pyCub: A Simulation and Exercise Framework for Humanoid Robotics"
+zhname: "Learning with pyCub：人形机器人学的仿真与练习框架"
+category: "Simulation Benchmark"
+arxiv: "2506.01756"
+---
+
+# Learning with pyCub: A Simulation and Exercise Framework for Humanoid Robotics
+**面向教学的 iCub 开源物理仿真 pyCub：相比需 C++ 与 YARP 中间件的 iCub SIM/Gazebo，pyCub 纯 Python、无需 YARP；完整仿真带眼部双相机与覆盖体表 4000 个感受器的独特敏感皮肤，配套从速度/关节/笛卡尔空间控制到注视、抓取、反应式控制的分级练习，已在两轮人形机器人课程中验证**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 教学仿真 · iCub · 纯 Python · 触觉皮肤 · 开源
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 6 月 |
+| arXiv | [2506.01756](https://arxiv.org/abs/2506.01756) · [PDF](https://arxiv.org/pdf/2506.01756) · [HTML](https://arxiv.org/html/2506.01756v1) |
+| 作者 | Lukas Rustler、Matej Hoffmann（捷克理工大学 CTU） |
+| 代码 | 开源，含文档与 Docker 支持 |
+| 主题 | cs.RO · 教学仿真 / iCub / 人形机器人学 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> pyCub 是一个**开源、基于物理**的 **iCub 人形仿真**，并配套**练习**用于教学生人形机器人学基础。相比已有 iCub 仿真器（iCub SIM、iCub Gazebo）需要 **C++ 代码与 YARP 中间件**，pyCub **无需 YARP**、用 **Python** 即可。它**完整仿真**了带全部关节的机器人，含**眼部双相机**与 iCub **独特的敏感皮肤**（体表 **4000 个感受器**）。练习从**速度/关节/笛卡尔空间**的基础控制，到**注视、抓取、反应式控制**等更复杂任务；整套用 **Python** 编写与控制，**即使编程基础很少**的人也能用，练习可**分级**到不同难度。作者在**两轮人形机器人课程**中验证了该框架。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| pyCub | 本文的 Python iCub 仿真框架 |
+| iCub | 一款知名人形研究平台 |
+| YARP | iCub 传统中间件（本文免去） |
+| Cartesian Control | 笛卡尔空间控制 |
+| Tactile Skin | 触觉皮肤（4000 感受器） |
+| Exercise Framework | 练习框架，分级教学任务 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形机器人学**教学门槛高**：
+- 现有 iCub 仿真需 **C++ + YARP**，对学生不友好；
+- 缺**纯 Python、低门槛**且涵盖触觉皮肤等特性的教学仿真与练习。
+
+pyCub 要：一个**纯 Python、免 YARP、带分级练习**的 iCub 教学仿真框架。
+
+---
+
+## 🔧 方法详解
+
+### 1. 纯 Python、免 YARP 的 iCub 物理仿真
+**无需 YARP**、用 **Python** 控制，完整仿真带全部关节的 iCub，含**眼部双相机**与**敏感皮肤（4000 感受器）**。
+
+### 2. 分级练习
+练习覆盖：
+- **基础**：速度/关节/笛卡尔空间控制；
+- **进阶**：注视、抓取、反应式控制。
+
+可**分级**到不同难度，适配不同水平学生。
+
+### 3. 低门槛 + 课程验证
+全 Python、**少编程基础也能用**；在**两轮人形机器人课程**中实测验证；**开源**含文档与 Docker。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    PY["🐍 纯 Python (免 YARP)"] --> SIM
+    subgraph SIM["pyCub 仿真"]
+        I["完整 iCub + 双相机 + 4000 感受器皮肤"]
+    end
+    SIM --> EX["分级练习<br/>控制→注视/抓取/反应式"]
+    EX --> OUT["🎓 两轮课程验证<br/>低门槛 · 开源 + Docker"]
+
+    style SIM fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **纯 Python、免 YARP 的 iCub 仿真**：大幅降低使用门槛；
+2. **完整仿真含触觉皮肤**：双相机 + 4000 感受器，覆盖 iCub 特色；
+3. **分级练习框架**：从基础控制到注视/抓取/反应式；
+4. **教学验证 + 开源**：两轮课程实测，开源含 Docker。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **降低教学/上手门槛**对扩大人形研究社区很重要；
+- **触觉皮肤仿真**为接触/灵巧研究提供少见的教学资源；
+- **纯 Python 生态**契合当下 RL/IL 工具链，利于教学到科研衔接；
+- 与重型仿真（Isaac、MuJoCo）互补，定位"教学友好"。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2506.01756](https://arxiv.org/abs/2506.01756) | 论文正文（pyCub 框架、练习、课程验证） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·仿真平台**：[Humanoid World Models（人形世界模型）](../Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md) · 本仓 11 其它仿真/基准工作。

--- a/papers/11_Simulation_Benchmark/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md
+++ b/papers/11_Simulation_Benchmark/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "ManiSkill-HAB: A Benchmark for Low-Level Manipulation in Home Rearrangement Tasks"
+zhname: "ManiSkill-HAB：家居重排任务中低层操作的基准"
+category: "Simulation Benchmark"
+arxiv: "2412.13211"
+---
+
+# ManiSkill-HAB: A Benchmark for Low-Level Manipulation in Home Rearrangement Tasks
+**面向长时程导航、操作与重排的高质量基准 MS-HAB：GPU 加速的家庭助理基准（HAB）实现，带真实低层控制，相比此前「魔法抓取」实现提速 3 倍以上、显存更省；训练 RL 与 IL 基线，并用基于规则的轨迹过滤系统大规模生成可控演示数据**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 家居重排 · 低层操作 · GPU 加速 · RL/IL 基线 · 演示生成
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 12 月 |
+| arXiv | [2412.13211](https://arxiv.org/abs/2412.13211) · [PDF](https://arxiv.org/pdf/2412.13211) · [HTML](https://arxiv.org/html/2412.13211v1) |
+| 作者 | Arth Shukla、Stone Tao、Hao Su（UC San Diego） |
+| 主题 | cs.RO · 家居重排 / 低层操作 / GPU 加速仿真 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 高质量基准是具身 AI 的基础，能推动**长时程导航、操作与重排**的进展。本文提出 **MS-HAB（ManiSkill-HAB）**：一个 **GPU 加速**的**家庭助理基准（Home Assistant Benchmark, HAB）**实现，提供**真实的低层控制**，相比此前"**魔法抓取（magical grasp）**"实现取得 **3 倍以上提速**且**显存更省**。作者训练了 **RL 与 IL 基线**，并开发一个**基于规则的轨迹过滤系统**，以**大规模**生成**可控的演示数据**。这把以往偏抽象/魔法抓取的家务重排基准，落到**真实低层操作**与**高效仿真**上。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| MS-HAB | ManiSkill-HAB，本文基准 |
+| HAB | Home Assistant Benchmark，家庭助理基准 |
+| Low-Level Control | 低层控制（真实物理操作，非魔法抓取） |
+| Magical Grasp | 魔法抓取，抽象的瞬时抓取 |
+| Trajectory Filtering | 轨迹过滤，筛选高质量演示 |
+| RL / IL | 强化学习 / 模仿学习 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+家务**重排**基准常用"**魔法抓取**"（抽象抓取），与真实**低层操作**脱节，且**仿真慢**：
+- 缺**真实低层控制**的家居重排基准；
+- 仿真**效率低**，难规模化训练/采集。
+
+ManiSkill-HAB 要：一个 **GPU 加速、真实低层、可大规模生成演示**的家居重排基准。
+
+---
+
+## 🔧 方法详解
+
+### 1. GPU 加速 + 真实低层控制
+**MS-HAB** 在 ManiSkill 上实现 **HAB**，提供**真实低层控制**（非魔法抓取），相比旧实现**提速 3 倍以上**、**显存更省**。
+
+### 2. RL / IL 基线
+训练 **RL 与 IL 基线**，给出可比较的参考。
+
+### 3. 规则化轨迹过滤生成演示
+用**基于规则的轨迹过滤系统**，**大规模**生成**可控**的演示数据，支撑模仿学习。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    HAB["家庭助理基准(HAB)"] --> MS
+    subgraph MS["MS-HAB"]
+        G["GPU 加速 + 真实低层控制(>3x)"]
+        B["RL/IL 基线"]
+        F["规则轨迹过滤 → 大规模演示"]
+    end
+    MS --> OUT["📊 长时程导航/操作/重排<br/>高效仿真 + 可控演示"]
+
+    style MS fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **真实低层家居重排基准**：取代魔法抓取，落到真实操作；
+2. **GPU 加速 >3x、显存更省**：高效仿真；
+3. **RL/IL 基线**：提供可比较参考；
+4. **规则轨迹过滤大规模生成演示**：支撑模仿学习。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"真实低层 vs 魔法抓取"很关键**：抽象抓取会高估能力，真实操作才有迁移价值；
+- **GPU 加速仿真**是规模化训练/采集的前提；
+- **规则过滤生成可控演示**是低成本扩数据的实用手段；
+- 虽以移动机械臂为主，重排/低层操作经验对人形家务同样适用。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2412.13211](https://arxiv.org/abs/2412.13211) | 论文正文（MS-HAB、基线、轨迹过滤） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；本基准以移动机械臂家居重排为主，因收录于上游而纳入；**数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·家居/重排基准**：[RoboCasa（日常任务大规模仿真）](../RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md) · [BiGym（演示驱动移动双手基准）](../BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.md)。

--- a/papers/11_Simulation_Benchmark/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning.md
+++ b/papers/11_Simulation_Benchmark/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "Mimicking-Bench: A Benchmark for Generalizable Humanoid-Scene Interaction Learning via Human Mimicking"
+zhname: "Mimicking-Bench：经由模仿人类的可泛化人形-场景交互学习基准"
+category: "Simulation Benchmark"
+arxiv: "2412.17730"
+---
+
+# Mimicking-Bench: A Benchmark for Generalizable Humanoid-Scene Interaction Learning via Human Mimicking
+**针对以往人形-场景交互依赖小规模手工采集演示的不足，提出大规模基准：含 6 个家居全身交互任务、11K 多样物体形状、20K 合成 + 3K 真实人类技能参考，系统比较运动重定向、运动跟踪、模仿学习及其组合，验证「模仿人类」对技能习得的价值并指出场景几何泛化的关键挑战**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 人形-场景交互 · 模仿人类 · 大规模基准 · 泛化
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 12 月 |
+| arXiv | [2412.17730](https://arxiv.org/abs/2412.17730) · [PDF](https://arxiv.org/pdf/2412.17730) · [HTML](https://arxiv.org/html/2412.17730v1) |
+| 作者 | Yun Liu、Bowen Yang、Licheng Zhong、He Wang、Li Yi（清华等） |
+| 主题 | cs.RO · 人形-场景交互 / 模仿学习 / 基准 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 让人形通过**模仿人类数据**学会与 **3D 场景**交互的通用技能，是机器人领域的关键挑战。已有的演示数据集**规模小、靠手工采集**。Mimicking-Bench 引入一个**大规模基准**：包含**6 个家居（全身）交互任务**、**11K** 多样**物体形状**、以及 **20K 合成 + 3K 真实**的**人类技能参考**。基准系统比较了**运动重定向、运动跟踪、模仿学习**及其**各种组合**策略，验证了**模仿人类**对**技能习得**的价值，并指出**场景几何泛化**等关键研究挑战与未来方向。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Humanoid-Scene Interaction | 人形与 3D 场景的交互 |
+| Human Mimicking | 模仿人类（数据/动作） |
+| Motion Retargeting | 运动重定向 |
+| Motion Tracking | 运动跟踪 |
+| Imitation Learning | 模仿学习 |
+| Scene Geometry Generalization | 场景几何泛化 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+人形-场景交互学习受限于**数据**：
+- 现有演示**小规模、手工采集**，难支撑泛化研究；
+- 缺**统一基准**比较重定向/跟踪/模仿等不同策略；
+- **场景几何泛化**难。
+
+Mimicking-Bench 要：一个**大规模、统一**的人形-场景交互基准。
+
+---
+
+## 🔧 方法详解
+
+### 1. 大规模基准资源
+- **6 个家居全身交互任务**；
+- **11K 多样物体形状**；
+- **20K 合成 + 3K 真实**人类技能参考。
+
+### 2. 统一比较多种策略
+系统比较**运动重定向、运动跟踪、模仿学习**及其**组合**，在统一基准上评估优劣。
+
+### 3. 发现
+验证**模仿人类**对技能习得的价值；指出**场景几何泛化**是关键挑战与未来方向。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    REF["人类技能参考<br/>20K 合成 + 3K 真实"] --> BENCH
+    OBJ["11K 物体形状 · 6 家居任务"] --> BENCH
+    subgraph BENCH["Mimicking-Bench"]
+        C["统一比较：重定向/跟踪/模仿/组合"]
+    end
+    BENCH --> OUT["📊 验证『模仿人类』价值<br/>指出场景几何泛化挑战"]
+
+    style BENCH fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **大规模人形-场景交互基准**：6 任务、11K 物体、20K+3K 人类参考；
+2. **统一比较多策略**：重定向/跟踪/模仿及组合；
+3. **验证模仿人类的价值**；
+4. **指出场景几何泛化**等关键挑战与方向。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **大规模基准是公平比较的前提**：把"模仿人类"的不同实现放在同一标尺；
+- **场景几何泛化**是人形-场景交互的硬骨头，值得持续投入；
+- **合成 + 真实**参考混合是扩充数据的实用做法；
+- 与本仓 04（从人类视频学技能）方向强相关。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2412.17730](https://arxiv.org/abs/2412.17730) | 论文正文（基准、策略比较、泛化分析） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·基准/数据**：[HumanoidGen（双手灵巧数据生成）](../HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md) · [RoboCasa365](../RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.md)。

--- a/papers/11_Simulation_Benchmark/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.md
+++ b/papers/11_Simulation_Benchmark/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots"
+zhname: "RoboCasa365：训练与评测通才机器人的大规模仿真框架"
+category: "Simulation Benchmark"
+arxiv: "2603.04356"
+---
+
+# RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots
+**在 RoboCasa 之上大规模扩展资产、环境、任务与数据集：含 365 个日常任务、2500 个多样厨房场景、600+ 小时人类演示与 1600 小时合成演示，并提供系统化基准；支持单臂移动平台、人形、带臂四足等多种形态，面向多任务学习、机器人基础模型训练与终身学习**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 大规模仿真 · 365 任务 · 多形态 · 基础模型 · 终身学习
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2026 年 3 月 |
+| arXiv | [2603.04356](https://arxiv.org/abs/2603.04356) · [PDF](https://arxiv.org/pdf/2603.04356) · [HTML](https://arxiv.org/html/2603.04356v1) |
+| 会议 | ICLR（会议贡献，见原文） |
+| 项目页 | [robocasa.ai](https://robocasa.ai/) |
+| 主题 | cs.RO · 大规模仿真 / 通才机器人 / 基准 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块（上游未直接给出 arXiv，经核对为 2603.04356）。
+
+---
+
+## 🎯 一句话总结
+
+> RoboCasa365 是一个面向**通才机器人**训练与评测的**大规模仿真框架**，在已有 **RoboCasa** 基础上**大幅扩展**资产、环境、任务与数据集。它包含 **365 个日常任务**、**2500 个多样厨房场景**、**600+ 小时人类演示**与额外 **1600 小时合成演示**，并提供**系统化基准**用于训练与评测通才机器人模型。框架支持**多种形态的移动操作机器人**——**单臂移动平台、人形机器人、带臂四足**——并面向**多任务学习、机器人基础模型训练、终身学习**等不同问题设定提供系统化评测。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Generalist Robot | 通才机器人，一模型多任务多形态 |
+| 365 Tasks | 365 个日常任务 |
+| Multi-task Learning | 多任务学习 |
+| Foundation Model | 机器人基础模型 |
+| Lifelong Learning | 终身学习 |
+| Mobile Manipulator | 移动操作机器人（含人形/四足） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+训练**通才机器人**缺**足够大、足够系统**的仿真与基准：
+- 任务/场景/数据规模不足；
+- 缺**跨形态**（含人形）统一平台；
+- 缺面向**基础模型/终身学习**的系统化评测设定。
+
+RoboCasa365 要：一个**大规模、多形态、系统化**的训练与评测框架。
+
+---
+
+## 🔧 方法详解
+
+### 1. 在 RoboCasa 上大规模扩展
+扩展**资产、环境、任务、数据集**：**365 任务**、**2500 厨房场景**、**600+ 小时人类演示 + 1600 小时合成演示**。
+
+### 2. 多形态支持
+支持**单臂移动平台、人形、带臂四足**等多种移动操作形态，便于跨本体研究。
+
+### 3. 系统化基准与问题设定
+面向**多任务学习、基础模型训练、终身学习**提供系统化评测。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    RC["RoboCasa"] --> RC365
+    subgraph RC365["RoboCasa365 扩展"]
+        T["365 任务 · 2500 厨房场景"]
+        D["600h 人类 + 1600h 合成演示"]
+        M["多形态：单臂/人形/带臂四足"]
+    end
+    RC365 --> OUT["📊 多任务/基础模型/终身学习<br/>系统化基准"]
+
+    style RC365 fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **大规模扩展 RoboCasa**：365 任务、2500 场景、600h+1600h 演示；
+2. **多形态支持**：单臂/人形/带臂四足；
+3. **系统化基准**：面向多任务、基础模型、终身学习；
+4. **通才机器人训练/评测平台**。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **规模 + 多形态**是训练机器人基础模型的底座，人形是其中一等公民；
+- **大量合成演示**缓解真实数据稀缺；
+- **终身学习/基础模型设定**指向通用机器人智能的评测方向；
+- 与本仓 11 其它基准（RoboCasa、ManiSkill-HAB、BiGym）一脉相承、规模更大。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2603.04356](https://arxiv.org/abs/2603.04356) | 论文正文（资产/任务/数据扩展、多形态、基准） |
+| [robocasa.ai](https://robocasa.ai/) | 项目主页 |
+
+> ℹ️ 备注：本笔记依据 arXiv 公开信息与项目页整理；**逐项数值（365/2500/600h/1600h）以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·大规模仿真/基准**：[RoboCasa（前作）](../RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md) · [ManiSkill-HAB](../ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md)。

--- a/papers/11_Simulation_Benchmark/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md
+++ b/papers/11_Simulation_Benchmark/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md
@@ -1,0 +1,131 @@
+---
+layout: paper
+title: "RoboCasa: Large-Scale Simulation of Everyday Tasks for Generalist Robots"
+zhname: "RoboCasa：面向通才机器人的日常任务大规模仿真"
+category: "Simulation Benchmark"
+arxiv: "2406.02523"
+---
+
+# RoboCasa: Large-Scale Simulation of Everyday Tasks for Generalist Robots
+**主张用真实物理仿真来规模化机器人学习的环境、任务与数据：以厨房为核心提供逼真多样场景、150+ 物体类别的数千 3D 资产与可交互家具家电；用生成式 AI（文本生 3D 资产、文本生纹理）增强真实与多样性，设计含 LLM 引导复合任务的 100 个任务，并配高质量人类演示 + 自动轨迹生成，实验显示合成数据用于大规模模仿学习有清晰的规模化趋势**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 11 Simulation & Benchmark · 大规模仿真 · 厨房 · 生成式资产 · 100 任务 · 规模化
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 6 月 |
+| arXiv | [2406.02523](https://arxiv.org/abs/2406.02523) · [PDF](https://arxiv.org/pdf/2406.02523) · [HTML](https://arxiv.org/html/2406.02523v1) |
+| 项目页 | [robocasa.ai](https://robocasa.ai/) |
+| 作者 | Soroush Nasiriany、Abhiram Maddukuri、Lance Zhang、Adeet Parikh、Ajay Mandlekar、Yuke Zhu 等（UT Austin / NVIDIA） |
+| 主题 | cs.RO · 大规模仿真 / 通才机器人 / 日常任务 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Simulation Benchmark 模块。
+
+---
+
+## 🎯 一句话总结
+
+> AI 的进展很大程度由**规模化**驱动，但机器人受限于**缺乏海量机器人数据集**。本文主张用**逼真物理仿真**来规模化机器人学习的**环境、任务与数据**。RoboCasa 是一个面向**日常环境**训练**通才机器人**的**大规模仿真框架**，以**厨房**为核心，提供**逼真多样**的场景、跨 **150+ 物体类别**的**数千 3D 资产**与数十种**可交互家具家电**。它用**生成式 AI**（**文本生 3D** 资产、**文本生图像**纹理）增强真实与多样性；设计 **100 个任务**用于系统评测，含由**大模型引导**生成的**复合任务**。为便于学习，提供**高质量人类演示**并集成**自动轨迹生成**以**最小人力**大幅扩充数据集。实验显示：用**合成生成**的机器人数据做**大规模模仿学习**有清晰的**规模化趋势**，且在真实任务上**前景可观**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Generalist Robot | 通才机器人 |
+| Text-to-3D / Text-to-Image | 文本生 3D / 文本生图，生成资产/纹理 |
+| Composite Task | 复合任务（LLM 引导生成） |
+| Trajectory Generation | 自动轨迹生成 |
+| Scaling Trend | 规模化趋势 |
+| 3D Asset | 3D 资产 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+机器人学习缺**海量数据**：
+- 真实采集**贵、慢**；
+- 缺**逼真、多样、可规模化**的仿真环境/任务/数据。
+
+RoboCasa 要：用**逼真仿真 + 生成式 AI + 自动轨迹生成**，把环境/任务/数据**规模化**。
+
+---
+
+## 🔧 方法详解
+
+### 1. 逼真厨房场景 + 海量资产
+以**厨房**为核心，提供**150+ 物体类别**的**数千 3D 资产**与可交互家具家电，场景逼真多样。
+
+### 2. 生成式 AI 增强多样性
+用**文本生 3D**（物体资产）与**文本生图**（环境纹理）增强真实与多样性。
+
+### 3. 100 任务（含 LLM 复合任务）
+设计 **100 个任务**做系统评测，含由**大模型引导**生成的**复合任务**。
+
+### 4. 演示 + 自动轨迹生成
+提供**高质量人类演示**，并集成**自动轨迹生成**以**最小人力**扩充数据。
+
+### 5. 规模化结论
+**合成数据**做**大规模模仿学习**有清晰**规模化趋势**，真实任务前景可观。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    subgraph RC["RoboCasa(厨房)"]
+        A["数千 3D 资产 / 150+ 类别"]
+        G["生成式 AI：文本生3D/纹理"]
+        T["100 任务(含 LLM 复合)"]
+        D["人类演示 + 自动轨迹生成"]
+    end
+    RC --> OUT["📊 合成数据大规模 IL<br/>清晰规模化趋势 · 真实前景"]
+
+    style RC fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **大规模厨房仿真框架**：数千资产、150+ 类别、可交互家具家电；
+2. **生成式 AI 增强**：文本生 3D 资产与纹理；
+3. **100 任务（含 LLM 复合）+ 演示/自动轨迹生成**；
+4. **规模化实证**：合成数据大规模 IL 呈清晰规模化趋势。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"仿真 + 生成式 AI"是规模化数据的强力路径**，后续 RoboCasa365 进一步放大；
+- **自动轨迹生成**以最小人力扩数据，是数据飞轮关键；
+- **规模化趋势**为机器人基础模型提供信心；
+- 厨房日常任务对人形家务落地高度相关。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2406.02523](https://arxiv.org/abs/2406.02523) | 论文正文（场景/资产、生成式增强、100 任务、规模化实验） |
+| [robocasa.ai](https://robocasa.ai/) | 项目主页 |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要与项目页整理；本框架以移动机械臂为主，因收录于上游而纳入；**数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·大规模仿真**：[RoboCasa365（后续大规模扩展）](../RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.md) · [ManiSkill-HAB](../ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md) · [BiGym](../BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.md)。

--- a/papers/13_Physics-Based_Animation/Spatial_Relationship_Preserving_Character_Motion_Adaptation/Spatial_Relationship_Preserving_Character_Motion_Adaptation.md
+++ b/papers/13_Physics-Based_Animation/Spatial_Relationship_Preserving_Character_Motion_Adaptation/Spatial_Relationship_Preserving_Character_Motion_Adaptation.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "Spatial Relationship Preserving Character Motion Adaptation"
+zhname: "保持空间关系的角色运动适配"
+category: "Physics-Based Animation"
+---
+
+# Spatial Relationship Preserving Character Motion Adaptation
+**面向「身体部位/多角色/角色-环境之间紧密交互」的运动编辑与重定向（跳舞、摔跤、剑斗、钻进车里等），提出用「交互网格（interaction mesh）」结构表示空间关系：在编辑各帧时最小化交互网格的局部形变，从而保持这些紧密空间关系、同时减少不当穿插；该表示通用，可统一处理单/多角色的身体部位与环境物体（SIGGRAPH 2010 / ACM TOG）**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 13 Physics-Based Animation · 运动适配 · 交互网格 · 空间关系保持 · 重定向 · SIGGRAPH 2010
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2010 年（SIGGRAPH 2010 / ACM TOG 29(4)） |
+| 发表 | [ACM TOG / SIGGRAPH 2010](https://dl.acm.org/doi/10.1145/1778765.1778770) · [预印本 PDF](http://www.edho.net/projects/mesh/SIGGRAPH10_preprint.pdf) |
+| 作者 | Edmond S. L. Ho、Taku Komura、Chiew-Lan Tai |
+| 主题 | cs.GR · 角色动画 / 运动编辑与重定向 / 交互 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Physics-Based Animation 模块（经典工作，无 arXiv）。
+
+---
+
+## 🎯 一句话总结
+
+> 本文提出一种**编辑与重定向**运动的新方法，专门针对涉及**身体部位之间紧密交互**的运动——可以是**单个或多个**关节化角色之间（如**跳舞、摔跤、剑斗**），也可以是**角色与受限环境**之间（如**钻进车里**）。核心是引入一个结构——**交互网格（interaction mesh）**——来**表示空间关系**。通过在动画各帧上**最小化交互网格的局部形变（local deformation）**，这些**紧密空间关系**在运动编辑/重定向时被**保持**，同时**减少不当的相互穿插（interpenetration）**。交互网格表示**通用**，对**单/多角色的交互身体部位**以及**环境中的物体**提供**统一处理**，适用于跳舞（单角色不同部位紧密交互）、摔跤/格斗游戏（多角色交互）等多种场景。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Interaction Mesh | 交互网格，表示部位/角色/物体间空间关系 |
+| Motion Adaptation | 运动适配（编辑 + 重定向） |
+| Spatial Relationship | 空间关系（紧密交互） |
+| Local Deformation | 局部形变（最小化以保关系） |
+| Interpenetration | 相互穿插（要减少） |
+| Retargeting | 重定向（到不同体型/环境） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+编辑/重定向**紧密交互**的运动很难：
+- 跳舞、摔跤、剑斗、钻车等涉及**部位/角色/环境**间**紧密空间关系**；
+- 朴素编辑会**破坏关系**或产生**穿插**；
+- 需要一种**通用**表示统一处理单/多角色与物体。
+
+本文要：在编辑/重定向时**保持空间关系**、**减少穿插**。
+
+---
+
+## 🔧 方法详解
+
+### 1. 交互网格表示空间关系
+构造一个**交互网格**，把**交互的身体部位、多个角色、环境物体**之间的**空间关系**编码进一个统一的网格结构。
+
+### 2. 最小化局部形变以保关系
+在动画**各帧**上**最小化交互网格的局部形变**：直观上，"关系网"尽量少变形 → **紧密空间关系被保持**，同时**减少不当穿插**。
+
+### 3. 统一、通用
+该表示对**单角色不同部位**（跳舞）、**多角色交互**（摔跤/格斗）、**角色-环境**（钻车）都适用，提供**统一处理**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    MO["🎞️ 原始交互运动<br/>(跳舞/摔跤/钻车…)"] --> IM
+    subgraph IM["交互网格表示"]
+        R["编码部位/角色/物体空间关系"]
+    end
+    IM --> EDIT["编辑/重定向时<br/>最小化交互网格局部形变"]
+    EDIT --> OUT["🕺 保持紧密空间关系<br/>减少穿插 (SIGGRAPH 2010)"]
+
+    style IM fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **交互网格（interaction mesh）**：统一表示部位/角色/物体间空间关系；
+2. **最小化局部形变保关系**：编辑/重定向时保持紧密交互、减少穿插；
+3. **通用统一**：单/多角色与环境物体一体处理；
+4. **经典基础**：紧密交互运动编辑的奠基性工作（SIGGRAPH 2010）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"交互网格 + 保空间关系"对人-人/人-物交互重定向有直接借鉴**：呼应本仓 04 的 PAIR（接触/关系保持的交互重定向）；
+- **减少穿插**正是人形动作重定向/接触任务要解决的；
+- **统一处理部位/角色/物体**的思想，对多接触全身任务的关系建模有价值；
+- 作为经典图形学工作，为当代"接触/关系保持"的数据生成提供思想源头。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [ACM TOG / SIGGRAPH 2010](https://dl.acm.org/doi/10.1145/1778765.1778770) | 正式论文 |
+| [预印本 PDF](http://www.edho.net/projects/mesh/SIGGRAPH10_preprint.pdf) | 作者预印本 |
+
+> ℹ️ 备注：本文为 SIGGRAPH 2010 / ACM TOG 经典工作，**无 arXiv**；本笔记依据论文公开摘要与预印本整理，**细节以正式论文为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **相关·接触/关系保持的交互重定向（本仓 04）**：[从人-人示范学人-人形交互（PAIR + D-STAR）](../../04_Loco-Manipulation_and_WBC/Learning_Whole-Body_Human-Humanoid_Interaction_from_Human-Human_Demonstrations/Learning_Whole-Body_Human-Humanoid_Interaction_from_Human-Human_Demonstrations.md)；
+- **人-物接触（本仓 14）**：[PICO（人-物接触重建）](../../14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md)。

--- a/papers/14_Human_Motion/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md
+++ b/papers/14_Human_Motion/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "AvatarPoser: Articulated Full-Body Pose Tracking from Sparse Motion Sensing"
+zhname: "AvatarPoser：从稀疏运动感知做关节化全身姿态跟踪"
+category: "Human Motion"
+arxiv: "2207.13784"
+---
+
+# AvatarPoser: Articulated Full-Body Pose Tracking from Sparse Motion Sensing
+**面向 VR/AR 头显场景，仅用头显与双手三点（HMD + 两个手柄）的稀疏运动信号，实时重建关节化全身姿态：基于 Transformer 从稀疏输入预测全身关节旋转，并把全局运动与局部姿态解耦；再用逆运动学微调手臂以精确对齐输入关节，在 AMASS 上达 SOTA，为头显平台的化身驱动奠基（ECCV 2022）**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 稀疏感知 · 全身姿态 · 三点输入 · Transformer · VR/AR · ECCV 2022
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2022 年 7 月（ECCV 2022） |
+| arXiv | [2207.13784](https://arxiv.org/abs/2207.13784) · [PDF](https://arxiv.org/pdf/2207.13784) · [HTML](https://arxiv.org/html/2207.13784v1) |
+| 项目页 | [siplab.org/projects/AvatarPoser](https://siplab.org/projects/AvatarPoser) · [code](https://github.com/eth-siplab/AvatarPoser) |
+| 作者 | Jiaxi Jiang、Paul Streli、Huajian Qiu、Andreas Fender、Christian Holz 等（ETH Zürich SIPLAB） |
+| 主题 | cs.CV · 全身姿态跟踪 / 稀疏感知 / VR/AR |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块（上游标 🌟）。
+
+---
+
+## 🎯 一句话总结
+
+> 在 **VR/AR 头显**平台上驱动**关节化化身**，通常只能拿到**稀疏运动信号**——**头显（HMD）+ 两个手柄**的**三点**位姿。AvatarPoser 提出从这些**稀疏运动感知**实时重建**全身关节姿态**：基于 **Transformer** 的网络从稀疏输入预测**全身关节旋转**，并把**全局运动**与**局部姿态解耦**（用稳定的全局参考），再用**逆运动学（IK）**微调手臂，使预测末端**精确对齐输入**关节。AvatarPoser 在大规模 **AMASS** 动作数据上达 **SOTA**，为头显平台的**化身驱动**奠定基础（ECCV 2022）。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Sparse Motion Sensing | 稀疏运动感知（三点输入） |
+| 3-point Input | 头显 + 两手柄三点位姿 |
+| Articulated Pose | 关节化全身姿态 |
+| Global/Local Decoupling | 全局运动与局部姿态解耦 |
+| IK | Inverse Kinematics，逆运动学微调 |
+| AMASS | 大规模人体动作数据集 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+头显平台只有**三点稀疏信号**，却要驱动**全身化身**：
+- 从极稀疏输入推全身**欠约束**；
+- 要**实时**、手部要**精确对齐**输入；
+- 全局漂移影响稳定。
+
+AvatarPoser 要：从三点稀疏输入实时、精确地重建全身关节姿态。
+
+---
+
+## 🔧 方法详解
+
+### 1. Transformer 从三点预测全身关节
+基于 **Transformer** 的网络，从**头显 + 双手柄**三点位姿预测**全身关节旋转**。
+
+### 2. 全局-局部解耦
+把**全局运动**与**局部姿态解耦**，在稳定的全局参考下预测局部姿态，减少漂移。
+
+### 3. IK 微调手臂（精确对齐）
+用**逆运动学**微调手臂关节，使预测末端**精确对齐输入**手柄位姿，消除手部误差。
+
+### 4. 结果
+在 **AMASS** 上达 **SOTA**，实时驱动头显化身。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    IN["🎮 三点输入<br/>HMD + 两手柄位姿"] --> T
+    subgraph T["AvatarPoser(Transformer)"]
+        P["预测全身关节旋转"]
+        D["全局-局部解耦"]
+        IK["IK 微调手臂(对齐输入)"]
+    end
+    T --> OUT["🧍 关节化全身姿态<br/>AMASS SOTA · VR/AR 化身 (ECCV 2022)"]
+
+    style T fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **三点稀疏 → 全身姿态**：从 HMD + 双手柄重建关节化全身；
+2. **Transformer + 全局-局部解耦**：稳定预测；
+3. **IK 微调手臂**：末端精确对齐输入；
+4. **AMASS SOTA**：头显化身驱动奠基（ECCV 2022）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **从稀疏末端推全身**与人形"少传感器估全身状态"相通（状态估计/本仓 09）；
+- **全局-局部解耦**对全身姿态/重心一致性有益（呼应 FRAME）；
+- **IK 微调对齐末端**是把学习预测与硬约束结合的经典做法；
+- 三点驱动化身的范式启发人形遥操作的稀疏输入控制。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2207.13784](https://arxiv.org/abs/2207.13784) | 论文正文（Transformer、解耦、IK、AMASS 实验） |
+| [项目页 + 代码](https://siplab.org/projects/AvatarPoser) | 概述、视频、开源代码 |
+
+> ℹ️ 备注：本笔记依据论文公开摘要与项目页整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·稀疏/第一视角姿态**：[EgoPoser（间歇观测鲁棒）](../EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md) · [MANIKIN（生物力学神经 IK）](../MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation.md) · [FRAME](../FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.md)。

--- a/papers/14_Human_Motion/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.md
+++ b/papers/14_Human_Motion/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.md
@@ -1,0 +1,121 @@
+---
+layout: paper
+title: "Being-M0.5: A Real-Time Controllable Vision-Language-Motion Model"
+zhname: "Being-M0.5：实时可控的视觉-语言-动作模型"
+category: "Human Motion"
+arxiv: "2508.07863"
+---
+
+# Being-M0.5: A Real-Time Controllable Vision-Language-Motion Model
+**针对视觉-语言-动作模型（VLMM）可控性这一主瓶颈（响应多样指令差、姿态初始化弱、长序列差、未见场景处理不足、缺细粒度部位控制），提出实时可控的 Being-M0.5：基于迄今最大最全的人类动作数据集 HuMo100M（500 万+自采序列、1 亿条多任务指令、细粒度部位标注），用部位感知残差量化做动作 token 化以实现逐部位精细控制，在多个动作生成基准上达 SOTA 且保持实时**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 视觉-语言-动作 · 可控性 · 部位感知量化 · 大数据集 · 实时
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 8 月 |
+| arXiv | [2508.07863](https://arxiv.org/abs/2508.07863) · [PDF](https://arxiv.org/pdf/2508.07863) · [HTML](https://arxiv.org/html/2508.07863v1) |
+| 作者 | Bin Cao、Sipeng Zheng、Ye Wang、Qin Jin、Jing Liu、Zongqing Lu 等（BAAI / 人大等） |
+| 主题 | cs.CV · 人类动作生成 / 视觉-语言-动作 / 可控性 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人类动作生成潜力巨大，但现有**视觉-语言-动作模型（VLMM）**实用部署受限。作者指出**可控性**是主瓶颈，体现在五方面：**对多样人类指令响应不足、姿态初始化能力有限、长序列表现差、对未见场景处理不足、缺乏对各身体部位的细粒度控制**。为此提出**Being-M0.5**，并引入 **HuMo100M** ——**迄今最大最全**的人类动作数据集（**500 万+ 自采动作序列、1 亿条多任务指令实例、细粒度部位级标注**）。方法用**部位感知残差量化（part-aware residual quantization）**做动作 token 化，实现**逐部位**的精细控制。模型在多个动作生成基准上达 **SOTA**，同时保持**实时**执行效率。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| VLMM | Vision-Language-Motion Model |
+| HuMo100M | 本文大规模人类动作数据集 |
+| Part-aware Residual Quantization | 部位感知残差量化（动作 token 化） |
+| Controllability | 可控性（本文主攻瓶颈） |
+| Pose Initialization | 姿态初始化 |
+| Part-level | 部位级（逐身体部位控制） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+VLMM 的**可控性**不足（五大短板）：响应多样指令差、姿态初始化弱、长序列差、未见场景差、**缺逐部位细粒度控制**。论文要：一个**实时、可控**、能逐部位控制的 VLMM，并配足够大的数据。
+
+---
+
+## 🔧 方法详解
+
+### 1. HuMo100M 大规模数据集
+**500 万+ 动作序列、1 亿条多任务指令、细粒度部位标注**——为可控生成提供数据底座。
+
+### 2. 部位感知残差量化（逐部位控制）
+用**部位感知残差量化**做动作 token 化，使模型可对**各身体部位**做**细粒度控制**，直击"缺部位控制"短板。
+
+### 3. 实时可控
+在保证**实时**效率的同时提升可控性（指令响应、姿态初始化、长序列、未见场景）。
+
+### 4. 结果
+多个动作生成基准 **SOTA**，保持实时。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DATA["HuMo100M<br/>500万序列 + 1亿指令 + 部位标注"] --> M
+    subgraph M["Being-M0.5"]
+        Q["部位感知残差量化<br/>(逐部位 token 化)"]
+    end
+    M --> OUT["🕺 实时可控动作生成<br/>多基准 SOTA · 逐部位控制"]
+
+    style M fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **诊断 VLMM 可控性五大短板**；
+2. **HuMo100M**：迄今最大最全人类动作数据集（500 万+/1 亿/部位标注）；
+3. **部位感知残差量化**：逐部位细粒度控制；
+4. **实时 SOTA**：多基准领先且实时。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **逐部位细粒度控制**对人形全身动作（上身操作 + 下身行走分控）有借鉴；
+- **大规模动作数据 + 量化 token 化**是动作生成模型的主流配方，可迁移到人形动作生成（FRoM-W1、UniAct 等）；
+- **可控性五维度**是评估动作生成是否实用的好框架；
+- 动作生成是人形"语言→动作"上游的关键一环。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2508.07863](https://arxiv.org/abs/2508.07863) | 论文正文（HuMo100M、部位量化、基准实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·动作生成/规模化**：[Scaling Large Motion Models](../Scaling_Large_Motion_Models_with_Million-Level_Human_Motions/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.md)；
+- **人形动作生成（本仓 04）**：[UniAct](../../04_Loco-Manipulation_and_WBC/UniAct__Unified_Motion_Generation_and_Action_Streaming_for_Humanoid_Robots/UniAct__Unified_Motion_Generation_and_Action_Streaming_for_Humanoid_Robots.md)。

--- a/papers/14_Human_Motion/Climber_Force_and_Motion_Estimation_from_Video/Climber_Force_and_Motion_Estimation_from_Video.md
+++ b/papers/14_Human_Motion/Climber_Force_and_Motion_Estimation_from_Video/Climber_Force_and_Motion_Estimation_from_Video.md
@@ -1,0 +1,121 @@
+---
+layout: paper
+title: "Climber Force and Motion Estimation from Video"
+zhname: "从视频估计攀岩者的受力与运动"
+category: "Human Motion"
+---
+
+# Climber Force and Motion Estimation from Video
+**从普通视频同时估计攀岩者的 3D 运动与作用于岩点的接触受力：把人体姿态估计与接触/力推断结合，从单目视频恢复攀岩这一强接触、离地全身运动下的人-岩交互力，免去佩戴力传感器即可分析攀岩动作与发力**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 攀岩 · 受力估计 · 运动估计 · 单目视频 · 人-岩接触
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 4 月（arXiv，详见项目页） |
+| 项目页 | [rihat99.github.io/climb_force](https://rihat99.github.io/climb_force/) |
+| 主题 | cs.CV · 攀岩运动分析 / 受力估计 / 人-物交互 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块（上游标 arXiv 2025.04，未给具体链接）。
+
+---
+
+## 🎯 一句话总结
+
+> 本工作研究从**视频**同时估计**攀岩者的运动与受力**：在攀岩这一**强接触、离地、全身**的运动下，恢复攀岩者的 **3D 运动**以及其作用于**岩点（holds）**的**接触受力**。相较于需要在岩壁/岩点上布置**力传感器**的侵入式方案，本方法仅凭**视频**就能推断**人-岩交互力**，从而**非侵入地**分析攀岩动作与**发力模式**。这属于"从视频做**力 + 运动**联合估计"的范式——把**人体姿态估计**与**接触/力推断**结合，对运动科学、教练辅助乃至机器人攀爬都有参考价值。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Force Estimation | 受力（接触力）估计 |
+| Motion Estimation | 3D 运动/姿态估计 |
+| Hold | 岩点（攀岩抓握/踩踏点） |
+| Contact | 人-岩接触 |
+| Monocular Video | 单目（普通）视频 |
+| Non-invasive | 非侵入（免力传感器） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+攀岩的**受力分析**通常要**侵入式力传感**（岩点/岩壁布传感器），成本高、难普及；而：
+- 攀岩是**强接触、离地、全身**运动，姿态与受力都难估；
+- 想**仅凭视频**就同时得到**运动 + 受力**。
+
+本工作要：从普通视频**非侵入地**联合估计攀岩者的**3D 运动与接触受力**。
+
+---
+
+## 🔧 方法详解
+
+> 说明：以下为依据论文标题与项目页所做的范式层面梳理；具体网络结构与数值以正式论文为准。
+
+### 1. 视频 → 3D 攀岩运动
+先从视频做**3D 人体姿态/运动估计**，恢复攀岩者在世界/相机坐标下的全身运动（强接触、离地场景对姿态估计是难点）。
+
+### 2. 接触与受力推断
+在估计的运动基础上，**推断人-岩接触**与作用于**岩点的受力**——把"运动学"与"动力学（接触力）"联系起来，本质是一个**力 + 运动**联合估计问题。
+
+### 3. 非侵入分析
+无需在岩点布置力传感器，仅凭**视频**即可分析攀岩**发力模式**，便于规模化采集与教练/科研应用。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    VID["🎥 攀岩单目视频"] --> POSE["3D 攀岩运动估计"]
+    POSE --> FORCE["接触 + 岩点受力推断"]
+    FORCE --> OUT["🧗 非侵入的运动 + 受力分析<br/>(免力传感器)"]
+
+    style POSE fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style FORCE fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **从视频联合估计攀岩运动 + 受力**：非侵入；
+2. **强接触/离地全身**场景下的姿态 + 接触力推断；
+3. **免力传感器**：仅凭视频分析发力模式；
+4. **面向运动科学/教练/机器人攀爬**的分析工具。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"从视频估接触力"对强接触全身任务很有价值**：攀岩、搬运、推压等都需理解接触力；
+- **运动 + 受力联合估计**把运动学与动力学连接，呼应人形 loco-manip 对"外力来源建模"的诉求；
+- 攀岩这类**离地多接触**运动可为人形攀爬/跑酷提供参考与受力先验；
+- 非侵入受力估计有望低成本扩充"带力标注"的人类数据。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [项目页 rihat99.github.io/climb_force](https://rihat99.github.io/climb_force/) | 概述、视频、方法（含 arXiv 链接） |
+
+> ℹ️ 备注：上游标注为 **arXiv 2025.04** 但未给出具体编号；本笔记依据**标题与项目页**所做范式层面整理，**方法细节与数值以正式论文/PDF 为准**，arXiv 编号待补。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·攀岩/人-物接触**：[ClimbingCap（攀岩多模态动捕）](../ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.md) · [PICO（人-物接触重建）](../PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md)；
+- **接触/力（本仓 04）**：[CHIP（可控柔顺）](../../04_Loco-Manipulation_and_WBC/CHIP__Adaptive_Compliance_for_Humanoid_Control_through_Hindsight_Perturbation/CHIP__Adaptive_Compliance_for_Humanoid_Control_through_Hindsight_Perturbation.md)。

--- a/papers/14_Human_Motion/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.md
+++ b/papers/14_Human_Motion/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "ClimbingCap: Multi-Modal Dataset and Method for Rock Climbing in World Coordinate"
+zhname: "ClimbingCap：世界坐标系下攀岩的多模态数据集与方法"
+category: "Human Motion"
+arxiv: "2503.21268"
+---
+
+# ClimbingCap: Multi-Modal Dataset and Method for Rock Climbing in World Coordinate
+**人体动作恢复多聚焦地面动作，离地的攀岩动作研究稀少且缺大规模 3D 标注数据；作者采集 AscendMotion（41.2 万帧 RGB+LiDAR+IMU，22 位攀岩教练、12 面岩壁），并提出 ClimbingCap：用 RGB 与 LiDAR 分别在相机坐标与全局坐标重建动作并联合优化，在世界坐标系下连续重建复杂攀岩动作（含全局位置），CVPR 2025**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 攀岩动捕 · 多模态(RGB+LiDAR+IMU) · 世界坐标 · 离地动作 · CVPR 2025
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.21268](https://arxiv.org/abs/2503.21268) · [PDF](https://arxiv.org/pdf/2503.21268) · [HTML](https://arxiv.org/html/2503.21268v1) |
+| 会议 | CVPR 2025 |
+| 作者 | Ming Yan、Xincheng Lin、Yudi Dai、Yuexin Ma、Lan Xu、Chenglu Wen、Siqi Shen、Cheng Wang（厦大 / 上科大等） |
+| 主题 | cs.CV · 攀岩动捕 / 多模态 / 世界坐标重建 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 人体动作恢复（HMR）研究多聚焦**地面动作**（如跑步），对**离地（off-ground）**的**攀岩动作**研究**稀少**，部分因**攀岩动作数据集**（尤其大规模、有挑战性的 3D 标注）**匮乏**。作者采集 **AscendMotion** ——一个**大规模、标注良好、有挑战性**的攀岩动作数据集：**41.2 万帧 RGB、LiDAR 帧与 IMU 测量**，含 **22 位熟练攀岩教练**在 **12 面不同岩壁**上的攀岩动作。攀岩动作捕捉难在需**精确恢复复杂姿态 + 全局位置**；现有全局 HMR 方法难以胜任。为此提出 **ClimbingCap**，在**全局坐标系**下**连续重建 3D 攀岩动作**：关键是用 **RGB 与 LiDAR** 分别在**相机坐标**与**全局坐标**重建动作，并**联合优化**。CVPR 2025 收录。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| HMR | Human Motion Recovery，人体动作恢复 |
+| AscendMotion | 本文攀岩多模态数据集 |
+| RGB / LiDAR / IMU | 彩色 / 激光雷达 / 惯性 |
+| Off-ground | 离地动作（攀岩） |
+| World Coordinate | 世界（全局）坐标系 |
+| Global Position | 全局位置 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+攀岩这类**离地动作**的动捕被忽视：
+- 缺**大规模 3D 标注**攀岩数据；
+- 需同时恢复**复杂姿态 + 全局位置**；
+- 现有全局 HMR 方法难胜任。
+
+ClimbingCap 要：建数据集（AscendMotion）+ 方法，在世界坐标下连续重建攀岩动作。
+
+---
+
+## 🔧 方法详解
+
+### 1. AscendMotion 多模态数据集
+**41.2 万帧 RGB + LiDAR + IMU**，22 位教练、12 面岩壁，大规模有挑战性。
+
+### 2. ClimbingCap：RGB + LiDAR 分坐标重建 + 联合优化
+- **RGB** 在**相机坐标**重建动作；
+- **LiDAR** 在**全局坐标**重建；
+- **联合优化**得到世界坐标下连续 3D 攀岩动作（含全局位置）。
+
+### 3. 结果
+在世界坐标系下有效捕捉复杂攀岩动作；CVPR 2025。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DATA["AscendMotion<br/>41.2万帧 RGB+LiDAR+IMU"] --> CC
+    subgraph CC["ClimbingCap"]
+        RGB["RGB → 相机坐标动作"]
+        LID["LiDAR → 全局坐标动作"]
+        RGB --> JO["联合优化"]
+        LID --> JO
+    end
+    CC --> OUT["🧗 世界坐标连续 3D 攀岩动作<br/>(姿态 + 全局位置) · CVPR 2025"]
+
+    style CC fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **AscendMotion 攀岩数据集**：41.2 万帧多模态，22 教练/12 岩壁；
+2. **ClimbingCap 方法**：RGB（相机）+ LiDAR（全局）分坐标重建 + 联合优化；
+3. **世界坐标连续重建**：姿态 + 全局位置；
+4. **离地动作**：填补攀岩动捕空白（CVPR 2025）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **离地/强接触动作（攀岩）**是高难全身动作，对人形多接触/跑酷有数据价值；
+- **RGB + LiDAR 分坐标 + 联合优化**是世界坐标全身重建的实用方案；
+- **全局位置恢复**对人形 loco-manip 的世界系跟踪相关（呼应 HiWET）；
+- 攀岩这类极限动作可作为人形高难技能的参考动作源。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.21268](https://arxiv.org/abs/2503.21268) | 论文正文（AscendMotion、ClimbingCap、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（41.2 万帧）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·人体重建/交互**：[PICO（人-物接触重建）](../PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md)；
+- **世界系跟踪（本仓 04）**：[HiWET](../../04_Loco-Manipulation_and_WBC/HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation/HiWET__Hierarchical_World-Frame_End-Effector_Tracking_for_Long-Horizon_Humanoid_Loco-Manipulation.md)。

--- a/papers/14_Human_Motion/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md
+++ b/papers/14_Human_Motion/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "EgoPoser: Robust Real-Time Egocentric Pose Estimation from Sparse and Intermittent Observations Everywhere"
+zhname: "EgoPoser：随处可用、面向稀疏且间歇观测的鲁棒实时第一视角姿态估计"
+category: "Human Motion"
+arxiv: "2308.06493"
+---
+
+# EgoPoser: Robust Real-Time Egocentric Pose Estimation from Sparse and Intermittent Observations Everywhere
+**现有头显第一视角全身姿态估计过度依赖室内动捕空间、假设关节连续跟踪与统一体型；EgoPoser 让全身姿态估计在「只有手进入头显视野时才有的间歇手部位置/朝向」下仍鲁棒，并提出独立于全局位置预测全身姿态的全局运动分解、用高效 SlowFast 模块兼顾更长时序与算力，且能跨不同体型泛化（ECCV 2024）**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 第一视角姿态 · 间歇观测 · 全局运动分解 · SlowFast · 跨体型 · ECCV 2024
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2023 年 8 月（ECCV 2024） |
+| arXiv | [2308.06493](https://arxiv.org/abs/2308.06493) · [PDF](https://arxiv.org/pdf/2308.06493) · [HTML](https://arxiv.org/html/2308.06493v3) |
+| 项目页 | [siplab.org/projects/EgoPoser](https://siplab.org/projects/EgoPoser) · [code](https://github.com/eth-siplab/EgoPoser) |
+| 作者 | Jiaxi Jiang、Paul Streli、Manuel Meier、Christian Holz（ETH Zürich SIPLAB） |
+| 主题 | cs.CV · 第一视角全身姿态 / 稀疏间歇观测 / VR/AR |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块（上游标 🌟）。
+
+---
+
+## 🎯 一句话总结
+
+> 仅用**头与手位姿**做**全身第一视角姿态估计**是头显平台驱动化身的活跃方向，但现有方法**过度依赖室内动捕空间**（数据录制环境），且**假设关节连续跟踪与统一体型**。EgoPoser 在**更真实**的设定下做到鲁棒：手部位置/朝向**只有进入头显视野（FoV）时才被跟踪**——即**稀疏且间歇**的观测。它还有三点关键贡献：① 在**间歇手部跟踪**下仍鲁棒建模全身姿态；② **全局运动分解**——**独立于全局位置**预测全身姿态；③ 高效的 **SlowFast 模块**设计，在**捕捉更长运动时序**的同时**保持算力高效**；并能**跨不同用户体型泛化**。ECCV 2024。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Egocentric | 第一视角（头显） |
+| Intermittent | 间歇（手出视野则丢跟踪） |
+| FoV | Field of View，头显视野 |
+| Global Motion Decomposition | 全局运动分解（独立于全局位置） |
+| SlowFast | 慢-快双路时序模块 |
+| Body Shape Generalization | 跨体型泛化 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+现有第一视角全身姿态估计**假设太理想**：
+- 依赖**室内动捕空间**、**连续**关节跟踪、**统一体型**；
+- 真实中手**常出视野**→**间歇**观测；
+- 全局位置变化影响稳定。
+
+EgoPoser 要：在**稀疏间歇**观测、**任意场景、任意体型**下鲁棒实时估计全身姿态。
+
+---
+
+## 🔧 方法详解
+
+### 1. 间歇手部观测下的鲁棒建模
+手部位置/朝向**仅在 FoV 内**可得，EgoPoser 在这种**间歇**信号下仍稳健建模全身姿态。
+
+### 2. 全局运动分解（独立于全局位置）
+提出**全局运动分解**：**独立于全局位置**预测全身姿态，避免对绝对位置的依赖、提升泛化。
+
+### 3. SlowFast 模块（长时序 + 高效）
+高效的 **SlowFast** 设计兼顾**更长运动时序**与**算力**。
+
+### 4. 跨体型泛化
+对**不同用户体型**泛化，摆脱"统一体型"假设。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    IN["🎮 头 + 间歇手部观测<br/>(仅 FoV 内)"] --> EP
+    subgraph EP["EgoPoser"]
+        G["全局运动分解(独立全局位置)"]
+        SF["SlowFast 模块(长时序+高效)"]
+    end
+    EP --> OUT["🧍 鲁棒实时全身姿态<br/>任意场景/任意体型 (ECCV 2024)"]
+
+    style EP fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **间歇观测鲁棒**：手出视野也能稳健估全身姿态；
+2. **全局运动分解**：独立于全局位置预测，提升泛化；
+3. **SlowFast 模块**：长时序 + 算力高效；
+4. **跨体型泛化**：摆脱统一体型假设（ECCV 2024）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"间歇/缺失观测下鲁棒"是真实部署的关键**，与人形状态估计在传感缺失时的鲁棒诉求一致；
+- **全局运动分解**对全身状态估计的泛化有借鉴（呼应 AvatarPoser、FRAME）；
+- **SlowFast 长时序 + 高效**是实时全身估计的实用结构；
+- 稀疏感知驱动全身，对人形遥操作/化身有直接价值。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2308.06493](https://arxiv.org/abs/2308.06493) | 论文正文（间歇建模、全局分解、SlowFast、实验） |
+| [项目页 + 代码](https://siplab.org/projects/EgoPoser) | 概述、视频、开源代码 |
+
+> ℹ️ 备注：本笔记依据论文公开摘要与项目页整理；**逐项数值以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·稀疏/第一视角姿态**：[AvatarPoser（三点全身）](../AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md) · [FRAME（地面对齐第一视角）](../FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.md) · [MANIKIN](../MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation.md)。

--- a/papers/14_Human_Motion/Example-based_Motion_Synthesis_via_Generative_Motion_Matching/Example-based_Motion_Synthesis_via_Generative_Motion_Matching.md
+++ b/papers/14_Human_Motion/Example-based_Motion_Synthesis_via_Generative_Motion_Matching/Example-based_Motion_Synthesis_via_Generative_Motion_Matching.md
@@ -1,0 +1,129 @@
+---
+layout: paper
+title: "Example-based Motion Synthesis via Generative Motion Matching"
+zhname: "GenMM：用生成式动作匹配做范例驱动的动作合成"
+category: "Human Motion"
+arxiv: "2306.00378"
+---
+
+# Example-based Motion Synthesis via Generative Motion Matching
+**GenMM：从单段或少量范例序列「挖」出尽可能多样的动作；不同于需长时离线训练、易出视觉伪影、在大型复杂骨架上易失败的数据驱动法，它继承了知名 Motion Matching 的免训练特性与高质量——用双向视觉相似度作代价、多阶段从随机初始化逐步细化，几分之一秒合成高质量动作，并扩展到动作补全、关键帧引导生成、无限循环与动作重组**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 范例驱动 · 生成式动作匹配 · 免训练 · 多阶段细化 · SIGGRAPH 2023
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2023 年 6 月 |
+| arXiv | [2306.00378](https://arxiv.org/abs/2306.00378) · [PDF](https://arxiv.org/pdf/2306.00378) · [HTML](https://arxiv.org/html/2306.00378v1) |
+| 会议 | SIGGRAPH 2023 |
+| 作者 | Weiyu Li、Xuelin Chen、Peizhuo Li、Olga Sorkine-Hornung、Baoquan Chen |
+| 主题 | cs.GR · 范例驱动动作合成 / 动作匹配 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> **GenMM** 是一个**生成模型**，从**单段或少量范例序列**中"**挖（mine）**"出尽可能**多样**的动作。与现有**数据驱动**方法（通常需**长时离线训练**、易出**视觉伪影**、在**大型复杂骨架**上易失败）形成鲜明对比，GenMM **继承了知名 Motion Matching 方法的免训练特性与卓越质量**。框架还可扩展到**动作补全、关键帧引导生成、无限循环、动作重组**等场景。核心是一个**生成式动作匹配模块**，用**双向视觉相似度**作代价函数，配**多阶段框架**从随机初始化**逐步细化**。它能在**几分之一秒**内合成高质量动作、处理**复杂大型骨架**、从极少范例生成多样动作。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| GenMM | 生成式动作匹配模型 |
+| Motion Matching | 经典免训练动作合成法 |
+| Example-based | 范例驱动（单/少样本） |
+| Bidirectional Similarity | 双向视觉相似度（代价函数） |
+| Multi-stage | 多阶段逐步细化 |
+| Training-free | 免训练 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+数据驱动动作合成的痛点：
+- **长时离线训练**；
+- **视觉伪影**；
+- **大型复杂骨架**上易失败；
+- 难从**极少范例**生成多样动作。
+
+GenMM 要：**免训练**、高质量、可处理复杂骨架、从单/少范例生成多样动作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 生成式动作匹配（双向相似度代价）
+继承 **Motion Matching** 的免训练高质量，用**双向视觉相似度**作代价函数衡量合成与范例的匹配度。
+
+### 2. 多阶段逐步细化
+从**随机初始化**出发，**多阶段**逐步细化，避免伪影、稳健处理大型骨架。
+
+### 3. 多场景扩展
+支持**动作补全、关键帧引导生成、无限循环、动作重组**。
+
+### 4. 效率
+**几分之一秒**合成高质量动作，免训练即用。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    EX["🎞️ 单/少范例序列"] --> GM
+    subgraph GM["GenMM(免训练)"]
+        C["双向视觉相似度代价"]
+        S["多阶段从随机初始化细化"]
+        C --> S
+    end
+    GM --> OUT["🕺 多样高质量动作(<1s)<br/>补全/关键帧/循环/重组"]
+
+    style GM fill:#fff4e6,stroke:#e67e22,color:#7d3c08
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **GenMM 免训练生成式动作匹配**：继承 Motion Matching 质量；
+2. **双向相似度 + 多阶段细化**：避伪影、稳健复杂骨架；
+3. **极少范例 → 多样动作**：单/少样本；
+4. **多场景 + 高效**：补全/关键帧/循环/重组，<1 秒。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **免训练范例驱动**对快速生成参考动作很实用，无需大数据/长训练；
+- **双向相似度**是衡量动作质量的可迁移代价；
+- **从少范例挖多样**契合人形稀缺动作数据的扩增需求；
+- 动作重组/循环可为人形技能库提供多样参考。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2306.00378](https://arxiv.org/abs/2306.00378) | 论文正文（生成式动作匹配、多阶段细化、应用） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·动作合成**：[TEDi（长时程合成）](../TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.md) · [Guided Motion Diffusion](../Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md)。

--- a/papers/14_Human_Motion/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.md
+++ b/papers/14_Human_Motion/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "FRAME: Floor-aligned Representation for Avatar Motion from Egocentric Video"
+zhname: "FRAME：面向第一视角视频化身动作的地面对齐表示"
+category: "Human Motion"
+arxiv: "2503.23094"
+---
+
+# FRAME: Floor-aligned Representation for Avatar Motion from Egocentric Video
+**用头戴朝身立体相机做第一视角动捕对 VR/AR 至关重要，但有严重遮挡与真实标注稀缺；作者搭建带实时 6D 位姿跟踪的轻量 VR 采集装置建立大规模数据集，并提出 FRAME——几何一致地融合设备位姿与相机画面做身体姿态预测，在现代硬件上以 300 FPS 运行、达 SOTA 且消除以往伪影、尤其改善下肢预测**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 第一视角动捕 · 地面对齐 · 设备位姿融合 · VR/AR · 300 FPS
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.23094](https://arxiv.org/abs/2503.23094) · [PDF](https://arxiv.org/pdf/2503.23094) · [HTML](https://arxiv.org/html/2503.23094v1) |
+| 作者 | Andrea Boscolo Camiletto、Jian Wang、Rishabh Dabral、Thabo Beeler、Marc Habermann、Christian Theobalt（MPI / Google） |
+| 主题 | cs.CV · 第一视角动捕 / 化身动作 / VR/AR |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 用**头戴、朝身立体相机**做**第一视角动捕**对 **VR/AR** 至关重要，但面临**严重遮挡**与**真实标注数据稀缺**。作者开发了一套**轻量 VR 数据采集装置**，带**实时 6D 位姿跟踪**，为朝身相机建立大规模数据集；并提出 **FRAME**，**几何一致地融合设备位姿与相机画面**做**身体姿态预测**，在现代硬件上以 **300 FPS** 运行。FRAME 达 **SOTA**，**消除以往方法的常见伪影**，尤其在真实场景下**下肢预测**表现更优。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| FRAME | Floor-aligned Representation（本文方法） |
+| Egocentric | 第一视角（头戴相机） |
+| 6D Pose | 设备 6 自由度位姿 |
+| Body-facing Stereo | 朝身立体相机 |
+| Floor-aligned | 地面对齐表示 |
+| FPS | 帧率（300 FPS） |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+头戴朝身相机第一视角动捕难：
+- **严重遮挡**（自遮挡）；
+- **真实标注数据稀缺**；
+- 要**实时**且融合**设备位姿**做准确身体姿态。
+
+FRAME 要：地面对齐 + 设备位姿与相机融合，实时高精度地预测全身姿态。
+
+---
+
+## 🔧 方法详解
+
+### 1. 轻量 VR 采集 + 实时 6D 跟踪
+搭建**轻量 VR 数据采集装置**，带**实时 6D 位姿跟踪**，建立大规模朝身相机数据集，缓解标注稀缺。
+
+### 2. 几何一致融合设备位姿 + 相机
+**FRAME** 把**设备位姿**与**相机画面**做**几何一致**融合（地面对齐表示），预测身体姿态。
+
+### 3. 实时 + 新训练策略
+**300 FPS** 运行；用新训练策略改善泛化、消除伪影。
+
+### 4. 结果
+**SOTA** 身体姿态预测，尤其**下肢**更准。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DEV["📟 设备 6D 位姿"] --> FUSE
+    CAM["📷 朝身立体相机画面"] --> FUSE
+    subgraph FUSE["FRAME 地面对齐融合"]
+        G["几何一致融合"]
+    end
+    FUSE --> OUT["🕺 身体姿态预测<br/>300 FPS · SOTA · 下肢更准"]
+
+    style FUSE fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **轻量 VR 采集 + 6D 跟踪数据集**：缓解第一视角标注稀缺；
+2. **FRAME 地面对齐融合**：几何一致融合设备位姿 + 相机；
+3. **300 FPS 实时 SOTA**：消除伪影、下肢更准；
+4. **面向 VR/AR**：实用的第一视角动捕。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **设备位姿 + 视觉融合**对第一视角姿态估计很关键，呼应人形 egocentric 控制（ZeroWBC 等）需要的状态估计；
+- **地面对齐表示**对全身姿态/重心一致性有益；
+- **实时高帧率**是机器人闭环所需；
+- 第一视角全身姿态是"从人类视频学全身控制"的上游感知。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.23094](https://arxiv.org/abs/2503.23094) | 论文正文（采集装置、FRAME 融合、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（300 FPS）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·第一视角姿态/动捕**：[EgoPoser](../EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md) · [AvatarPoser](../AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md)。

--- a/papers/14_Human_Motion/Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.md
+++ b/papers/14_Human_Motion/Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.md
@@ -1,0 +1,126 @@
+---
+layout: paper
+title: "Flexible Motion In-betweening with Diffusion Models"
+zhname: "用扩散模型做灵活的动作中间帧补全"
+category: "Human Motion"
+arxiv: "2405.11126"
+---
+
+# Flexible Motion In-betweening with Diffusion Models
+**动作中间帧补全（in-betweening）是角色动画的基础但费力任务；本文用扩散模型从用户关键帧生成多样、逼真的过渡动作，提出统一模型 CondMDI：支持任意密/稀关键帧放置、部分关键帧约束，并可文本条件，在 HumanML3D 上生成既精确又多样、与关键帧一致的高质量动作，并比较了引导与插补式的推理期关键帧方案**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 中间帧补全 · 扩散模型 · 关键帧约束 · 文本条件 · HumanML3D
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 5 月 |
+| arXiv | [2405.11126](https://arxiv.org/abs/2405.11126) · [PDF](https://arxiv.org/pdf/2405.11126) · [HTML](https://arxiv.org/html/2405.11126v1) |
+| 作者 | Setareh Cohan、Guy Tevet、Daniele Reda、Xue Bin Peng、Michiel van de Panne（UBC / SFU 等） |
+| 主题 | cs.GR · 角色动画 / 动作补全 / 扩散模型 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> **动作中间帧补全（motion in-betweening）**是角色动画的基础任务：在用户给定的**关键帧约束**之间生成**合理过渡**的动作序列，长期被视为**费力且有挑战**。本文研究**扩散模型**在**关键帧引导**下生成**多样人类动作**的潜力。不同于以往补全方法，作者提出一个**简单统一**的模型，能生成**精确且多样**、符合**灵活范围**的用户**空间约束**与**文本条件**的动作——即 **CondMDI（Conditional Motion Diffusion In-betweening）**：允许**任意密集或稀疏关键帧放置**与**部分关键帧约束**，同时生成与给定关键帧**一致、连贯、多样**的高质量动作。在文本条件的 **HumanML3D** 数据集上评测，验证扩散模型用于关键帧补全的**通用性与有效性**，并进一步比较了**引导（guidance）**与**插补（imputation）**式的推理期关键帧方案。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| In-betweening | 中间帧补全，关键帧之间生成过渡 |
+| CondMDI | 本文条件动作扩散补全模型 |
+| Keyframe | 关键帧（用户指定约束） |
+| Dense/Sparse | 密集/稀疏关键帧 |
+| Imputation | 插补，推理期填入约束 |
+| HumanML3D | 文本-动作数据集 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+中间帧补全费力且约束方式僵硬：
+- 以往方法**关键帧放置不灵活**（固定密度）；
+- 难同时支持**部分约束 + 文本条件**；
+- 要**多样且与关键帧一致**。
+
+CondMDI 要：一个**统一扩散模型**，支持**任意密/稀、部分关键帧 + 文本**，生成多样一致的动作。
+
+---
+
+## 🔧 方法详解
+
+### 1. CondMDI 统一条件扩散
+一个模型即可处理**任意密集或稀疏关键帧**、**部分关键帧约束**，并叠加**文本条件**，生成符合空间约束的多样动作。
+
+### 2. 灵活关键帧 + 文本
+用户可在任意位置放关键帧（甚至只约束部分关节/帧），文本进一步指定语义。
+
+### 3. 推理期关键帧方案比较
+比较**引导（guidance）**与**插补（imputation）**两类推理期关键帧实现，分析各自优劣。
+
+### 4. 评测
+在 **HumanML3D** 上验证通用性与有效性，生成高质量、与关键帧一致的多样动作。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    KF["🔑 任意密/稀关键帧 + 部分约束"] --> M
+    TXT["📝 文本条件"] --> M
+    subgraph M["CondMDI 条件扩散"]
+        D["统一模型生成过渡动作"]
+    end
+    M --> OUT["🕺 与关键帧一致的多样动作<br/>HumanML3D 验证"]
+
+    style M fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **CondMDI 统一补全模型**：任意密/稀关键帧 + 部分约束 + 文本；
+2. **多样且一致**：高质量过渡动作；
+3. **推理期关键帧方案比较**：引导 vs 插补；
+4. **HumanML3D 验证**：扩散模型补全的通用性。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **灵活关键帧约束**对人形动作编辑/规划有用：给少量关键姿态即可补全全程；
+- **引导 vs 插补**的推理期约束注入，是把硬约束加进扩散生成的通用手段（与 SafeFlow 的约束门控相通）；
+- 角色动画补全经验可迁移到人形参考动作生成；
+- 文本 + 空间双约束契合人形"语言 + 目标"控制。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2405.11126](https://arxiv.org/abs/2405.11126) | 论文正文（CondMDI、关键帧方案、HumanML3D 实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·可控动作扩散**：[Guided Motion Diffusion（空间约束）](../Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md) · [Taming Diffusion（实时角色控制）](../Taming_Diffusion_Probabilistic_Models_for_Character_Control/Taming_Diffusion_Probabilistic_Models_for_Character_Control.md)。

--- a/papers/14_Human_Motion/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data.md
+++ b/papers/14_Human_Motion/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data.md
@@ -1,0 +1,131 @@
+---
+layout: paper
+title: "Go to Zero: Towards Zero-shot Motion Generation with Million-scale Data"
+zhname: "Go to Zero：迈向百万级数据的零样本动作生成"
+category: "Human Motion"
+arxiv: "2507.07095"
+---
+
+# Go to Zero: Towards Zero-shot Motion Generation with Million-scale Data
+**把文本到动作推向「零样本泛化」：提出高效动作标注机制，从网络规模人类动作视频自动用运动学回归采集高质量动作、用视觉语言模型生成语义丰富描述，构建迄今最大的人类动作数据集 MotionMillion（2000+ 小时、200 万条序列），并提出最全面的零样本评测 MotionMillion-Eval；把模型规模化到 7B 参数，对域外与复杂组合动作展现强泛化**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 零样本动作生成 · 百万级数据 · 自动标注 · 7B 模型 · 评测基准
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 7 月 |
+| arXiv | [2507.07095](https://arxiv.org/abs/2507.07095) · [PDF](https://arxiv.org/pdf/2507.07095) · [HTML](https://arxiv.org/html/2507.07095v1) |
+| 项目页 | [vankouf.github.io/MotionMillion](https://vankouf.github.io/MotionMillion/) · [code](https://github.com/VankouF/MotionMillion-Codes) |
+| 主题 | cs.CV · 零样本动作生成 / 大规模数据 / 文本到动作 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文要把**文本到动作（text-to-motion）**推向**零样本泛化**的新阶段。为此提出一套**高效动作标注机制**：从**网络规模人类动作视频**中**自主采集**人类动作——用**运动学回归（kinematic regression）**从无标注视频中提取动作，并用先进**视觉语言模型**生成**语义丰富的描述（caption）**。据此构建 **MotionMillion** ——**迄今最大**的人类动作数据集（**2000+ 小时、200 万条**高质量动作序列）。还提出 **MotionMillion-Eval** ——**最全面**的零样本动作生成评测基准。作者把模型**规模化到 7B 参数**并在 MotionMillion-Eval 上验证：结果对**域外（out-of-domain）**与**复杂组合（compositional）**动作展现**强泛化**，是迈向**零样本人类动作生成**的重要一步。代码开源。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| Zero-shot | 零样本（未见文本/动作） |
+| MotionMillion | 本文百万级动作数据集 |
+| Kinematic Regression | 运动学回归（从视频提动作） |
+| VLM Caption | 视觉语言模型生成描述 |
+| MotionMillion-Eval | 零样本评测基准 |
+| 7B | 70 亿参数模型 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+文本到动作缺**零样本泛化**：
+- 现有数据集**小**，难覆盖多样文本/动作；
+- 缺**自动标注**把网络视频转成"动作 + 描述"；
+- 缺**零样本评测基准**。
+
+Go to Zero 要：**自动**造百万级数据、训大模型、建零样本基准，实现零样本动作生成。
+
+---
+
+## 🔧 方法详解
+
+### 1. 高效自动标注（视频 → 动作 + 描述）
+- **运动学回归**从**无标注网络视频**提取人类动作；
+- **VLM** 生成**语义丰富的描述**；
+- 自主大规模采集。
+
+### 2. MotionMillion 数据集
+**2000+ 小时、200 万条**高质量动作序列——迄今最大。
+
+### 3. 7B 大模型 + MotionMillion-Eval
+把模型**规模化到 7B**，并提出**最全面的零样本评测**基准验证。
+
+### 4. 结果
+对**域外**与**复杂组合**动作**强泛化**，迈向零样本动作生成。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    VID["🎥 网络规模人类动作视频"] --> ANNO
+    subgraph ANNO["高效自动标注"]
+        KR["运动学回归提动作"]
+        VLM["VLM 生成描述"]
+    end
+    ANNO --> DATA["MotionMillion<br/>2000h+ / 200万序列"]
+    DATA --> M["7B 大模型"]
+    M --> OUT["🕺 零样本动作生成<br/>域外/复杂组合强泛化 (MotionMillion-Eval)"]
+
+    style ANNO fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **高效自动标注机制**：运动学回归 + VLM 描述，从网络视频造数据；
+2. **MotionMillion**：迄今最大（2000h+/200 万序列）；
+3. **MotionMillion-Eval**：最全面零样本评测基准；
+4. **7B 模型 + 强零样本泛化**：域外与复杂组合动作。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **零样本是动作生成的下一个高地**，数据规模 + 模型规模是关键，对人形动作生成同样适用；
+- **自动从视频造"动作 + 描述"**是规模化数据的范式（与 Scaling Large Motion Models、SCHUR 同向）；
+- **零样本评测基准**对衡量真正泛化很重要；
+- 大规模动作模型可作人形"语言→动作"的强先验。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2507.07095](https://arxiv.org/abs/2507.07095) | 论文正文（自动标注、MotionMillion、7B 模型、零样本评测） |
+| [项目页 + 代码](https://vankouf.github.io/MotionMillion/) | 概述、数据、开源代码 |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要与项目页整理；数值（2000h+/200 万/7B）取自公开信息，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·动作生成/规模化**：[Scaling Large Motion Models](../Scaling_Large_Motion_Models_with_Million-Level_Human_Motions/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.md) · [Being-M0.5](../Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.md)。

--- a/papers/14_Human_Motion/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md
+++ b/papers/14_Human_Motion/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md
@@ -1,0 +1,128 @@
+---
+layout: paper
+title: "Guided Motion Diffusion for Controllable Human Motion Synthesis"
+zhname: "GMD：用引导式动作扩散做可控的人体动作合成"
+category: "Human Motion"
+arxiv: "2305.12577"
+---
+
+# Guided Motion Diffusion for Controllable Human Motion Synthesis
+**文本条件的动作扩散难以纳入空间约束（预定轨迹、障碍物），而这对连接孤立动作与周遭环境很关键；GMD 把空间约束注入生成：用特征投影方案增强空间信息与局部姿态的一致性、配新的插补公式让动作可靠遵循全局轨迹，并用「稠密引导」把易被忽略的稀疏约束（如稀疏关键帧）转成更密的引导信号，在文本动作生成上显著超 SOTA 且支持轨迹跟随与避障**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 可控动作扩散 · 空间约束 · 特征投影 · 稠密引导 · 轨迹/避障
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2023 年 5 月 |
+| arXiv | [2305.12577](https://arxiv.org/abs/2305.12577) · [PDF](https://arxiv.org/pdf/2305.12577) · [HTML](https://arxiv.org/html/2305.12577v1) |
+| 作者 | Korrawe Karunratanakul、Konpat Preechakul、Supasorn Suwajanakorn、Siyu Tang（ETH Zürich / VISTEC） |
+| 主题 | cs.CV · 可控动作合成 / 扩散 / 空间约束 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 去噪扩散在**文本条件**的人体动作合成上很有前景，但**纳入空间约束**（如**预定运动轨迹**与**障碍物**）仍难——而这对连接**孤立动作**与其**周遭环境**至关重要。GMD（**Guided Motion Diffusion**）把**空间约束**注入动作生成：① 提出有效的**特征投影方案**，操纵动作表示以增强**空间信息**与**局部姿态**的一致性；② 配一个新的**插补公式（imputation formulation）**，使生成动作可靠**遵循全局运动轨迹**等空间约束；③ 针对**稀疏空间约束**（如稀疏关键帧）易在反向步骤中**被忽略**的问题，提出**稠密引导（dense guidance）**，把稀疏信号转成**更密**的信号去引导生成。实验证明 GMD 在**文本动作生成**上**显著超 SOTA**，同时支持**轨迹跟随与避障**等空间控制。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| GMD | Guided Motion Diffusion |
+| Spatial Constraint | 空间约束（轨迹/障碍） |
+| Feature Projection | 特征投影（增强空间-姿态一致性） |
+| Imputation | 插补公式（约束遵循） |
+| Dense Guidance | 稠密引导（稀疏→密集信号） |
+| Trajectory Following | 轨迹跟随 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+文本动作扩散难纳入**空间约束**：
+- 预定**轨迹/障碍**难融入生成；
+- **稀疏约束**（稀疏关键帧）在反向去噪中**易被忽略**；
+- 要把**孤立动作**与**环境**连接。
+
+GMD 要：把空间约束**可靠注入**文本动作扩散，支持轨迹跟随/避障。
+
+---
+
+## 🔧 方法详解
+
+### 1. 特征投影（空间-姿态一致性）
+**特征投影方案**操纵动作表示，让**空间信息**与**局部姿态**更一致，便于约束生效。
+
+### 2. 插补公式（遵循全局轨迹）
+新的**插补公式**让生成动作可靠**遵循全局运动轨迹**等空间约束。
+
+### 3. 稠密引导（救稀疏约束）
+**稠密引导**把**稀疏关键帧**等易被忽略的信号转成**更密**的引导信号，确保被遵循。
+
+### 4. 结果
+文本动作生成**显著超 SOTA**，并支持**轨迹跟随、避障**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    TXT["📝 文本"] --> GMD
+    SP["📐 空间约束(轨迹/障碍/稀疏关键帧)"] --> GMD
+    subgraph GMD["GMD 引导扩散"]
+        FP["特征投影(空间-姿态一致)"]
+        IMP["插补公式(遵循轨迹)"]
+        DG["稠密引导(稀疏→密)"]
+    end
+    GMD --> OUT["🕺 可控动作<br/>文本超 SOTA + 轨迹跟随/避障"]
+
+    style GMD fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **GMD 空间约束注入**：把轨迹/障碍纳入文本动作扩散；
+2. **特征投影**：增强空间信息与局部姿态一致性；
+3. **插补公式 + 稠密引导**：可靠遵循约束、救稀疏信号；
+4. **超 SOTA + 空间可控**：轨迹跟随与避障。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **空间约束注入**是把"环境/轨迹"接进生成式动作的关键，与人形导航/避障相关；
+- **稠密引导救稀疏约束**是通用技巧，可借鉴到稀疏关键帧/目标控制；
+- **特征投影增强一致性**有助于约束真正生效；
+- 可控动作生成是人形"目标驱动动作"的上游方法。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2305.12577](https://arxiv.org/abs/2305.12577) | 论文正文（特征投影、插补、稠密引导、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·可控/物理动作扩散**：[Flexible Motion In-betweening](../Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.md) · [PhysDiff（物理引导扩散）](../PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model.md)。

--- a/papers/14_Human_Motion/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control.md
+++ b/papers/14_Human_Motion/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control/Implicit_Bezier_Motion_Model_for_Precise_Spatial_and_Temporal_Control.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "Implicit Bézier Motion Model for Precise Spatial and Temporal Control"
+zhname: "隐式贝塞尔运动模型：精确的空间与时间控制"
+category: "Human Motion"
+---
+
+# Implicit Bézier Motion Model for Precise Spatial and Temporal Control
+**针对此前贝塞尔运动模型（BMM）只能在均匀时间间隔预测固定控制点、艺术家无法做细粒度时间控制的局限，IBMM 在训练中隐式学习贝塞尔拟合、允许任意时间控制点、彻底取消「步幅（stride）」概念，使艺术家可在任意帧约束任意末端关节，并新增对运动全局缓入/缓出（ease-in/out）的直接全局时间控制——首个在生成自然运动时无需人工标注即可全局控时的方法（SIGGRAPH MIG 2025, Disney）**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 贝塞尔运动模型 · 时空控制 · 隐式拟合 · 全局缓入缓出 · SIGGRAPH MIG 2025
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 12 月（SIGGRAPH MIG 2025） |
+| 发表 | [Disney Research Studios 项目页](https://studios.disneyresearch.com/2025/12/03/implicit-bezier-motion-model-for-precise-spatial-and-temporal-control/) · [ACM DL](https://dl.acm.org/doi/10.1145/3769047.3769052) |
+| 作者 | Disney Research Studios（详见项目页） |
+| 主题 | cs.GR · 角色动画 / 运动模型 / 时空控制 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块（上游未给 arXiv 链接，发表于 SIGGRAPH MIG 2025）。
+
+---
+
+## 🎯 一句话总结
+
+> **隐式贝塞尔运动模型（Implicit Bézier Motion Model, IBMM）**提供对生成运动的**细粒度空间与时间控制**。它针对此前**贝塞尔运动模型（BMM）**的关键局限——BMM 只能在**均匀时间间隔**预测**一组固定控制点**，使艺术家**无法做细粒度时间控制**（如在时间上移动控制点、或在需要更多细节的区域增加控制点）。IBMM 在**训练时隐式学习贝塞尔拟合**，支持**任意时间控制点**，**无需对数据预先拟合**，并**彻底取消「步幅（stride）」概念**，使艺术家可在**任意帧**约束**任意末端关节**。此外，IBMM 还为用户引入一项**新的全局控制**：对运动**全局缓入/缓出（ease-in/out）**的**直接手柄**——这是**首个**在**生成自然运动**时**无需人工标注**即可**全局控制时间**的方法。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| IBMM | Implicit Bézier Motion Model |
+| BMM | （前作）Bézier Motion Model |
+| Control Point | 贝塞尔控制点 |
+| Stride | 步幅（固定时间间隔，本文取消） |
+| Ease-in/out | 缓入/缓出（全局时间控制） |
+| End-effector | 末端关节 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+前作 **BMM** 的时间控制太僵：
+- 只在**均匀间隔**预测**固定控制点**；
+- 艺术家**无法**在时间上移动/增加控制点；
+- 缺**全局时间（缓入/缓出）**控制。
+
+IBMM 要：**任意时间控制点**、**任意帧约束任意末端**、且可**全局控时**，无需人工标注。
+
+---
+
+## 🔧 方法详解
+
+### 1. 隐式贝塞尔拟合（取消步幅）
+训练中**隐式学习贝塞尔拟合**，支持**任意时间控制点**，**无需预拟合数据**，并**彻底取消步幅**概念。
+
+### 2. 任意帧约束任意末端
+艺术家可在**任意帧**约束**任意末端关节**，实现细粒度**空间**控制。
+
+### 3. 全局缓入/缓出控制
+新增**全局 ease-in/out 直接手柄**——首个在生成自然运动时**无需人工标注**即可**全局控时**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    USER["🎨 艺术家约束<br/>任意帧 · 任意末端 · 任意时间控制点"] --> IBMM
+    subgraph IBMM["IBMM(隐式贝塞尔)"]
+        F["训练时隐式拟合(取消步幅)"]
+        G["全局缓入/缓出手柄"]
+    end
+    IBMM --> OUT["🕺 精确时空可控的自然运动<br/>(SIGGRAPH MIG 2025)"]
+
+    style IBMM fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **隐式贝塞尔拟合**：任意时间控制点、无需预拟合、取消步幅；
+2. **任意帧约束任意末端**：细粒度空间控制；
+3. **全局缓入/缓出控制**：首个无需人工标注的全局控时；
+4. **面向艺术家工作流**：精确时空控制的自然运动生成。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"任意帧约束任意末端 + 全局控时"是强可控运动表示**，对人形动作编辑/关键帧规划有借鉴；
+- **隐式拟合取消步幅**比固定时间网格更灵活，可迁移到机器人轨迹参数化；
+- **全局缓入/缓出**对应运动的加减速塑形，与人形动作自然性相关；
+- 贝塞尔等紧凑参数化适合作机器人参考轨迹的可控表示。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [Disney Research 项目页](https://studios.disneyresearch.com/2025/12/03/implicit-bezier-motion-model-for-precise-spatial-and-temporal-control/) | 概述、视频、方法说明 |
+| [ACM DL](https://dl.acm.org/doi/10.1145/3769047.3769052) | SIGGRAPH MIG 2025 论文 |
+
+> ℹ️ 备注：本论文发表于 SIGGRAPH MIG 2025（Disney Research），**上游与公开页面未提供 arXiv**；本笔记依据项目页/公开摘要整理，**细节以正式论文为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·可控动作生成**：[Flexible Motion In-betweening（关键帧约束）](../Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.md) · [Guided Motion Diffusion](../Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md)。

--- a/papers/14_Human_Motion/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation.md
+++ b/papers/14_Human_Motion/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation/MANIKIN__Biomechanically_Accurate_Neural_Inverse_Kinematics_for_Human_Motion_Estimation.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "MANIKIN: Biomechanically Accurate Neural Inverse Kinematics for Human Motion Estimation"
+zhname: "MANIKIN：生物力学精确的神经逆运动学用于人体动作估计"
+category: "Human Motion"
+---
+
+# MANIKIN: Biomechanically Accurate Neural Inverse Kinematics for Human Motion Estimation
+**面向混合现实「仅用头与手末端位姿估全身关节」的逆运动学问题，已有方法沿运动链累积误差、致末端不对齐、手位偏差或脚穿地；MANIKIN 是一个神经-解析式 IK 求解器，给常用 SMPL 参数模型嵌入解剖学约束、缩减特定参数自由度以贴近人体生物力学，并基于摆转角（swivel angle）预测，使输出完美匹配输入末端位姿、避免穿地，在快速推理下超越 SOTA（ECCV 2024）**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 神经逆运动学 · 生物力学约束 · 摆转角 · 末端对齐 · 混合现实 · ECCV 2024
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年（ECCV 2024） |
+| 发表 | [项目页 siplab.org/projects/MANIKIN](https://siplab.org/projects/MANIKIN) · [ECCV 2024 PDF](https://www.ecva.net/papers/eccv_2024/papers_ECCV/papers/00194.pdf) |
+| 作者 | ETH Zürich SIPLAB（详见项目页） |
+| 主题 | cs.CV · 神经逆运动学 / 全身动作估计 / 混合现实 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块（上游未给 arXiv 链接，发表于 ECCV 2024）。
+
+---
+
+## 🎯 一句话总结
+
+> 混合现实（MR）系统常需**仅从末端（主要是头与手）位姿**估计用户**全身关节配置**——即从**稀疏观测**解**逆运动学（IK）**得全身骨架。但现有方法沿**运动链累积误差**，导致**预测末端与输入位姿不对齐**（手位偏差、脚**穿地**等）。MANIKIN 是一个**神经-解析（neural-analytic）IK 求解器**，仅用**头与手位姿**即可跟踪全身动作。其关键是：精炼常用的 **SMPL 参数模型**，**嵌入解剖学约束**、**缩减特定参数的自由度**以更贴近**人体生物力学**，确保**物理可信**的姿态预测；并**基于摆转角（swivel angle）预测**，使输出**完美匹配输入末端位姿**、同时**避免地面穿插**。方法在**快速推理**下，于定量与定性上**超越 SOTA**（ECCV 2024）。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| MANIKIN | 本文神经-解析 IK 求解器 |
+| IK | Inverse Kinematics，逆运动学 |
+| Neural-analytic | 神经 + 解析结合 |
+| SMPL | 参数化人体模型 |
+| Swivel Angle | 摆转角（肘/膝绕轴自由度） |
+| MR | Mixed Reality，混合现实 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+从**头 + 手稀疏末端**解全身 IK 难：
+- 沿**运动链累积误差** → 末端**不对齐**（手偏、脚穿地）；
+- 纯神经预测**未必物理可信**；
+- MR 需**快速**。
+
+MANIKIN 要：**精确对齐输入末端**、**物理/生物力学可信**、且**快**的全身 IK。
+
+---
+
+## 🔧 方法详解
+
+### 1. 生物力学约束的 SMPL
+精炼 **SMPL**：**嵌入解剖学约束**、**缩减特定参数自由度**，使预测姿态贴近**人体生物力学**、物理可信。
+
+### 2. 基于摆转角的神经-解析 IK
+**基于摆转角预测**的神经-解析求解，使输出**完美匹配输入末端位姿**，并**避免地面穿插**——解决"累积误差致末端不对齐"。
+
+### 3. 结果
+**快速推理**下，定量与定性**超越 SOTA**（ECCV 2024）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    IN["🎮 头 + 手末端位姿(稀疏)"] --> MAN
+    subgraph MAN["MANIKIN 神经-解析 IK"]
+        B["生物力学约束 SMPL(减自由度)"]
+        SW["摆转角预测(末端完美匹配)"]
+    end
+    MAN --> OUT["🧍 物理可信全身姿态<br/>对齐末端 + 不穿地 · 快 · 超 SOTA (ECCV 2024)"]
+
+    style MAN fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **神经-解析 IK**：从头+手稀疏末端解全身；
+2. **生物力学约束 SMPL**：嵌入解剖约束、减自由度、物理可信；
+3. **摆转角预测**：完美匹配输入末端、避免穿地；
+4. **快且超 SOTA**：ECCV 2024。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"神经预测 + 解析 IK + 生物力学约束"是稀疏末端解全身的稳健配方**，对人形从末端目标解全身姿势有借鉴；
+- **避免脚穿地/末端对齐**正是人形动作重定向/跟踪的常见诉求（呼应 PhysDiff、DynaRetarget）；
+- **缩减自由度的解剖约束**提升可行性，可迁移到机器人 IK；
+- 稀疏末端驱动全身对人形遥操作有价值。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [项目页 siplab.org/projects/MANIKIN](https://siplab.org/projects/MANIKIN) | 概述、视频、方法 |
+| [ECCV 2024 PDF](https://www.ecva.net/papers/eccv_2024/papers_ECCV/papers/00194.pdf) | 正式论文 |
+
+> ℹ️ 备注：本论文发表于 ECCV 2024（ETH SIPLAB），**上游与公开页面未提供 arXiv**；本笔记依据项目页/公开摘要整理，**细节以正式论文为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·稀疏末端/IK 全身**：[AvatarPoser](../AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md) · [EgoPoser](../EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md)。

--- a/papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md
+++ b/papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects/PICO__Reconstructing_3D_People_In_Contact_with_Objects.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "PICO: Reconstructing 3D People In Contact with Objects"
+zhname: "PICO：重建与物体接触的 3D 人体"
+category: "Human Motion"
+arxiv: "2504.17695"
+---
+
+# PICO: Reconstructing 3D People In Contact with Objects
+**从单张彩色图重建 3D 人-物交互（HOI）难在深度歧义、遮挡与物体多样；PICO 两条腿走路：① 构建 PICO-db——自然图像配对身体与物体网格上的稠密 3D 接触（借视觉基础模型检索 3D 物体网格，再用每补丁仅 2 次点击把身体接触投影到物体）；② 用 PICO-fit 渲染-比较拟合，依接触迭代拟合 SMPL-X 身体与物体网格，泛化到许多以往方法无法处理的物体类别**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 人-物交互 · 单图重建 · 接触标注 · SMPL-X · 渲染-比较
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 4 月 |
+| arXiv | [2504.17695](https://arxiv.org/abs/2504.17695) · [PDF](https://arxiv.org/pdf/2504.17695) · [HTML](https://arxiv.org/html/2504.17695v1) |
+| 作者 | Alpár Cseke、Shashank Tripathi、Sai Kumar Dwivedi、Michael J. Black、Dimitrios Tzionas（MPI / 图宾根等） |
+| 主题 | cs.CV · 人-物交互 / 单图 3D 重建 / 接触 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 从**单张彩色图**恢复 **3D 人-物交互（HOI）**很难：**深度歧义、遮挡、物体形状外观差异巨大**。以往工作需**受控设置**（已知物体形状/接触）且只处理有限物体类。PICO 想**泛化到自然图像与新物体类**，用两条思路：① 构建 **PICO-db** ——自然图像，**唯一地**配对**身体与物体网格上的稠密 3D 接触**：借**视觉基础模型**从数据库**检索合适 3D 物体网格**，再用一种**每补丁仅 2 次点击**的新方法把（DAMON 的）身体接触补丁**投影到物体**，以最小人工建立丰富的身-物接触对应；② 用 **PICO-fit** ——一种**渲染-比较（render-and-compare）拟合**方法，为 SMPL-X 身体推断接触、从 PICO-db 检索可能的 3D 物体网格与接触，并据接触**迭代拟合**身体与物体网格到图像证据。PICO 对**许多现有方法无法处理的物体类别**都работает（泛化好）。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| HOI | Human-Object Interaction，人-物交互 |
+| PICO-db | 本文接触标注数据集 |
+| PICO-fit | 渲染-比较拟合方法 |
+| SMPL-X | 参数化人体模型 |
+| Render-and-compare | 渲染-比较优化 |
+| Contact Correspondence | 身-物接触对应 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+单图 3D 人-物交互重建难：
+- **深度歧义、遮挡、物体多样**；
+- 以往需**已知物体/接触**、只限少数类；
+- 缺**身-物双侧接触**标注。
+
+PICO 要：泛化到**自然图像 + 新物体类**的 3D HOI 重建。
+
+---
+
+## 🔧 方法详解
+
+### 1. PICO-db：身-物双侧稠密接触数据
+借**视觉基础模型**检索 3D 物体网格，用**每补丁 2 次点击**把身体接触投影到物体，得到**身体 + 物体双侧**的稠密 3D 接触对应。
+
+### 2. PICO-fit：渲染-比较拟合
+为 SMPL-X 推断接触、检索物体网格与接触，依**接触**迭代**渲染-比较**拟合身体与物体网格到图像证据。
+
+### 3. 泛化
+对**许多以往方法无法处理的物体类**都有效，无需预知物体几何/接触。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    IMG["🖼️ 单张彩色图"] --> FIT
+    DB["PICO-db<br/>(身-物双侧接触, VFM 检索+2点击)"] --> FIT
+    subgraph FIT["PICO-fit 渲染-比较"]
+        F["依接触迭代拟合 SMPL-X + 物体网格"]
+    end
+    FIT --> OUT["🧍📦 3D 人-物交互<br/>泛化到新物体类"]
+
+    style FIT fill:#e8f4fd,stroke:#1f78b4,color:#0b3954
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **PICO-db**：自然图像 + 身-物双侧稠密 3D 接触（VFM 检索 + 2 点击投影）；
+2. **PICO-fit**：基于接触的渲染-比较拟合；
+3. **泛化新物体类**：无需预知物体几何/接触；
+4. **大规模 HOI 理解**：从单图恢复交互。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **接触是人-物交互的核心线索**，呼应本仓多篇"接触为中心"的人形交互/操作工作；
+- **身-物双侧接触标注**对学习抓取/操作的接触先验有价值；
+- **VFM 检索 + 最小人工标注**是低成本造数据的范式；
+- 人-物交互重建可为人形操作提供目标/接触监督。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2504.17695](https://arxiv.org/abs/2504.17695) | 论文正文（PICO-db、PICO-fit、实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·人体/交互重建**：[ClimbingCap（攀岩动捕）](../ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.md)；
+- **接触为中心（本仓 04）**：[从人-人示范学人-人形交互（PAIR）](../../04_Loco-Manipulation_and_WBC/Learning_Whole-Body_Human-Humanoid_Interaction_from_Human-Human_Demonstrations/Learning_Whole-Body_Human-Humanoid_Interaction_from_Human-Human_Demonstrations.md)。

--- a/papers/14_Human_Motion/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.md
+++ b/papers/14_Human_Motion/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "PRIMAL: Physically Reactive and Interactive Motor Model for Avatar Learning"
+zhname: "PRIMAL：可物理反应与交互的化身运动模型"
+category: "Human Motion"
+arxiv: "2503.17544"
+---
+
+# PRIMAL: Physically Reactive and Interactive Motor Model for Avatar Learning
+**把交互式化身的「运动系统」建成一个生成式动作模型，实现持续、逼真、可控、可响应的 3D 运动：采用基础模型式两阶段训练——先在无监督的亚秒级动作片段上预训练，再用类 ControlNet 微调做个性化动作与空间目标到达；从单帧出发即可生成无界限逼真动作，同时实时响应外部冲量，并接入 Unreal Engine 做角色动画**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 化身运动 · 生成式动作 · 两阶段训练 · ControlNet 微调 · 实时响应
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2025 年 3 月 |
+| arXiv | [2503.17544](https://arxiv.org/abs/2503.17544) · [PDF](https://arxiv.org/pdf/2503.17544) · [HTML](https://arxiv.org/html/2503.17544v1) |
+| 作者 | Yan Zhang、Yao Feng、Alpár Cseke、Nitin Saini、Nathan Bajandas、Michael J. Black（Meshcapade / MPI） |
+| 主题 | cs.CV · 化身运动 / 生成式动作 / 实时交互 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 把**交互式化身**的**运动系统（motor system）**建成一个**生成式动作模型**，实现**持续（perpetual）、逼真、可控、可响应**的 3D 运动。沿**基础模型范式**，PRIMAL 用**两阶段训练**：先在**无监督的亚秒级动作片段**上**预训练**，再用**类 ControlNet 微调**做**个性化动作**与**空间目标到达**。从**单帧**出发即可生成**无界限的逼真动作**，同时**实时响应外部冲量（impulses）**。并集成 **Unreal Engine** 做角色动画。实验中**优于 SOTA 基线**，支持**少样本个性化动作生成**与**目标到达**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| PRIMAL | 本文化身运动模型 |
+| Motor Model | 运动系统的生成式模型 |
+| Perpetual | 持续/无界限地生成 |
+| ControlNet-like | 类 ControlNet 的条件微调 |
+| Impulse | 外部冲量（实时响应） |
+| Few-shot | 少样本个性化 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+交互式化身需要**持续、逼真、可控、可响应**的运动：
+- 单纯回放/生成难**实时响应物理冲量**；
+- 难**个性化**且**到达空间目标**。
+
+PRIMAL 要：一个**生成式运动模型**，从单帧持续生成、实时响应冲量、可个性化与目标到达。
+
+---
+
+## 🔧 方法详解
+
+### 1. 两阶段训练（基础模型范式）
+- **预训练**：在**无监督亚秒级动作片段**上学通用运动先验；
+- **微调**：**类 ControlNet** 条件微调，做**个性化动作**与**空间目标到达**。
+
+### 2. 持续生成 + 实时响应冲量
+从**单帧**起持续生成**无界限逼真动作**，并**实时响应外部冲量**（被推时自然反应）。
+
+### 3. 引擎集成 + 结果
+集成 **Unreal Engine** 做角色动画；优于 SOTA，支持少样本个性化与目标到达。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    PRE["①无监督亚秒动作片段预训练"] --> FT["②类 ControlNet 微调<br/>(个性化 + 目标到达)"]
+    SEED["单帧起点"] --> GEN
+    IMP["⚡ 外部冲量"] --> GEN
+    FT --> GEN["持续生成(实时响应)"]
+    GEN --> OUT["🕺 无界限逼真动作<br/>Unreal Engine · 优于 SOTA"]
+
+    style GEN fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **生成式运动系统 PRIMAL**：持续、逼真、可控、可响应；
+2. **两阶段训练**：无监督预训练 + 类 ControlNet 微调；
+3. **实时响应冲量 + 单帧续写**：自然交互；
+4. **少样本个性化 + 目标到达 + 引擎集成**。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"持续生成 + 实时响应冲量"与人形抗扰恢复目标一致**，呼应 Heracles 等"扰动下自然恢复"；
+- **基础模型式两阶段（预训练 + ControlNet 微调）**是动作生成的通用范式；
+- **从单帧续写**对在线控制友好；
+- 角色动画的生成式运动经验可迁移到人形（本仓 13 物理动画方向）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2503.17544](https://arxiv.org/abs/2503.17544) | 论文正文（两阶段训练、ControlNet 微调、实时响应） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **相关·生成 + 实时响应（本仓 04）**：[Heracles（状态条件扩散中间件）](../../04_Loco-Manipulation_and_WBC/Heracles__Bridging_Precise_Tracking_and_Generative_Synthesis_for_General_Humanoid_Control/Heracles__Bridging_Precise_Tracking_and_Generative_Synthesis_for_General_Humanoid_Control.md)；
+- **同模块·动作合成**：[Guided Motion Diffusion](../Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md)。

--- a/papers/14_Human_Motion/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model.md
+++ b/papers/14_Human_Motion/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model.md
@@ -1,0 +1,124 @@
+---
+layout: paper
+title: "PhysDiff: Physics-Guided Human Motion Diffusion Model"
+zhname: "PhysDiff：物理引导的人体动作扩散模型"
+category: "Human Motion"
+arxiv: "2212.02500"
+---
+
+# PhysDiff: Physics-Guided Human Motion Diffusion Model
+**现有动作扩散模型忽视物理定律，常生成漂浮、脚滑、地面穿插等明显伪影；PhysDiff 把物理约束注入扩散去噪过程——用一个「物理引导的动作投影」模块，在去噪步中借物理仿真器里的动作模仿，把扩散出的动作投影成物理可行的动作，再引导下一步去噪，从而生成物理可信的高质量动作，大幅减少伪影（ICCV 2023 Oral）**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 物理引导 · 动作扩散 · 物理投影 · 减伪影 · ICCV 2023
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2022 年 12 月 |
+| arXiv | [2212.02500](https://arxiv.org/abs/2212.02500) · [PDF](https://arxiv.org/pdf/2212.02500) · [HTML](https://arxiv.org/html/2212.02500v1) |
+| 会议 | ICCV 2023（Oral） |
+| 作者 | Ye Yuan、Jiaman Li、Yang Zou、Xiaolong Wang、Umar Iqbal、Sifei Liu、Jan Kautz（NVIDIA / Stanford） |
+| 主题 | cs.CV · 人体动作扩散 / 物理可行性 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 去噪扩散模型在人体动作生成上效果很好，但**现有动作扩散模型忽视物理定律**，常生成带明显**伪影**的动作——**漂浮（floating）、脚滑（foot sliding/skating）、地面穿插（ground penetration）**等。PhysDiff 把**物理约束注入扩散过程**：提出一个**物理引导的动作投影（physics-guided motion projection）**模块——在扩散的**去噪步**中，借**物理仿真器**里的**动作模仿（motion imitation）**，把当前**扩散出的（含噪）动作投影成一个物理可行的动作**，再用它**引导下一步去噪**。如此生成的动作**物理可信**、自然，**大幅减少**上述伪影，在大规模人体动作数据集上取得**SOTA 的动作质量与物理可信度**。ICCV 2023 Oral。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| PhysDiff | 物理引导的动作扩散模型 |
+| Motion Projection | 物理引导动作投影 |
+| Motion Imitation | 物理仿真器里的动作模仿 |
+| Floating / Foot Sliding | 漂浮 / 脚滑（被消除的伪影） |
+| Ground Penetration | 地面穿插 |
+| Denoising Step | 扩散去噪步 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+动作扩散模型**不懂物理**：
+- 生成动作有**漂浮、脚滑、穿地**等伪影；
+- 纯数据驱动**无物理约束**，难保证可信。
+
+PhysDiff 要：把**物理**注入扩散，生成**物理可信、少伪影**的动作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 物理引导动作投影（核心）
+在扩散的某些**去噪步**插入一个**物理投影**：用**物理仿真器**里的**动作模仿策略**，把当前**含噪/扩散动作**"跑"成一个**物理可行**的动作（满足接触、重力、无穿插）。
+
+### 2. 用投影结果引导下一步去噪
+把**物理可行的投影动作**作为**引导**，回灌到扩散的**下一步去噪**——让生成过程"被物理拉回"可行流形。
+
+### 3. 结果
+生成动作**物理可信**、伪影大减（漂浮/脚滑/穿地），在大规模动作数据集上**动作质量 + 物理可信度 SOTA**。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    NOISE["扩散含噪动作"] --> PROJ
+    subgraph PROJ["物理引导动作投影"]
+        SIM["物理仿真器 + 动作模仿<br/>→ 物理可行动作"]
+    end
+    PROJ -->|引导下一步去噪| DEN["去噪步"]
+    DEN --> OUT["🕺 物理可信动作<br/>去漂浮/脚滑/穿地 (ICCV 2023)"]
+
+    style PROJ fill:#eef7ee,stroke:#27ae60,color:#0f3d1e
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **把物理注入动作扩散**：物理引导动作投影模块；
+2. **去噪步内物理投影 + 引导**：用仿真器动作模仿拉回可行流形；
+3. **大减伪影**：漂浮/脚滑/穿地；
+4. **SOTA 物理可信度**：大规模动作数据集（ICCV 2023 Oral）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"生成 + 物理投影"是把生成动作变可执行的关键范式**，与 SafeFlow（物理引导整流流）、Heracles 等"物理可执行生成"一脉相承；
+- **用物理仿真器的动作模仿做投影**，直接把"可被机器人执行"注入生成；
+- 去脚滑/穿地正是人形动作重定向/跟踪要解决的；
+- 物理可信动作可作人形参考运动，减少 sim-to-real 风险。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2212.02500](https://arxiv.org/abs/2212.02500) | 论文正文（物理投影、扩散引导、实验） |
+
+> ℹ️ 备注：本笔记依据该论文公开摘要与已知信息整理（本轮 arXiv 抓取受限）；**逐项数值与细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **相关·物理可执行生成（本仓 04）**：[SafeFlow（物理引导整流流）](../../04_Loco-Manipulation_and_WBC/SafeFlow__Real-Time_Text-Driven_Humanoid_Whole-Body_Control_via_Physics-Guided_Rectified_Flow/SafeFlow__Real-Time_Text-Driven_Humanoid_Whole-Body_Control_via_Physics-Guided_Rectified_Flow.md) · [Heracles](../../04_Loco-Manipulation_and_WBC/Heracles__Bridging_Precise_Tracking_and_Generative_Synthesis_for_General_Humanoid_Control/Heracles__Bridging_Precise_Tracking_and_Generative_Synthesis_for_General_Humanoid_Control.md)；
+- **同模块·动作扩散**：[Guided Motion Diffusion](../Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md)。

--- a/papers/14_Human_Motion/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.md
+++ b/papers/14_Human_Motion/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.md
@@ -1,0 +1,123 @@
+---
+layout: paper
+title: "Scaling Large Motion Models with Million-Level Human Motions"
+zhname: "用百万级人类动作扩展大型动作模型"
+category: "Human Motion"
+arxiv: "2410.03311"
+---
+
+# Scaling Large Motion Models with Million-Level Human Motions
+**构建首个百万级动作生成数据集 MotionLib（至少比现有大 15 倍、配分层文本描述），训练一个在多样人类活动上表现强的大型动作模型，强调数据与模型规模一起放大；并提出 Motionbook 动作编码——一种紧凑无损动作表示与新颖的「2D 无查找」token 化，在保留细粒度细节的同时扩大码本容量**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 大型动作模型 · 百万级数据 · 分层文本 · 无查找 token 化 · 规模化
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 10 月 |
+| arXiv | [2410.03311](https://arxiv.org/abs/2410.03311) · [PDF](https://arxiv.org/pdf/2410.03311) · [HTML](https://arxiv.org/html/2410.03311v1) |
+| 作者 | Ye Wang、Sipeng Zheng、Bin Cao、Qianshan Wei、Qin Jin、Zongqing Lu（BAAI / 人大等） |
+| 主题 | cs.CV · 大型动作模型 / 数据规模化 / 动作 token 化 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文构建 **MotionLib** ——**首个百万级**动作生成数据集，**至少比现有同类大 15×**，并配**分层文本描述（hierarchical text）**。用它训练一个**大型动作模型**，在**多样人类活动**（含**未见类别**）上表现强劲，强调**数据与模型规模一起放大**的重要性。还提出 **Motionbook** 动作编码：一种**紧凑无损**的动作表示，以及一个**新颖的「2D 无查找（lookup-free）」token 化**方法——在**保留细粒度细节**的同时**扩大码本容量**。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| MotionLib | 百万级动作生成数据集 |
+| Motionbook | 本文动作编码/token 化方法 |
+| Hierarchical Text | 分层文本描述 |
+| Lookup-free Tokenizer | 无查找 token 化（2D） |
+| Codebook | 码本（量化字典） |
+| Scaling | 数据/模型规模化 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+动作生成缺**大规模数据**与**好的动作 token 化**：
+- 现有数据集**小**，难支撑大模型；
+- 传统码本 token 化在**容量与细节**间难两全。
+
+论文要：建**百万级**数据集、训**大型动作模型**、并设计**更好的动作编码**。
+
+---
+
+## 🔧 方法详解
+
+### 1. MotionLib：百万级 + 分层文本
+**首个百万级**动作数据集，**≥15× 大于现有**，配**分层文本描述**，支撑大模型与规模化研究。
+
+### 2. 大型动作模型 + 规模化
+在 MotionLib 上训练**大型动作模型**，系统考察**数据/模型规模**对性能的影响，泛化到**未见活动类别**。
+
+### 3. Motionbook：紧凑无损 + 2D 无查找 token 化
+- **紧凑无损**动作表示；
+- **2D 无查找 token 化**：保留细粒度细节、**扩大码本容量**（避免查找瓶颈）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    DATA["MotionLib<br/>百万级 + 分层文本(≥15×)"] --> M
+    subgraph M["大型动作模型"]
+        MB["Motionbook 编码<br/>(紧凑无损 + 2D 无查找 token)"]
+    end
+    M --> OUT["🕺 多样人类活动(含未见类)<br/>数据/模型规模化见效"]
+
+    style M fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **MotionLib**：首个百万级动作数据集（≥15×、分层文本）；
+2. **大型动作模型 + 规模化研究**：数据与模型一起放大；
+3. **Motionbook 编码**：紧凑无损 + 2D 无查找 token 化；
+4. **强泛化**：多样人类活动含未见类别。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"数据 + 模型一起放大"是动作生成的 scaling law**，对人形动作生成（Being-M0.5、UniAct）有指导；
+- **无查找 token 化**缓解码本容量瓶颈，是动作离散化的改进方向；
+- **分层文本**有助于细粒度可控生成；
+- 大规模动作模型可作人形"语言→动作"的上游先验。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2410.03311](https://arxiv.org/abs/2410.03311) | 论文正文（MotionLib、大模型、Motionbook、规模化实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；数值（15×）取自摘要，**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·动作生成/规模化**：[Being-M0.5（实时可控 VLMM）](../Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.md)；
+- **人形动作生成（本仓 04）**：[UniAct](../../04_Loco-Manipulation_and_WBC/UniAct__Unified_Motion_Generation_and_Action_Streaming_for_Humanoid_Robots/UniAct__Unified_Motion_Generation_and_Action_Streaming_for_Humanoid_Robots.md)。

--- a/papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.md
+++ b/papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "TEDi: Temporally-Entangled Diffusion for Long-Term Motion Synthesis"
+zhname: "TEDi：时间纠缠扩散的长时程动作合成"
+category: "Human Motion"
+arxiv: "2307.15042"
+---
+
+# TEDi: Temporally-Entangled Diffusion for Long-Term Motion Synthesis
+**把扩散「逐步加噪去噪」的渐进性从扩散时间轴搬到运动时间轴：维护一个含「越靠后越噪」姿态的运动缓冲区，每步只在时间轴上推进、扩散时间轴保持静止，让干净帧从缓冲区滑出、末端追加新噪声向量，自回归地生成任意长的动作序列，适用于角色动画的长时程合成**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 长时程合成 · 时间纠缠扩散 · 运动缓冲区 · 自回归 · 角色动画
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2023 年 7 月 |
+| arXiv | [2307.15042](https://arxiv.org/abs/2307.15042) · [PDF](https://arxiv.org/pdf/2307.15042) · [HTML](https://arxiv.org/html/2307.15042v1) |
+| 作者 | Zihan Zhang、Richard Liu、Kfir Aberman、Rana Hanocka（芝加哥大学 / Google） |
+| 主题 | cs.GR · 长时程动作合成 / 扩散模型 / 角色动画 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> **去噪扩散概率模型（DDPM）**逐步、小增量地合成样本——这种**渐进性**是其关键。TEDi 把这种渐进性**应用到运动序列**，并**扩展 DDPM** 以实现**随时间变化的去噪**，从而**把"扩散时间轴"与"运动时间轴"两条轴纠缠（entangle）**起来。具体：维护一个**运动缓冲区（motion buffer）**，里面是**越靠后越噪**的姿态序列，对其**迭代去噪**，**自回归**地生成**任意长**的帧序列。**每个扩散步只推进运动时间轴**、而**扩散时间轴保持静止**，于是**干净帧从缓冲区滑出**、末端**追加新噪声向量**，实现**长时程动作合成**，适用于角色动画等。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| TEDi | Temporally-Entangled Diffusion |
+| DDPM | 去噪扩散概率模型 |
+| Motion Buffer | 运动缓冲区（越后越噪） |
+| Temporal Axis | 运动时间轴 |
+| Diffusion Time-axis | 扩散时间轴 |
+| Auto-regressive | 自回归生成 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+扩散做**长时程**动作合成难：
+- 一次性生成超长序列**代价高、不稳**；
+- 朴素自回归易**断裂/漂移**。
+
+TEDi 要：把扩散的渐进性"搬到"运动时间轴，**滑动缓冲**式地生成任意长动作。
+
+---
+
+## 🔧 方法详解
+
+### 1. 两轴纠缠：运动时间轴 × 扩散时间轴
+扩展 DDPM 实现**随时间变化的去噪**：缓冲区里**越靠后的帧越噪**，去噪程度沿时间轴渐变——把"扩散步"与"时间步"纠缠。
+
+### 2. 运动缓冲区 + 滑动生成
+- 每步**只推进运动时间轴**，扩散时间轴**静止**；
+- **干净帧从缓冲区前端滑出**（输出）；
+- **末端追加新噪声向量**（续写）。
+
+如此**自回归**生成**任意长**序列。
+
+### 3. 应用
+长时程角色动画等动作合成。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    BUF["🎞️ 运动缓冲区<br/>(越靠后越噪)"] --> DEN["逐步去噪(沿时间轴推进)"]
+    DEN --> CLEAN["干净帧从前端滑出(输出)"]
+    DEN --> APP["末端追加新噪声向量(续写)"]
+    APP --> BUF
+    CLEAN --> OUT["🕺 任意长动作序列<br/>长时程角色动画"]
+
+    style DEN fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **时间纠缠扩散 TEDi**：把渐进去噪搬到运动时间轴；
+2. **运动缓冲区 + 滑动生成**：干净帧滑出、末端续噪；
+3. **任意长自回归合成**：长时程稳定；
+4. **角色动画应用**：长时程动作合成。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **"滑动缓冲 + 时间轴去噪"是长时程生成的优雅机制**，对人形长时程动作/规划有借鉴；
+- **自回归续写**契合在线控制（边生成边执行），与 UniAct 的流式思路相通；
+- 把"扩散步"与"时间步"解耦/纠缠是值得迁移的生成范式；
+- 长时程稳定性是人形长任务的共性挑战。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2307.15042](https://arxiv.org/abs/2307.15042) | 论文正文（时间纠缠扩散、运动缓冲区、长序列实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·长时程/生成**：[PRIMAL（持续生成）](../PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.md) · [Example-based Motion Synthesis](../Example-based_Motion_Synthesis_via_Generative_Motion_Matching/Example-based_Motion_Synthesis_via_Generative_Motion_Matching.md)。

--- a/papers/14_Human_Motion/Taming_Diffusion_Probabilistic_Models_for_Character_Control/Taming_Diffusion_Probabilistic_Models_for_Character_Control.md
+++ b/papers/14_Human_Motion/Taming_Diffusion_Probabilistic_Models_for_Character_Control/Taming_Diffusion_Probabilistic_Models_for_Character_Control.md
@@ -1,0 +1,125 @@
+---
+layout: paper
+title: "Taming Diffusion Probabilistic Models for Character Control"
+zhname: "驯服扩散概率模型以实现角色控制"
+category: "Human Motion"
+arxiv: "2404.15121"
+---
+
+# Taming Diffusion Probabilistic Models for Character Control
+**一个能实时响应多样动态用户控制信号、生成高质量多样角色动画的新框架：核心是基于 Transformer 的「条件自回归动作扩散模型 CAMDM」，依据历史动作与粗粒度用户控制生成可能的未来动作；配合条件单独 token 化、对历史动作的无分类器引导、启发式未来轨迹外延来保实时；单一统一模型支持多种动画风格与多样行走技能，SIGGRAPH 2024**
+
+> 📅 阅读日期: 2026-06-21
+>
+> 🏷️ 板块: 14 Human Motion · 角色控制 · 自回归扩散 CAMDM · 实时 · 无分类器引导 · SIGGRAPH 2024
+>
+> 🔁 推进轨: 模块轮转补全（与上游 awesome-humanoid-robot-learning 对齐）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| 时间 | 2024 年 4 月 |
+| arXiv | [2404.15121](https://arxiv.org/abs/2404.15121) · [PDF](https://arxiv.org/pdf/2404.15121) · [HTML](https://arxiv.org/html/2404.15121v1) |
+| 会议 | SIGGRAPH 2024 |
+| 作者 | Rui Chen、Mingyi Shi、Shaoli Huang、Ping Tan、Taku Komura、Xuelin Chen |
+| 主题 | cs.GR · 角色控制 / 动作扩散 / 实时交互 |
+
+> 来源：YanjieZe/awesome-humanoid-robot-learning · Human Motion 模块。
+
+---
+
+## 🎯 一句话总结
+
+> 本文提出一个新颖的**角色控制框架**，有效利用**动作扩散概率模型**生成**高质量、多样**的角色动画，并**实时响应**各种**动态用户控制信号**。系统核心是一个基于 **Transformer** 的**条件自回归动作扩散模型（Conditional Autoregressive Motion Diffusion Model, CAMDM）**，依据**历史动作**与**粗粒度用户控制**生成**可能的未来动作**。为实现高质量实时控制，框架用三招：**条件单独 token 化**、对**历史动作的无分类器引导（classifier-free guidance）**、以及**启发式未来轨迹外延**（提升计算效率）。这是**首个**支持**基于用户交互控制实时生成高质量多样角色动画**的模型，**单一统一模型**支持**多种动画风格**与多样**行走技能**。SIGGRAPH 2024。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 含义 |
+|---|---|
+| CAMDM | 条件自回归动作扩散模型 |
+| Autoregressive | 自回归，依历史生成未来 |
+| Classifier-free Guidance | 无分类器引导 |
+| Condition Tokenization | 条件单独 token 化 |
+| Real-time Control | 实时交互控制 |
+| Locomotion Skills | 行走技能 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+扩散模型质量高但**难实时交互控制**：
+- 采样慢、难响应**动态用户控制**；
+- 要**单一模型多风格**、保**多样性**。
+
+论文要：**驯服**扩散模型，实现**实时、可控、多样**的角色动画生成。
+
+---
+
+## 🔧 方法详解
+
+### 1. CAMDM：条件自回归动作扩散
+基于 **Transformer**，依**历史动作 + 粗用户控制**自回归生成**未来动作**，把扩散用于实时角色控制。
+
+### 2. 三招保质量与实时
+- **条件单独 token 化**：分别处理控制输入；
+- **对历史动作的无分类器引导**：用好历史信息、增强可控；
+- **启发式未来轨迹外延**：提升计算效率、达实时。
+
+### 3. 结果
+首个实时交互控制的高质量多样角色动画；**单一模型多风格 + 多样行走技能**（SIGGRAPH 2024）。
+
+---
+
+### 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart LR
+    HIST["历史动作"] --> CAMDM
+    CTRL["🎮 粗粒度用户控制"] --> CAMDM
+    subgraph CAMDM["CAMDM(条件自回归扩散)"]
+        T["条件 token 化 + 无分类器引导 + 轨迹外延"]
+    end
+    CAMDM --> OUT["🕹️ 实时高质量多样角色动画<br/>单一模型多风格 (SIGGRAPH 2024)"]
+
+    style CAMDM fill:#f7e8fd,stroke:#9b59b6,color:#4a1c5d
+    style OUT fill:#fde8e8,stroke:#c0392b,color:#641e16
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **CAMDM**：Transformer 条件自回归动作扩散；
+2. **实时可控**：条件 token 化 + 无分类器引导 + 轨迹外延；
+3. **首个实时交互角色动画扩散**：质量与多样兼得；
+4. **单一模型多风格 + 多样行走**（SIGGRAPH 2024）。
+
+---
+
+## 🤖 对人形机器人学习的启发
+
+- **自回归扩散 + 历史条件**让生成式模型可实时响应控制，与人形在线控制需求一致；
+- **无分类器引导用在"历史动作"上**是个巧思，可借鉴到动作跟踪；
+- **启发式轨迹外延**降算力，是把扩散压进实时的实用技巧；
+- 角色控制的实时扩散经验可迁移到人形 loco 控制（与 Heracles/SafeFlow 的生成式控制呼应）。
+
+---
+
+## 📁 资源对照
+
+| 资源 | 内容 |
+|---|---|
+| [arXiv 2404.15121](https://arxiv.org/abs/2404.15121) | 论文正文（CAMDM、三招、实时控制实验） |
+
+> ℹ️ 备注：本笔记依据 arXiv 摘要整理；**细节以原文/PDF 为准**。
+
+---
+
+## 🔗 相关阅读
+
+- **同模块·实时/可控动作生成**：[PRIMAL（实时响应化身运动）](../PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.md) · [Flexible Motion In-betweening](../Flexible_Motion_In-betweening_with_Diffusion_Models/Flexible_Motion_In-betweening_with_Diffusion_Models.md)。

--- a/progress.json
+++ b/progress.json
@@ -4470,6 +4470,106 @@
       "pdf_file": "",
       "route": "Teleoperation",
       "title_cn": ""
+    },
+    {
+      "title": "BiGym: A Demo-Driven Mobile Bi-Manual Manipulation Benchmark",
+      "folder": "papers/11_Simulation_Benchmark/BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark",
+      "note_file": "BiGym__A_Demo-Driven_Mobile_Bi-Manual_Manipulation_Benchmark.md",
+      "status": "done",
+      "arxiv": "2407.07788",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "DexMimicGen: Automated Data Generation for Bimanual Dexterous Manipulation via Imitation Learning",
+      "folder": "papers/11_Simulation_Benchmark/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation",
+      "note_file": "DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md",
+      "status": "done",
+      "arxiv": "2410.24185",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "DualTHOR: A Dual-Arm Humanoid Simulation Platform for Contingency-Aware Planning",
+      "folder": "papers/11_Simulation_Benchmark/DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning",
+      "note_file": "DualTHOR__A_Dual-Arm_Humanoid_Simulation_Platform_for_Contingency-Aware_Planning.md",
+      "status": "done",
+      "arxiv": "2506.16012",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "HumanoidGen: Data Generation for Bimanual Dexterous Manipulation via LLM Reasoning",
+      "folder": "papers/11_Simulation_Benchmark/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning",
+      "note_file": "HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md",
+      "status": "done",
+      "arxiv": "2507.00833",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "Humanoid World Models: Open World Foundation Models for Humanoid Robotics",
+      "folder": "papers/11_Simulation_Benchmark/Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics",
+      "note_file": "Humanoid_World_Models__Open_World_Foundation_Models_for_Humanoid_Robotics.md",
+      "status": "done",
+      "arxiv": "2506.01182",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "Learning with pyCub: A Simulation and Exercise Framework for Humanoid Robotics",
+      "folder": "papers/11_Simulation_Benchmark/Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics",
+      "note_file": "Learning_with_pyCub__A_Simulation_and_Exercise_Framework_for_Humanoid_Robotics.md",
+      "status": "done",
+      "arxiv": "2506.01756",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "ManiSkill-HAB: A Benchmark for Low-Level Manipulation in Home Rearrangement Tasks",
+      "folder": "papers/11_Simulation_Benchmark/ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks",
+      "note_file": "ManiSkill-HAB__A_Benchmark_for_Low-Level_Manipulation_in_Home_Rearrangement_Tasks.md",
+      "status": "done",
+      "arxiv": "2412.13211",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "Mimicking-Bench: A Benchmark for Generalizable Humanoid-Scene Interaction Learning via Human Mimicking",
+      "folder": "papers/11_Simulation_Benchmark/Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning",
+      "note_file": "Mimicking-Bench__A_Benchmark_for_Generalizable_Humanoid-Scene_Interaction_Learning.md",
+      "status": "done",
+      "arxiv": "2412.17730",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots",
+      "folder": "papers/11_Simulation_Benchmark/RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots",
+      "note_file": "RoboCasa365__A_Large-Scale_Simulation_Framework_for_Training_and_Benchmarking_Generalist_Robots.md",
+      "status": "done",
+      "arxiv": "2603.04356",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
+    },
+    {
+      "title": "RoboCasa: Large-Scale Simulation of Everyday Tasks for Generalist Robots",
+      "folder": "papers/11_Simulation_Benchmark/RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots",
+      "note_file": "RoboCasa__Large-Scale_Simulation_of_Everyday_Tasks_for_Generalist_Robots.md",
+      "status": "done",
+      "arxiv": "2406.02523",
+      "pdf_file": "",
+      "route": "Simulation Benchmark",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4570,6 +4570,66 @@
       "pdf_file": "",
       "route": "Simulation Benchmark",
       "title_cn": ""
+    },
+    {
+      "title": "A Humanoid Visual-Tactile-Action Dataset for Contact-Rich Manipulation",
+      "folder": "papers/06_Manipulation/A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation",
+      "note_file": "A_Humanoid_Visual-Tactile-Action_Dataset_for_Contact-Rich_Manipulation.md",
+      "status": "done",
+      "arxiv": "2510.25725",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Dexterity from Smart Lenses: Multi-Fingered Robot Manipulation with In-the-Wild Human Demonstrations",
+      "folder": "papers/06_Manipulation/Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos",
+      "note_file": "Dexterity_from_Smart_Lenses__Multi-Fingered_Manipulation_with_In-the-Wild_Human_Demos.md",
+      "status": "done",
+      "arxiv": "2511.16661",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "EgoMI: Learning Active Vision and Whole-Body Manipulation from Egocentric Human Demonstrations",
+      "folder": "papers/06_Manipulation/EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos",
+      "note_file": "EgoMI__Learning_Active_Vision_and_Whole-Body_Manipulation_from_Egocentric_Human_Demos.md",
+      "status": "done",
+      "arxiv": "2511.00153",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Endowing GPT-4 with a Humanoid Body: Building the Bridge Between Off-the-Shelf VLMs and the Physical World",
+      "folder": "papers/06_Manipulation/Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World",
+      "note_file": "Endowing_GPT-4_with_a_Humanoid_Body__Bridge_Between_VLMs_and_the_Physical_World.md",
+      "status": "done",
+      "arxiv": "2511.00041",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "In-N-On: Scaling Egocentric Manipulation with in-the-wild and on-task Data",
+      "folder": "papers/06_Manipulation/In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data",
+      "note_file": "In-N-On__Scaling_Egocentric_Manipulation_with_in-the-wild_and_on-task_Data.md",
+      "status": "done",
+      "arxiv": "2511.15704",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Lightning Grasp: High Performance Procedural Grasp Synthesis with Contact Fields",
+      "folder": "papers/06_Manipulation/Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields",
+      "note_file": "Lightning_Grasp__High_Performance_Procedural_Grasp_Synthesis_with_Contact_Fields.md",
+      "status": "done",
+      "arxiv": "2511.07418",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4750,6 +4750,66 @@
       "pdf_file": "",
       "route": "Manipulation",
       "title_cn": ""
+    },
+    {
+      "title": "Dexterous Safe Control for Humanoids in Cluttered Environments via Projected Safe Set Algorithm",
+      "folder": "papers/06_Manipulation/Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set",
+      "note_file": "Dexterous_Safe_Control_for_Humanoids_in_Cluttered_Environments_via_Projected_Safe_Set.md",
+      "status": "done",
+      "arxiv": "2502.02858",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "EgoDex: Learning Dexterous Manipulation from Large-Scale Egocentric Video",
+      "folder": "papers/06_Manipulation/EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video",
+      "note_file": "EgoDex__Learning_Dexterous_Manipulation_from_Large-Scale_Egocentric_Video.md",
+      "status": "done",
+      "arxiv": "2505.11709",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Humanoid Policy ~ Human Policy",
+      "folder": "papers/06_Manipulation/Humanoid_Policy__Human_Policy",
+      "note_file": "Humanoid_Policy__Human_Policy.md",
+      "status": "done",
+      "arxiv": "2503.13441",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Humanoids in Hospitals: A Technical Study of Humanoid Robot Surrogates for Dexterous Medical Interventions",
+      "folder": "papers/06_Manipulation/Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions",
+      "note_file": "Humanoids_in_Hospitals__Humanoid_Surrogates_for_Dexterous_Medical_Interventions.md",
+      "status": "done",
+      "arxiv": "2503.12725",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Sim-and-Real Co-Training: A Simple Recipe for Vision-Based Robotic Manipulation",
+      "folder": "papers/06_Manipulation/Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation",
+      "note_file": "Sim-and-Real_Co-Training__A_Simple_Recipe_for_Vision-Based_Robotic_Manipulation.md",
+      "status": "done",
+      "arxiv": "2503.24361",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Unified Video Action Model",
+      "folder": "papers/06_Manipulation/Unified_Video_Action_Model",
+      "note_file": "Unified_Video_Action_Model.md",
+      "status": "done",
+      "arxiv": "2503.00200",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4690,6 +4690,66 @@
       "pdf_file": "",
       "route": "Manipulation",
       "title_cn": ""
+    },
+    {
+      "title": "Being-H0: Vision-Language-Action Pretraining from Large-Scale Human Videos",
+      "folder": "papers/06_Manipulation/Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos",
+      "note_file": "Being-H0__Vision-Language-Action_Pretraining_from_Large-Scale_Human_Videos.md",
+      "status": "done",
+      "arxiv": "2507.15597",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "DreamGen: Unlocking Generalization in Robot Learning through Video World Models",
+      "folder": "papers/06_Manipulation/DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models",
+      "note_file": "DreamGen__Unlocking_Generalization_in_Robot_Learning_through_Video_World_Models.md",
+      "status": "done",
+      "arxiv": "2505.12705",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "H-RDT: Human Manipulation Enhanced Bimanual Robotic Manipulation",
+      "folder": "papers/06_Manipulation/H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation",
+      "note_file": "H-RDT__Human_Manipulation_Enhanced_Bimanual_Robotic_Manipulation.md",
+      "status": "done",
+      "arxiv": "2507.23523",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Hierarchical Vision-Language Planning for Multi-Step Humanoid Manipulation",
+      "folder": "papers/06_Manipulation/Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation",
+      "note_file": "Hierarchical_Vision-Language_Planning_for_Multi-Step_Humanoid_Manipulation.md",
+      "status": "done",
+      "arxiv": "2506.22827",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Robot Drummer: Learning Rhythmic Skills for Humanoid Drumming",
+      "folder": "papers/06_Manipulation/Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming",
+      "note_file": "Robot_Drummer__Learning_Rhythmic_Skills_for_Humanoid_Drumming.md",
+      "status": "done",
+      "arxiv": "2507.11498",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Vision in Action: Learning Active Perception from Human Demonstrations",
+      "folder": "papers/06_Manipulation/Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations",
+      "note_file": "Vision_in_Action__Learning_Active_Perception_from_Human_Demonstrations.md",
+      "status": "done",
+      "arxiv": "2506.15666",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4960,6 +4960,66 @@
       "pdf_file": "",
       "route": "Human Motion",
       "title_cn": ""
+    },
+    {
+      "title": "Example-based Motion Synthesis via Generative Motion Matching",
+      "folder": "papers/14_Human_Motion/Example-based_Motion_Synthesis_via_Generative_Motion_Matching",
+      "note_file": "Example-based_Motion_Synthesis_via_Generative_Motion_Matching.md",
+      "status": "done",
+      "arxiv": "2306.00378",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "Flexible Motion In-betweening with Diffusion Models",
+      "folder": "papers/14_Human_Motion/Flexible_Motion_In-betweening_with_Diffusion_Models",
+      "note_file": "Flexible_Motion_In-betweening_with_Diffusion_Models.md",
+      "status": "done",
+      "arxiv": "2405.11126",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "Guided Motion Diffusion for Controllable Human Motion Synthesis",
+      "folder": "papers/14_Human_Motion/Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis",
+      "note_file": "Guided_Motion_Diffusion_for_Controllable_Human_Motion_Synthesis.md",
+      "status": "done",
+      "arxiv": "2305.12577",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "PhysDiff: Physics-Guided Human Motion Diffusion Model",
+      "folder": "papers/14_Human_Motion/PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model",
+      "note_file": "PhysDiff__Physics-Guided_Human_Motion_Diffusion_Model.md",
+      "status": "done",
+      "arxiv": "2212.02500",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "TEDi: Temporally-Entangled Diffusion for Long-Term Motion Synthesis",
+      "folder": "papers/14_Human_Motion/TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis",
+      "note_file": "TEDi__Temporally-Entangled_Diffusion_for_Long-Term_Motion_Synthesis.md",
+      "status": "done",
+      "arxiv": "2307.15042",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "Taming Diffusion Probabilistic Models for Character Control",
+      "folder": "papers/14_Human_Motion/Taming_Diffusion_Probabilistic_Models_for_Character_Control",
+      "note_file": "Taming_Diffusion_Probabilistic_Models_for_Character_Control.md",
+      "status": "done",
+      "arxiv": "2404.15121",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4810,6 +4810,66 @@
       "pdf_file": "",
       "route": "Manipulation",
       "title_cn": ""
+    },
+    {
+      "title": "ARMADA: Augmented Reality for Robot Manipulation and Robot-Free Data Acquisition",
+      "folder": "papers/06_Manipulation/ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition",
+      "note_file": "ARMADA__Augmented_Reality_for_Robot_Manipulation_and_Robot-Free_Data_Acquisition.md",
+      "status": "done",
+      "arxiv": "2412.10631",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "DexHub and DART: Towards Internet Scale Robot Data Collection",
+      "folder": "papers/06_Manipulation/DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection",
+      "note_file": "DexHub_and_DART__Towards_Internet_Scale_Robot_Data_Collection.md",
+      "status": "done",
+      "arxiv": "2411.02214",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Learning to Look Around: Enhancing Teleoperation and Learning with a Human-like Actuated Neck",
+      "folder": "papers/06_Manipulation/Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning",
+      "note_file": "Learning_to_Look_Around__Enhancing_Teleoperation_and_Learning.md",
+      "status": "done",
+      "arxiv": "2411.00704",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Learning to Look: Seeking Information for Decision Making via Policy Factorization",
+      "folder": "papers/06_Manipulation/Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization",
+      "note_file": "Learning_to_Look__Seeking_Information_for_Decision_Making_via_Policy_Factorization.md",
+      "status": "done",
+      "arxiv": "2410.18964",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "MobileH2R: Learning Generalizable Human to Mobile Robot Handover Exclusively from Scalable and Diverse Synthetic Data",
+      "folder": "papers/06_Manipulation/MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data",
+      "note_file": "MobileH2R__Learning_Generalizable_Human_to_Mobile_Robot_Handover_from_Synthetic_Data.md",
+      "status": "done",
+      "arxiv": "2501.04595",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Object-Centric Dexterous Manipulation from Human Motion Data",
+      "folder": "papers/06_Manipulation/Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data",
+      "note_file": "Object-Centric_Dexterous_Manipulation_from_Human_Motion_Data.md",
+      "status": "done",
+      "arxiv": "2411.04005",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -1928,10 +1928,10 @@
     {
       "title": "TWIST2: Scalable, Portable, and Holistic Humanoid Data Collection System",
       "arxiv": "TWIST2: Scalable, Portable, and Holistic Humanoid Data Collection System",
-      "folder": "papers/04_Loco-Manipulation_and_WBC/TWIST2__Scalable,_Portable,_and_Holistic_Humanoid_Data_Collection_System",
-      "note_file": "TWIST2__Scalable,_Portable,_and_Holistic_Humanoid_Data_Collection_System.md",
+      "folder": "papers/07_Teleoperation/TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System",
+      "note_file": "TWIST2__Scalable_Portable_and_Holistic_Humanoid_Data_Collection_System.md",
       "pdf_file": "TWIST2.pdf",
-      "status": "pending",
+      "status": "done",
       "start_date": null,
       "done_date": null,
       "route": "Loco-Manipulation",
@@ -2636,10 +2636,10 @@
     {
       "title": "TWIST: Teleoperated Whole-Body Imitation System",
       "arxiv": "TWIST: Teleoperated Whole-Body Imitation System",
-      "folder": "papers/04_Loco-Manipulation_and_WBC/TWIST__Teleoperated_Whole-Body_Imitation_System",
+      "folder": "papers/07_Teleoperation/TWIST__Teleoperated_Whole-Body_Imitation_System",
       "note_file": "TWIST__Teleoperated_Whole-Body_Imitation_System.md",
       "pdf_file": "TWIST.pdf",
-      "status": "pending",
+      "status": "done",
       "start_date": null,
       "done_date": null,
       "route": "Loco-Manipulation",
@@ -2852,10 +2852,10 @@
     {
       "title": "Mobile-TeleVision: Predictive Motion Priors for Humanoid Whole-Body Control",
       "arxiv": "Mobile-TeleVision: Predictive Motion Priors for Humanoid Whole-Body Control",
-      "folder": "papers/04_Loco-Manipulation_and_WBC/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control",
+      "folder": "papers/07_Teleoperation/Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control",
       "note_file": "Mobile-TeleVision__Predictive_Motion_Priors_for_Humanoid_Whole-Body_Control.md",
       "pdf_file": "Mobile-TeleVision.pdf",
-      "status": "pending",
+      "status": "done",
       "start_date": null,
       "done_date": null,
       "route": "Loco-Manipulation",
@@ -4379,6 +4379,96 @@
       "arxiv": "2505.24068",
       "pdf_file": "",
       "route": "Sim-to-Real",
+      "title_cn": ""
+    },
+    {
+      "title": "ACE: A Cross-Platform Visual-Exoskeletons System for Low-Cost Dexterous Teleoperation",
+      "folder": "papers/07_Teleoperation/ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation",
+      "note_file": "ACE__A_Cross-Platform_Visual-Exoskeletons_System_for_Low-Cost_Dexterous_Teleoperation.md",
+      "status": "done",
+      "arxiv": "2408.11805",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "Bunny-VisionPro: Real-Time Bimanual Dexterous Teleoperation for Imitation Learning",
+      "folder": "papers/07_Teleoperation/Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning",
+      "note_file": "Bunny-VisionPro__Real-Time_Bimanual_Dexterous_Teleoperation_for_Imitation_Learning.md",
+      "status": "done",
+      "arxiv": "2407.03162",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "CHILD: a Whole-Body Humanoid Teleoperation System",
+      "folder": "papers/07_Teleoperation/CHILD__a_Whole-Body_Humanoid_Teleoperation_System",
+      "note_file": "CHILD__a_Whole-Body_Humanoid_Teleoperation_System.md",
+      "status": "done",
+      "arxiv": "2508.00162",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "Heavy lifting tasks via haptic teleoperation of a wheeled humanoid",
+      "folder": "papers/07_Teleoperation/Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid",
+      "note_file": "Heavy_Lifting_Tasks_via_Haptic_Teleoperation_of_a_Wheeled_Humanoid.md",
+      "status": "done",
+      "arxiv": "2505.19530",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "High-Speed and Impact Resilient Teleoperation of Humanoid Robots",
+      "folder": "papers/07_Teleoperation/High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots",
+      "note_file": "High-Speed_and_Impact_Resilient_Teleoperation_of_Humanoid_Robots.md",
+      "status": "done",
+      "arxiv": "2409.04639",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "Human-Robot Collaboration for the Remote Control of Mobile Humanoid Robots with Torso-Arm Coordination",
+      "folder": "papers/07_Teleoperation/Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots",
+      "note_file": "Human-Robot_Collaboration_for_Remote_Control_of_Mobile_Humanoid_Robots.md",
+      "status": "done",
+      "arxiv": "2505.05773",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "NuExo: A Wearable Exoskeleton Covering all Upper Limb ROM for Outdoor Data Collection and Teleoperation of Humanoid Robots",
+      "folder": "papers/07_Teleoperation/NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM",
+      "note_file": "NuExo__A_Wearable_Exoskeleton_Covering_all_Upper_Limb_ROM.md",
+      "status": "done",
+      "arxiv": "2503.10554",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "TeleOpBench: A Simulator-Centric Benchmark for Dual-Arm Dexterous Teleoperation",
+      "folder": "papers/07_Teleoperation/TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation",
+      "note_file": "TeleOpBench__A_Simulator-Centric_Benchmark_for_Dual-Arm_Dexterous_Teleoperation.md",
+      "status": "done",
+      "arxiv": "2505.12748",
+      "pdf_file": "",
+      "route": "Teleoperation",
+      "title_cn": ""
+    },
+    {
+      "title": "Whole-Body Bilateral Teleoperation with Multi-Stage Object Parameter Estimation for Wheeled Humanoid Locomanipulation",
+      "folder": "papers/07_Teleoperation/Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation",
+      "note_file": "Whole-Body_Bilateral_Teleoperation_with_Multi-Stage_Object_Parameter_Estimation.md",
+      "status": "done",
+      "arxiv": "2508.09846",
+      "pdf_file": "",
+      "route": "Teleoperation",
       "title_cn": ""
     }
   ]

--- a/progress.json
+++ b/progress.json
@@ -5020,6 +5020,36 @@
       "pdf_file": "",
       "route": "Human Motion",
       "title_cn": ""
+    },
+    {
+      "title": "AvatarPoser: Articulated Full-Body Pose Tracking from Sparse Motion Sensing",
+      "folder": "papers/14_Human_Motion/AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing",
+      "note_file": "AvatarPoser__Articulated_Full-Body_Pose_Tracking_from_Sparse_Motion_Sensing.md",
+      "status": "done",
+      "arxiv": "2207.13784",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "EgoPoser: Robust Real-Time Egocentric Pose Estimation from Sparse and Intermittent Observations Everywhere",
+      "folder": "papers/14_Human_Motion/EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors",
+      "note_file": "EgoPoser__Robust_Real-Time_Egocentric_Pose_Estimation_from_Sparse_Sensors.md",
+      "status": "done",
+      "arxiv": "2308.06493",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "Go to Zero: Towards Zero-shot Motion Generation with Million-scale Data",
+      "folder": "papers/14_Human_Motion/Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data",
+      "note_file": "Go_to_Zero__Towards_Zero-shot_Motion_Generation_with_Million-scale_Data.md",
+      "status": "done",
+      "arxiv": "2507.07095",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4870,6 +4870,36 @@
       "pdf_file": "",
       "route": "Manipulation",
       "title_cn": ""
+    },
+    {
+      "title": "A Systematic Study of Data Modalities and Strategies for Co-training Large Behavior Models for Robot Manipulation",
+      "folder": "papers/06_Manipulation/A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models",
+      "note_file": "A_Systematic_Study_of_Data_Modalities_and_Strategies_for_Co-training_Behavior_Models.md",
+      "status": "done",
+      "arxiv": "2602.01067",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Learning Visuotactile Skills with Two Multifingered Hands",
+      "folder": "papers/06_Manipulation/Learning_Visuotactile_Skills_with_Two_Multifingered_Hands",
+      "note_file": "Learning_Visuotactile_Skills_with_Two_Multifingered_Hands.md",
+      "status": "done",
+      "arxiv": "2404.16823",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "OKAMI: Teaching Humanoid Robots Manipulation Skills through Single Video Imitation",
+      "folder": "papers/06_Manipulation/OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation",
+      "note_file": "OKAMI__Teaching_Humanoid_Robots_Manipulation_Skills_through_Single_Video_Imitation.md",
+      "status": "done",
+      "arxiv": "2410.11792",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4900,6 +4900,66 @@
       "pdf_file": "",
       "route": "Manipulation",
       "title_cn": ""
+    },
+    {
+      "title": "Being-M0.5: A Real-Time Controllable Vision-Language-Motion Model",
+      "folder": "papers/14_Human_Motion/Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model",
+      "note_file": "Being-M0.5__A_Real-Time_Controllable_Vision-Language-Motion_Model.md",
+      "status": "done",
+      "arxiv": "2508.07863",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "ClimbingCap: Multi-Modal Dataset and Method for Rock Climbing in World Coordinate",
+      "folder": "papers/14_Human_Motion/ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate",
+      "note_file": "ClimbingCap__Multi-Modal_Dataset_and_Method_for_Rock_Climbing_in_World_Coordinate.md",
+      "status": "done",
+      "arxiv": "2503.21268",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "FRAME: Floor-aligned Representation for Avatar Motion from Egocentric Video",
+      "folder": "papers/14_Human_Motion/FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video",
+      "note_file": "FRAME__Floor-aligned_Representation_for_Avatar_Motion_from_Egocentric_Video.md",
+      "status": "done",
+      "arxiv": "2503.23094",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "PICO: Reconstructing 3D People In Contact with Objects",
+      "folder": "papers/14_Human_Motion/PICO__Reconstructing_3D_People_In_Contact_with_Objects",
+      "note_file": "PICO__Reconstructing_3D_People_In_Contact_with_Objects.md",
+      "status": "done",
+      "arxiv": "2504.17695",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "PRIMAL: Physically Reactive and Interactive Motor Model for Avatar Learning",
+      "folder": "papers/14_Human_Motion/PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning",
+      "note_file": "PRIMAL__Physically_Reactive_and_Interactive_Motor_Model_for_Avatar_Learning.md",
+      "status": "done",
+      "arxiv": "2503.17544",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
+    },
+    {
+      "title": "Scaling Large Motion Models with Million-Level Human Motions",
+      "folder": "papers/14_Human_Motion/Scaling_Large_Motion_Models_with_Million-Level_Human_Motions",
+      "note_file": "Scaling_Large_Motion_Models_with_Million-Level_Human_Motions.md",
+      "status": "done",
+      "arxiv": "2410.03311",
+      "pdf_file": "",
+      "route": "Human Motion",
+      "title_cn": ""
     }
   ]
 }

--- a/progress.json
+++ b/progress.json
@@ -4630,6 +4630,66 @@
       "pdf_file": "",
       "route": "Manipulation",
       "title_cn": ""
+    },
+    {
+      "title": "EgoDemoGen: Egocentric Demonstration Generation for Viewpoint Generalization in Robotic Manipulation",
+      "folder": "papers/06_Manipulation/EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization",
+      "note_file": "EgoDemoGen__Egocentric_Demonstration_Generation_for_Viewpoint_Generalization.md",
+      "status": "done",
+      "arxiv": "2509.22578",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Masquerade: Learning from In-the-wild Human Videos using Data-Editing",
+      "folder": "papers/06_Manipulation/Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing",
+      "note_file": "Masquerade__Learning_from_In-the-wild_Human_Videos_using_Data-Editing.md",
+      "status": "done",
+      "arxiv": "2508.09976",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "MimicDroid: In-Context Learning for Humanoid Robot Manipulation from Human Play Videos",
+      "folder": "papers/06_Manipulation/MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos",
+      "note_file": "MimicDroid__In-Context_Learning_for_Humanoid_Manipulation_from_Human_Play_Videos.md",
+      "status": "done",
+      "arxiv": "2509.09769",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Residual Off-Policy RL for Finetuning Behavior Cloning Policies",
+      "folder": "papers/06_Manipulation/Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies",
+      "note_file": "Residual_Off-Policy_RL_for_Finetuning_Behavior_Cloning_Policies.md",
+      "status": "done",
+      "arxiv": "2509.19301",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "TOP: Time Optimization Policy for Stable and Accurate Standing Manipulation with Humanoid Robots",
+      "folder": "papers/06_Manipulation/TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation",
+      "note_file": "TOP__Time_Optimization_Policy_for_Stable_and_Accurate_Standing_Manipulation.md",
+      "status": "done",
+      "arxiv": "2508.00355",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
+    },
+    {
+      "title": "Towards Proprioception-Aware Embodied Planning for Dual-Arm Humanoid Robots",
+      "folder": "papers/06_Manipulation/Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots",
+      "note_file": "Towards_Proprioception-Aware_Embodied_Planning_for_Dual-Arm_Humanoid_Robots.md",
+      "status": "done",
+      "arxiv": "2510.07882",
+      "pdf_file": "",
+      "route": "Manipulation",
+      "title_cn": ""
     }
   ]
 }


### PR DESCRIPTION
## 概述

接续已合并的 #317，本 PR 补全其余模块的上游缺失论文笔记。合并后，**模块 04–14 对照上游 `YanjieZe/awesome-humanoid-robot-learning` 近期覆盖区间的「holes」全部清零**。

> 经全仓审计修正：缺失论文判定改为「全仓范围」核对（而非仅对应模块），已排除实际收录于其它模块（多为 03 高影响力精选）或已归档的论文。

## 本 PR 新增笔记（74 篇）

| 模块 | 新增 | 合并后 |
|---|---:|---:|
| 06 Manipulation | +33 | 44 |
| 14 Human Motion | +18 | 26 |
| 07 Teleoperation | +12 | 21 |
| 11 Simulation/Benchmark | +10 | 18 |
| 13 Physics-Based Animation | +1 | 6 |

（#317 已合并的模块 04/05/08/10 共 35 篇不在本 PR 差异内。）

每篇笔记遵循仓库模板：front matter（`zhname`/`category`/`arxiv`）、一句话方法概述、基本信息表、缩写速查、问题与方法详解、mermaid 流程图、核心贡献、对人形机器人学习的启发、相关阅读；内容依据真实 arXiv 摘要（无预印本者依据 ECCV/SIGGRAPH/项目页，并在笔记中注明）。

## 质量校验

- 每批次后重跑 `prepare_pages.py` 与 `sync_progress.py`
- `ruff` + `pytest`（123）全绿；无 stub 告警

## 顺带修正的上游数据问题

- **误链**：「Learning Social Navigation」arXiv 链接指向他文 → 校正为 `2510.12215`
- **补链**：RoboCasa365 → `2603.04356`；TRI 协同训练系统研究 → `2602.01067`；Go to Zero → `2507.07095`；EgoPoser → `2308.06493`
- **确无 arXiv**（以 ECCV/SIGGRAPH/项目页为准，笔记已注明）：Implicit Bézier（SIGGRAPH MIG 2025）、MANIKIN（ECCV 2024）、Spatial-Relationship-Preserving（SIGGRAPH 2010）；Climber Force（arXiv 2025.04，编号待补）
- **DualTHOR** 标注其 v2 已撤稿；**ReActor / ACE / Bunny-VisionPro** 作为跨模块条目保留（已收录于 02 / 07）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vomg5Xf6NC6nn5vdTwKkHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vomg5Xf6NC6nn5vdTwKkHD)_