### PR TITLE
fix(Home): 移除人体动作模块下方的空模块

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -3185,11 +3185,5 @@
     "zhname": "人体动作分析与生成",
     "sort_order_hint": "Paper tags ordered by arXiv date, newest first",
     "sort_order_hint_zh": "论文标签按 arXiv 发表时间新→旧排列"
-  },
-  "_archived": {
-    "display_name": " archived",
-    "papers": [],
-    "sort_order_hint": "Paper tags ordered by arXiv date, newest first",
-    "sort_order_hint_zh": "论文标签按 arXiv 发表时间新→旧排列"
   }
 }

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -18,7 +18,7 @@ from collections.abc import Iterator
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PAPERS_DIR = os.path.join(BASE_DIR, "papers")
-SKIP_DIRS = {"todos"}
+SKIP_DIRS = {"todos", "_archived"}
 
 # A note is considered a stub when EITHER:
 #   1. it is short AND has no recognisable "方法" (method) section heading, OR

--- a/scripts/update_badges.py
+++ b/scripts/update_badges.py
@@ -34,7 +34,7 @@ def count_notes() -> int:
 
     # 回退：按目录结构统计论文笔记
     excluded_names = {"PROGRESS.md"}
-    excluded_dirs = {"todos"}
+    excluded_dirs = {"todos", "_archived"}
     return sum(
         1
         for f in PAPERS_DIR.rglob("*.md")

--- a/tests/test_prepare_pages_golden.py
+++ b/tests/test_prepare_pages_golden.py
@@ -50,6 +50,11 @@ def _build_fixture_repo(root: Path) -> None:
     (papers / "todos").mkdir(parents=True)
     (papers / "todos" / "TODO_v1.md").write_text("ignored", encoding="utf-8")
 
+    (papers / "_archived" / "02_Locomotion" / "ArchivedPaper").mkdir(parents=True)
+    (papers / "_archived" / "02_Locomotion" / "ArchivedPaper" / "ArchivedPaper.md").write_text(
+        _make_note_body("Archived Paper", 99), encoding="utf-8"
+    )
+
     (papers / "PROGRESS.md").write_text(
         "| # | 论文 | 状态 |\n|---|------|------|\n"
         "| 1 | Proximal Policy Optimization | ✅ |\n"
@@ -102,7 +107,7 @@ def test_process_papers_emits_index(fixture_repo):
 
     data = json.loads(papers_json.read_text(encoding="utf-8"))
     assert set(data.keys()) == {"01_Foundational_RL", "02_Locomotion"}, (
-        "todos directory must be skipped"
+        "todos and _archived directories must be skipped"
     )
 
     assert data["01_Foundational_RL"]["display_name"] == "Foundational RL"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

主页「人体动作分析与生成」模块下方多出一个空模块，显示为 ` archived (0)`，内容为「暂无笔记，敬请期待...」。

## 原因

`papers/_archived/` 是归档笔记目录，但 `prepare_pages.py` 会扫描 `papers/` 下所有子目录并写入 `_data/papers.json`。`_archived` 未被加入 `SKIP_DIRS`，因此被当成普通分类渲染到首页。

## 修复

- 将 `_archived` 加入 `scripts/_common.py` 的 `SKIP_DIRS`（与 `todos` 同级处理）
- `update_badges.py` 回退统计路径同步排除 `_archived`
- 重新运行 `prepare_pages.py`，从 `_data/papers.json` 移除 `_archived` 条目
- 补充 golden 测试，确保 `_archived` 目录不会进入索引

## 验收

![修复后：人体动作模块为最后一项，下方无空模块](https://cursor.com/artifacts/c/art-fcbe6e36-5d55-4939-9b10-76c9cb6d79b0)

## 测试

- `pytest tests/test_prepare_pages_golden.py -v` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3458a63e-ef0b-416b-a743-e666cf47847e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3458a63e-ef0b-416b-a743-e666cf47847e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

