### PR TITLE
docs(11_Simulation_Benchmark): 新增 GRAIL 人形 Loco-Manipulation 数据生成论文笔记

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -2186,6 +2186,7 @@
         "url": "/papers/08_Navigation/EgoActor__Grounding_Task_Planning_into_Spatial-aware_Egocentric_Actions_for_Hum/EgoActor__Grounding_Task_Planning_into_Spatial-aware_Egocentric_Actions_for_Hum.html",
         "dir": "EgoActor__Grounding_Task_Planning_into_Spatial-aware_Egocentric_Actions_for_Hum",
         "arxiv": "2602.04515",
+        "has_open_source": true,
         "published_date_zh": "2026年2月4日（arXiv）",
         "published_date_en": "Feb 4, 2026 (arXiv)",
         "zhname": "EgoActor：用 VLM 把任务规划落到人形机器人的空间感知第一视角动作上",
@@ -2633,6 +2634,18 @@
   "11_Simulation_Benchmark": {
     "display_name": "Simulation Benchmark",
     "papers": [
+      {
+        "title": "GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors",
+        "path": "papers/11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.md",
+        "url": "/papers/11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.html",
+        "dir": "GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors",
+        "arxiv": "2606.05160",
+        "has_open_source": true,
+        "published_date_zh": "2026年6月3日（arXiv v1）",
+        "published_date_en": "Jun 3, 2026 (arXiv v1)",
+        "zhname": "GRAIL：用 3D 资产与视频先验生成人形 Loco-Manipulation 数据",
+        "zh_title": "GRAIL：用 3D 资产与视频先验生成人形 Loco-Manipulation 数据"
+      },
       {
         "title": "ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control",
         "path": "papers/11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md",

--- a/papers/11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.md
+++ b/papers/11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.md
@@ -1,0 +1,158 @@
+---
+layout: paper
+paper_order: 9
+title: "GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors"
+zhname: "GRAIL：用 3D 资产与视频先验生成人形 Loco-Manipulation 数据"
+category: "Simulation Benchmark"
+---
+
+# GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors
+**全数字的数据生成管线：把 3D 资产、可仿真场景与「视频基础模型（VFM）」先验拼起来，直接合成人形机器人的全身操作 + 行走交互数据，部署前完全不碰真机、不做遥操作。**
+
+> 📅 阅读日期: 2026-06-25
+>
+> 🏷️ 板块: 11 Simulation Benchmark · 数据生成管线 / 视频先验 / 4D 人-物交互重建 / Sim-to-Real
+>
+> 🔁 推进轨: 模块轮转（10_Sim-to-Real → **11_Simulation_Benchmark**）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| arXiv | [2606.05160](https://arxiv.org/abs/2606.05160) |
+| HTML | [在线阅读](https://arxiv.org/html/2606.05160) |
+| PDF | [下载](https://arxiv.org/pdf/2606.05160) |
+| 项目主页 | [research.nvidia.com/labs/dair/grail](https://research.nvidia.com/labs/dair/grail/) |
+| 源码 | [NVlabs/GRAIL](https://github.com/NVlabs/GRAIL)（已开源，NVIDIA 非商业许可） |
+| 数据集 | [HuggingFace · PhysicalAI-Robotics-Locomanipulation-GRAIL](https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-Locomanipulation-GRAIL) |
+| **发布时间** | 2026-06-03（arXiv v1） |
+
+**作者 / 机构**：Tianyi Xie、Ye Yuan、Yuke Zhu、Linxi Fan、Jan Kautz、Sanja Fidler 等（NVIDIA，DAIR Lab 等）
+**机器人平台**：Unitree **G1** 人形（真机部署：取物成功率 84%、爬楼成功率 90%）
+**领域归属**：面向人形 loco-manipulation 的**仿真就绪数据生成 / 数据扩展**
+
+---
+
+## 🎯 一句话总结
+
+人形机器人要学「边走边操作（loco-manipulation）」，最缺的是**机器人可用的演示数据**——要覆盖多样物体、全身动作和不同场景几何。但遥操作和动捕都**很难规模化**：每采一批数据都要搭真实场景、给演员穿戴设备、还得真机上场。GRAIL 给出一条**全数字**的路：在部署前**始终停留在虚拟世界里**，把三样东西拼起来——① 现成 **3D 资产**、② **可仿真（simulator-ready）的场景**、③ 来自**视频基础模型（VFM）**的运动先验，从而**不重建真实环境、不遥操作机器人**就合成出交互数据。管线先用 VFM 生成一段「人-物交互参考视频」，再把它**重建成度量级的 4D 人-物交互轨迹**，最后**重定向（retarget）到 G1 人形**并训练「任务通用」的跟踪策略，落到第一视角 RGB 策略上真机部署。最终产出 **2 万+ 条序列**，真机上取物 84%、爬楼 90%。
+
+---
+
+## 📌 英文缩写速查
+
+| 缩写 | 全称 | 解释 |
+|---|---|---|
+| Loco-Manipulation | Locomotion + Manipulation | 边走边操作，需要全身协调的人形任务 |
+| VFM | Video Foundation Model | 视频基础模型，提供运动 / 交互先验 |
+| 4D HOI | 4D Human-Object Interaction | 带时间维的三维人-物交互轨迹 |
+| Retargeting | - | 把人体动作映射到机器人（G1）关节的过程 |
+| Simulator-ready | - | 场景已配好物理 / 碰撞，可直接进物理仿真 |
+
+---
+
+## ❓ 论文要解决什么问题？
+
+> 人形 loco-manipulation 的数据为什么贵？因为**每一批演示都绑死在物理世界**：要搭真实场景、要动捕设备、要真机遥操作。换物体、换场景、换动作都得重来一遍，**规模化几乎不可能**。
+
+GRAIL 的核心问题：
+
+> 能否**完全在虚拟世界里**，仅靠现成 3D 资产 + 视频模型先验，**自动批量生成**机器人可直接训练的全身操作 + 行走数据，并迁移到真机？
+
+---
+
+## 🔧 方法拆解：三阶段全数字管线
+
+### ① 场景装配 + 视频生成
+组装一个**完整指定的 3D 配置**：把一个**已按目标机器人比例预拟合**的虚拟角色放进可仿真场景，再用**视频基础模型**合成一段「人-物交互参考视频」。这一步把「想要什么交互」用视频先验表达出来。
+
+### ② 4D 人-物交互重建
+利用已知的场景上下文，对参考视频做**位姿估计 + 物体跟踪 + 交互感知优化**，恢复出**度量级、时间连贯的 4D 人-物交互轨迹**——既知道人怎么动，也知道物体怎么被推/抓/搬。
+
+### ③ 机器人适配 + 策略训练
+把重建出的运动**重定向到 Unitree G1 人形**，训练**任务通用（task-general）的跟踪策略**覆盖操作与行走，最终蒸馏成**第一视角 RGB 策略**用于真机部署。
+
+> 三阶段串成一条「部署前全虚拟」的流水线，产出 **20,000+ 序列**，覆盖取物、操作、坐下、地形通过等任务。
+
+---
+
+## 🧭 整体流程（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    ASSET["🧱 现成 3D 资产 + 可仿真场景<br/>角色按 G1 比例预拟合"]
+
+    subgraph S1["① 场景装配 + 视频生成"]
+        CFG["完整 3D 配置"]
+        VFM["🎬 视频基础模型 (VFM)<br/>合成人-物交互参考视频"]
+        CFG --> VFM
+    end
+
+    subgraph S2["② 4D 人-物交互重建"]
+        POSE["位姿估计 + 物体跟踪"]
+        OPT["交互感知优化<br/>→ 度量级 4D HOI 轨迹"]
+        POSE --> OPT
+    end
+
+    subgraph S3["③ 机器人适配 + 策略训练"]
+        RT["重定向到 Unitree G1"]
+        POL["任务通用跟踪策略<br/>→ 第一视角 RGB 策略"]
+        RT --> POL
+    end
+
+    ASSET --> S1 --> S2 --> S3
+    POL --> OUT["🚀 20,000+ 仿真就绪序列<br/>真机: 取物 84% · 爬楼 90%"]
+
+    style S1 fill:#e8f4fd,stroke:#1f78b4
+    style S2 fill:#fff7e6,stroke:#e67e22
+    style S3 fill:#eafaf1,stroke:#27ae60
+</div>
+
+---
+
+## 💡 核心贡献
+
+1. **数据生成范式**：提出**部署前全虚拟**的 loco-manipulation 数据管线，靠 3D 资产 + VFM 先验合成交互，**摆脱真实场景搭建与遥操作**，从根上解决数据规模化难题；
+2. **4D 重建桥接**：用「位姿估计 + 物体跟踪 + 交互感知优化」把生成视频还原成**度量级 4D 人-物交互**，为重定向提供可用监督；
+3. **任务通用跟踪策略**：同一套策略覆盖操作与地形通过，落到第一视角 RGB 策略真机部署；
+4. **开放资源**：开源 [NVlabs/GRAIL](https://github.com/NVlabs/GRAIL) 与 HuggingFace 数据集（**20,000+ 序列**），真机验证取物 84% / 爬楼 90%。
+
+---
+
+## 📊 关键设定
+
+| 维度 | 值 |
+|---|---|
+| 数据来源 | 3D 资产 + 可仿真场景 + 视频基础模型先验（全数字） |
+| 中间表示 | 度量级 4D 人-物交互轨迹（4D HOI） |
+| 机器人 | Unitree G1 人形 |
+| 策略形态 | 任务通用跟踪策略 → 第一视角 RGB 策略 |
+| 数据规模 | 20,000+ 序列 |
+| 真机结果 | 取物 84%、爬楼 90% |
+| 许可 | NVIDIA 非商业研究许可 |
+
+> 📌 具体合成质量、消融、与遥操作/动捕基线的数据效率对比等数值，请以论文 PDF 实验章节为准。
+
+---
+
+## 🤖 对仿真数据 / 人形学习的意义
+
+| 方向 | 含义 |
+|---|---|
+| **数据规模化** | 把「采数据」从物理世界搬进纯虚拟管线，理论上可随资产/场景数量任意扩展 |
+| **视频先验落地机器人** | 展示了如何把 VFM 的运动想象力经 4D 重建「接地」成机器人可执行的轨迹 |
+| **与 DexMimicGen / HumanoidGen 的关系** | 同属「自动数据生成」赛道，但卖点在用**视频先验 + 全身 loco-manipulation**，而非纯桌面双手操作 |
+
+---
+
+## 🔗 相关阅读
+
+- [DexMimicGen: Automated Data Generation for Bimanual Dexterous Manipulation](../DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation/DexMimicGen__Automated_Data_Generation_for_Bimanual_Dexterous_Manipulation.md)：另一条自动数据生成路线（双手灵巧操作），本仓库已有笔记
+- [HumanoidGen: Data Generation for Bimanual Dexterous Manipulation via LLM Reasoning](../HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning/HumanoidGen__Data_Generation_for_Bimanual_Dexterous_Manipulation_via_LLM_Reasoning.md)：用 LLM 推理生成人形操作数据，与视频先验路线形成对照，本仓库已有笔记
+- [Humanoid Everyday: A Comprehensive Robotic Dataset for Open-World Humanoid Manipulation](../Humanoid_Everyday__Comprehensive_Robotic_Dataset_for_Open-World_Humanoid_Manipulation/Humanoid_Everyday__Comprehensive_Robotic_Dataset_for_Open-World_Humanoid_Manipulation.md)：真实采集的人形操作数据集，与全合成路线对照，本仓库已有笔记
+
+---
+
+> 备注：本笔记基于 arXiv 摘要、项目主页（[research.nvidia.com/labs/dair/grail](https://research.nvidia.com/labs/dair/grail/)）与源码仓库（[NVlabs/GRAIL](https://github.com/NVlabs/GRAIL)）整理；网络受限期间论文全文 HTML/PDF 未完整抓取，**合成质量、消融与各项数据效率对比**请以论文 PDF 为准。

--- a/papers/DAILY_SUMMARY_LOG.md
+++ b/papers/DAILY_SUMMARY_LOG.md
@@ -299,6 +299,7 @@
 | 368 | LOVON: Legged Open-Vocabulary Object Navigator | 08_Navigation | ✅ 已完成（2026-06-24） |
 | 374 | The Invariant Extended Kalman Filter as a Stable Observer (InEKF) | 09_State_Estimation | ✅ 已完成（2026-06-25） |
 | 551 | Simulator Adaptation for Sim-to-Real Learning of Legged Locomotion via Proprioceptive Distribution Matching | 10_Sim-to-Real | ✅ 已完成（2026-06-26） |
-| ? | （下一篇：11_Simulation_Benchmark 模块首个未完成论文；按 04 → 05 → 06 → 07 → 08 → 09 → 10 → 11 → 12 → 13 → 14 → 04 顺序循环） | 11_Simulation_Benchmark | ⏭️ 下一篇候选 |
+| 552 | GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors | 11_Simulation_Benchmark | ✅ 已完成（2026-06-25） |
+| ? | （下一篇：12_Hardware_Design 模块首个未完成论文；按 04 → 05 → 06 → 07 → 08 → 09 → 10 → 11 → 12 → 13 → 14 → 04 顺序循环） | 12_Hardware_Design | ⏭️ 下一篇候选 |
 
 > 实际推进时会按当天轮转到的模块在 `papers` 列表中扫描，跳过已有内容的笔记。

--- a/papers/PROGRESS.md
+++ b/papers/PROGRESS.md
@@ -549,6 +549,7 @@
 | 407  | RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots                                            | -       |     | ⏳ 待读 |
 | 408  | [ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control](https://arxiv.org/abs/2603.12185) ✅ [笔记](11_Simulation_Benchmark/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine/ComFree-Sim__GPU-Parallelized_Analytical_Contact_Physics_Engine.md) | 2026.03 |  | ✅ 已总结 |
 | 409  | [Humanoid Everyday: A Comprehensive Robotic Dataset for Open-World Humanoid Manipulation](https://arxiv.org/abs/2510.08807) ✅ [笔记](11_Simulation_Benchmark/Humanoid_Everyday__Comprehensive_Robotic_Dataset_for_Open-World_Humanoid_Manipulation/Humanoid_Everyday__Comprehensive_Robotic_Dataset_for_Open-World_Humanoid_Manipulation.md) | 2025.10 |  | ✅ 已总结 |
+| 552  | [GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors](https://arxiv.org/abs/2606.05160) ✅ [笔记](11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.md) | 2026-06-03 |  | ✅ 已总结 |
 | 527  | [MuJoCo Playground](https://playground.mujoco.org/)                                                                                       | 2025.01 |     | ⏳ 待读 |
 
 

--- a/progress.json
+++ b/progress.json
@@ -41,14 +41,14 @@
         "13_Physics-Based_Animation",
         "14_Human_Motion"
       ],
-      "last_module": "10_Sim-to-Real",
-      "last_index": 551,
-      "last_title": "Simulator Adaptation for Sim-to-Real Learning of Legged Locomotion via Proprioceptive Distribution Matching (arXiv:2604.11090)",
-      "next_module": "11_Simulation_Benchmark"
+      "last_module": "11_Simulation_Benchmark",
+      "last_index": 552,
+      "last_title": "GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors (arXiv:2606.05160)",
+      "next_module": "12_Hardware_Design"
     },
-    "last_summary_index": 551,
-    "last_summary_date": "2026-06-26",
-    "last_summary_title": "The Invariant Extended Kalman Filter as a Stable Observer",
+    "last_summary_index": 552,
+    "last_summary_date": "2026-06-25",
+    "last_summary_title": "GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors",
     "next_summary_index": null,
     "log": [
       {
@@ -1040,6 +1040,18 @@
         "arxiv": "2507.06747",
         "source_repo": "https://github.com/DaojiePENG/LOVON",
         "project_page": "https://daojiepeng.github.io/LOVON/"
+      },
+      {
+        "date": "2026-06-25",
+        "index": 552,
+        "title": "GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors",
+        "module": "11_Simulation_Benchmark",
+        "category": "11_Simulation_Benchmark",
+        "note_path": "papers/11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.md",
+        "track": "module_rotation",
+        "arxiv": "2606.05160",
+        "source_repo": "https://github.com/NVlabs/GRAIL",
+        "project_page": "https://research.nvidia.com/labs/dair/grail/"
       }
     ],
     "last_completed_index": 368,
@@ -4591,6 +4603,16 @@
       "pdf_file": "",
       "route": "Simulation Benchmark",
       "title_cn": ""
+    },
+    {
+      "title": "GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors",
+      "arxiv": "2606.05160",
+      "folder": "papers/11_Simulation_Benchmark/GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors",
+      "note_file": "GRAIL__Generating_Humanoid_Loco-Manipulation_from_3D_Assets_and_Video_Priors.md",
+      "pdf_file": "",
+      "status": "done",
+      "route": "Simulation Benchmark",
+      "title_cn": "GRAIL：用 3D 资产与视频先验生成人形 Loco-Manipulation 数据"
     },
     {
       "title": "A Humanoid Visual-Tactile-Action Dataset for Contact-Rich Manipulation",


### PR DESCRIPTION
## 概述

按「每日一篇 · 模块轮转」推进（10_Sim-to-Real → **11_Simulation_Benchmark**），本次新增 NVIDIA **GRAIL** 论文笔记。模块 11 已有 18 篇均已总结，故按「优先最新发表」原则补充该模块当前最新论文（arXiv:2606.05160，2026-06-03）。

## 论文

- **GRAIL: Generating Humanoid Loco-Manipulation from 3D Assets and Video Priors**
- 一句话：一条**全数字**数据生成管线——拼接 3D 资产、可仿真场景与视频基础模型（VFM）先验，合成人形「边走边操作」数据，部署前完全不碰真机、不做遥操作。
- arXiv：[2606.05160](https://arxiv.org/abs/2606.05160) ｜ [HTML](https://arxiv.org/html/2606.05160) ｜ [PDF](https://arxiv.org/pdf/2606.05160)
- 项目主页：[research.nvidia.com/labs/dair/grail](https://research.nvidia.com/labs/dair/grail/)
- 源码：[NVlabs/GRAIL](https://github.com/NVlabs/GRAIL)（已开源）｜ 数据集：[HuggingFace](https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-Locomanipulation-GRAIL)

## 笔记要点

- 三阶段管线：① 场景装配 + VFM 视频生成 → ② 4D 人-物交互重建 → ③ 重定向到 Unitree G1 + 任务通用跟踪策略
- 产出 20,000+ 仿真就绪序列；真机取物 84%、爬楼 90%
- 含一张三阶段 mermaid 流程图
- 与同模块 DexMimicGen / HumanoidGen / Humanoid Everyday 做了对照说明

## 同步更新

- `progress.json`：新增条目、更新 `module_rotation`（last_module=11，next_module=12_Hardware_Design）与日志
- `papers/PROGRESS.md`、`papers/DAILY_SUMMARY_LOG.md`：标记已总结，登记下一篇候选（模块 12）
- `_data/papers.json`：重跑 `prepare_pages.py` 重新生成；`pytest tests/test_prepare_pages.py` 全部通过（21 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6siQEmVrcVNsBh3cXUWmK)_