### PR TITLE
🛡️ Sentinel: [MEDIUM] Add API response size limit

### DIFF
--- a/scripts/fill_published_dates.py
+++ b/scripts/fill_published_dates.py
@@ -118,7 +118,9 @@ def _fetch_arxiv_dates(arxiv_ids: list[str]) -> dict[str, str]:
         req = urllib.request.Request(url, headers={"User-Agent": "HumanoidPaperNotes/1.0"})
         for attempt in range(4):
             try:
-                payload = urllib.request.urlopen(req, timeout=60).read()
+                # 🛡️ Sentinel: Prevent memory exhaustion (DoS) by bounding the API response size.
+                # Maximum 5MB is sufficient for 40 arXiv atom entries.
+                payload = urllib.request.urlopen(req, timeout=60).read(5242880)
                 break
             except urllib.error.URLError:
                 if attempt == 3:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `fill_published_dates.py` script fetched arXiv data using `urllib.request.urlopen(req).read()` without any upper limit on the payload size. An unexpectedly large or infinite stream from a compromised or anomalous API could lead to memory exhaustion (CWE-400).
🎯 Impact: Denial of Service (DoS) during the build process, crashing the CI/CD pipeline.
🔧 Fix: Bounded the `read()` call with a maximum size of 5MB (`read(5242880)`). This provides a fail-safe against unbounded responses while remaining generous enough for normal API operation.
✅ Verification: Ran `pytest` to ensure no functionality is broken, and tested the script logic with `--dry-run`.

---
*PR created automatically by Jules for task [1728981300516415491](https://jules.google.com/task/1728981300516415491) started by @ImChong*