### PR TITLE
Add cache-busting query parameters to local assets

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,13 @@
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>">
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  {%- comment -%}
+    Cache-bust local assets with their last-modified time so a corrected
+    stylesheet/script actually reaches returning visitors instead of a stale
+    copy cached by URL. The query only changes when the file changes.
+  {%- endcomment -%}
+  {% assign style_css = site.static_files | where: "path", "/assets/css/style.css" | first %}
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}{% if style_css %}?v={{ style_css.modified_time | date: '%s' }}{% endif %}">
   <!-- KaTeX (pinned + SRI) -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
@@ -53,8 +59,10 @@
   <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"
           integrity="sha384-rbtjAdnIQE/aQJGEgXrVUlMibdfTSa4PQju4HDhN3sR2PmaKFzhEafuePsl9H/9I"
           crossorigin="anonymous"></script>
-  <script src="{{ '/assets/js/mermaid-config.js' | relative_url }}"></script>
-  <script src="{{ '/assets/js/mermaid-zoom.js' | relative_url }}" defer></script>
+  {% assign mermaid_config_js = site.static_files | where: "path", "/assets/js/mermaid-config.js" | first %}
+  <script src="{{ '/assets/js/mermaid-config.js' | relative_url }}{% if mermaid_config_js %}?v={{ mermaid_config_js.modified_time | date: '%s' }}{% endif %}"></script>
+  {% assign mermaid_zoom_js = site.static_files | where: "path", "/assets/js/mermaid-zoom.js" | first %}
+  <script src="{{ '/assets/js/mermaid-zoom.js' | relative_url }}{% if mermaid_zoom_js %}?v={{ mermaid_zoom_js.modified_time | date: '%s' }}{% endif %}" defer></script>
   <script>
     function initMermaid(theme) {
       if (typeof mermaid === 'undefined') return;

--- a/_layouts/paper.html
+++ b/_layouts/paper.html
@@ -56,4 +56,5 @@ layout: default
 }
 </script>
 
-<script src="{{ '/assets/js/paper.js' | relative_url }}" defer></script>
+{% assign paper_js = site.static_files | where: "path", "/assets/js/paper.js" | first %}
+<script src="{{ '/assets/js/paper.js' | relative_url }}{% if paper_js %}?v={{ paper_js.modified_time | date: '%s' }}{% endif %}" defer></script>


### PR DESCRIPTION
## Summary
This PR implements cache-busting for local CSS and JavaScript assets by appending query parameters based on file modification timestamps. This ensures that returning visitors receive updated assets instead of stale cached versions when files are modified.

## Changes
- **default.html**: Added cache-busting query parameters to three local assets:
  - `style.css` - Main stylesheet
  - `mermaid-config.js` - Mermaid configuration script
  - `mermaid-zoom.js` - Mermaid zoom functionality script

- **paper.html**: Added cache-busting query parameter to:
  - `paper.js` - Paper layout script

## Implementation Details
- Uses Jekyll's `site.static_files` to retrieve file metadata and extract the `modified_time` of each asset
- Appends a version query parameter (`?v=<unix-timestamp>`) to asset URLs that changes whenever the file is modified
- The query parameter is only added if the file metadata is available, maintaining graceful fallback behavior
- Added explanatory comment in default.html documenting the cache-busting strategy
- Uses Unix timestamp format (`%s`) for the version parameter, ensuring consistent and sortable version strings

https://claude.ai/code/session_01DysddyaGr3hZfLFmpGpfHB