### PR TITLE
fix(UI): 修复移动端双指缩小后主列右侧空白

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -607,16 +607,27 @@ body.index-search-active .paper-list-toggle-btn {
   .paper-content,
   .paper-layout,
   .paper-body {
+    width: 100%;
     max-width: 100%;
+    min-width: 0;
     box-sizing: border-box;
     overflow-x: hidden;
     overflow-x: clip;
   }
+
+  .header-inner {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
 }
 
-/* Wider container for paper pages to accommodate TOC */
-.paper-content .paper-layout {
-  max-width: none;
+/* Wider container for paper pages to accommodate TOC (desktop only) */
+@media (min-width: 1201px) {
+  .paper-content .paper-layout {
+    max-width: none;
+  }
 }
 
 /* ===== Index Layout with TOC ===== */
@@ -1473,17 +1484,22 @@ body.sponsor-dialog-open {
     justify-content: flex-start;
     padding: 0.6rem 0.5rem;
     gap: 0.5rem;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
   }
   .site-title {
     display: block;
-    flex: 0 1 auto;
-    width: calc(100% - 220px);
-    max-width: calc(100% - 220px);
+    flex: 1 1 0;
+    width: auto;
+    max-width: none;
     min-width: 0;
     line-height: 1.25;
     font-size: 1rem;
     white-space: nowrap;
     overflow: hidden;
+    overflow-wrap: normal;
     text-overflow: ellipsis;
   }
   .header-right {
@@ -1650,15 +1666,21 @@ body.sponsor-dialog-open {
     flex-wrap: nowrap;
     align-items: center;
     gap: 0.75rem;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
   }
 
   .site-title {
     flex: 1 1 0;
     min-width: 0;
-    white-space: normal;
-    overflow: visible;
-    overflow-wrap: anywhere;
-    text-overflow: unset;
+    width: auto;
+    max-width: none;
+    white-space: nowrap;
+    overflow: hidden;
+    overflow-wrap: normal;
+    text-overflow: ellipsis;
     line-height: 1.3;
   }
 
@@ -1688,9 +1710,13 @@ body.sponsor-dialog-open {
   .paper-body .code-block {
     width: 100%;
     max-width: 100%;
+    min-width: 0;
     box-sizing: border-box;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    /* ``minmax(0, auto)`` lets the code column scroll inside the block instead
+       of expanding the page width (grid default ``auto`` = max-content). */
+    grid-template-columns: 3rem minmax(0, auto);
     /* inline-size only: ``contain: strict`` collapses block height (~1 line) on
        mobile and clips Python/bash samples inside DeepMimic-style notes. */
     contain: inline-size;
@@ -1787,49 +1813,5 @@ body.sponsor-dialog-open {
     white-space: nowrap;
     overflow-wrap: normal;
     word-break: normal;
-  }
-}
-
-@media (max-width: 600px) {
-  .header-inner {
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    padding: 0.6rem 0.5rem;
-    gap: 0.5rem;
-  }
-
-  .site-title {
-    display: block;
-    flex: 0 1 auto;
-    width: calc(100% - 220px);
-    max-width: calc(100% - 220px);
-    font-size: 1rem;
-    line-height: 1.25;
-    min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    overflow-wrap: normal;
-    text-overflow: ellipsis;
-  }
-
-  .header-right {
-    flex: 0 0 auto;
-    justify-content: flex-end;
-    gap: 0.35rem;
-    margin-left: auto;
-  }
-
-  .github-link {
-    font-size: 0.78rem;
-    white-space: nowrap;
-  }
-
-  .lang-toggle,
-  .theme-toggle,
-  .sponsor-toggle {
-    min-width: 32px;
-    height: 30px;
-    padding: 0 0.45rem;
   }
 }

--- a/tests/test_mobile_column_width_css.py
+++ b/tests/test_mobile_column_width_css.py
@@ -1,0 +1,51 @@
+"""Regression: mobile main column and header must not exceed viewport width."""
+
+from pathlib import Path
+
+STYLE = Path(__file__).resolve().parents[1] / "assets" / "css" / "style.css"
+
+
+def _block(start_marker: str, end_marker: str | None = None) -> str:
+    text = STYLE.read_text(encoding="utf-8")
+    start = text.find(start_marker)
+    assert start != -1, f"missing marker: {start_marker!r}"
+    if end_marker is None:
+        return text[start:]
+    end = text.find(end_marker, start)
+    assert end != -1, f"missing end marker: {end_marker!r}"
+    return text[start:end]
+
+
+def test_mobile_header_inner_constrained_to_viewport():
+    block = _block("@media (max-width: 1200px) {\n  .header-inner {")
+    assert "width: 100%" in block
+    assert "max-width: 100%" in block
+    assert "min-width: 0" in block
+
+
+def test_mobile_site_title_uses_flex_shrink_not_fixed_calc_width():
+    """``calc(100% - 220px)`` sized the title against an already-over-wide
+    header and let ``white-space: nowrap`` expand the page past the viewport."""
+    text = STYLE.read_text(encoding="utf-8")
+    assert "calc(100% - 220px)" not in text
+
+
+def test_paper_layout_max_width_none_is_desktop_only():
+    text = STYLE.read_text(encoding="utf-8")
+    assert ".paper-content .paper-layout {\n    max-width: none;\n  }" in text
+    desktop_idx = text.index("@media (min-width: 1201px)")
+    assert text.index(".paper-content .paper-layout", desktop_idx) > desktop_idx
+
+
+def test_mobile_code_block_grid_allows_internal_scroll():
+    block = _block(".paper-body .code-block {", ".paper-body .table-wrapper")
+    assert "grid-template-columns: 3rem minmax(0, auto)" in block
+    assert "min-width: 0" in block
+
+
+def test_mobile_container_chain_has_full_width():
+    block = _block("@media (max-width: 1200px) {\n  html,")
+    snippet = block[: block.index("/* Wider container")]
+    for selector in (".container", ".paper-content", ".paper-layout", ".paper-body"):
+        assert selector in snippet
+    assert snippet.count("width: 100%") >= 4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在 iOS Safari 上对论文详情页（如 PPO）双指缩小后，主内容列与顶栏停留在左侧，右侧出现大块空白区域，页面实际布局宽度（约 667px）超出 390px 视口。

## 根因

1. **顶栏撑宽页面**：`.site-title` 在 `max-width: 600px` 下使用 `white-space: nowrap` + `width: calc(100% - 220px)`，标题全文不换行时把 `.header-inner` 撑到 ~667px，进而扩大整页布局宽度。
2. **桌面规则泄漏到移动端**：`.paper-content .paper-layout { max-width: none }` 未限定桌面，覆盖移动端 `max-width: 100%`。
3. **代码块网格列**：`.code-block` 使用 `grid-template-columns: 3rem auto`，`auto` 列按最长行 max-content 计算，易把内部滚动区域撑出列宽。

## 修复

- 移动端 `.header-inner` / 主列容器统一 `width: 100%; max-width: 100%; min-width: 0`
- 站点标题改为 `flex: 1 1 0` + `text-overflow: ellipsis`，移除 `calc(100% - 220px)`
- `.paper-content .paper-layout { max-width: none }` 仅保留在 `min-width: 1201px`
- 代码块网格第二列改为 `minmax(0, auto)`，长代码在块内横向滚动

## 验收

[修复后：PPO 论文页移动端（390×844）](https://cursor.com/agents/bc-1214e418-26bd-48c6-9f54-409a59884f5d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-ppo-fixed-normal.png)

- `pytest tests/test_mobile_column_width_css.py -v` 通过

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1214e418-26bd-48c6-9f54-409a59884f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1214e418-26bd-48c6-9f54-409a59884f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

