### PR TITLE
fix(UI): 修复移动端双指缩小后主列右侧空白

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1123,7 +1123,7 @@ body.mermaid-lightbox-open {
   border: 1px solid var(--border);
   background: var(--card-bg);
   -webkit-overflow-scrolling: touch;
-  contain: inline-size;
+  contain: inline-size paint;
 }
 
 .paper-body table {
@@ -1717,13 +1717,17 @@ body.sponsor-dialog-open {
     /* ``minmax(0, auto)`` lets the code column scroll inside the block instead
        of expanding the page width (grid default ``auto`` = max-content). */
     grid-template-columns: 3rem minmax(0, auto);
-    /* inline-size only: ``contain: strict`` collapses block height (~1 line) on
-       mobile and clips Python/bash samples inside DeepMimic-style notes. */
-    contain: inline-size;
+    /* ``contain: paint`` keeps wide tables from inflating the root scroll width on
+       iOS Safari (``inline-size`` alone still lets overflow widen the layout
+       viewport when the user pinch-zooms out). ``strict`` collapses height. */
+    contain: inline-size paint;
   }
 
   .paper-body .table-wrapper {
-    contain: inline-size;
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+    contain: inline-size paint;
   }
 
   /* Rouge block wrapper only (``div.highlighter-rouge``). Inline ``code.highlighter-rouge``

--- a/tests/test_mobile_column_width_css.py
+++ b/tests/test_mobile_column_width_css.py
@@ -43,6 +43,19 @@ def test_mobile_code_block_grid_allows_internal_scroll():
     assert "min-width: 0" in block
 
 
+def test_mobile_table_wrapper_uses_paint_containment():
+    """Wide tables inside ``overflow-x: auto`` still inflated ``html.scrollWidth``
+    on iOS; ``contain: paint`` keeps scroll inside the wrapper."""
+    block = _block(".paper-body .table-wrapper {", "/* Rouge block wrapper")
+    assert "contain: inline-size paint" in block
+    assert "min-width: 0" in block
+
+
+def test_mobile_code_block_uses_paint_containment():
+    block = _block(".paper-body .code-block {", ".paper-body .table-wrapper")
+    assert "contain: inline-size paint" in block
+
+
 def test_mobile_container_chain_has_full_width():
     block = _block("@media (max-width: 1200px) {\n  html,")
     snippet = block[: block.index("/* Wider container")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在 iOS Safari 上对论文详情页（如 PPO）双指缩小后，主内容列与顶栏停留在左侧，右侧出现大块空白区域。

## 根因（两轮定位）

1. **顶栏撑宽（已修）**：`.site-title` 的 `nowrap` + `calc(100% - 220px)` 曾把 `.header-inner` 撑到 ~667px。
2. **宽表格泄漏布局宽度（本轮）**：`.table-wrapper` 虽有 `overflow-x: auto` 与 `contain: inline-size`，但宽表格（如 891px）仍使 `document.documentElement.scrollWidth` 变为 **667px**。iOS 据此扩大布局视口；顶栏 `width:100%` 随视口变为 667px，而主列仍约 390px，双指缩小后右侧露出空白。

## 修复

- 移动端 `.table-wrapper`：`contain: inline-size paint` + `min-width:0`（保留内部横向滚动，不撑宽根滚动宽度）
- 移动端 `.code-block`：同步 `contain: inline-size paint`
- 全局 `.table-wrapper`：基线规则同步为 `contain: inline-size paint`

## 验收

修复后（390×844，mobile 仿真）`html.scrollWidth = innerWidth = header = container = 390`。

[修复后：PPO 论文页移动端（390×844）](https://cursor.com/agents/bc-1214e418-26bd-48c6-9f54-409a59884f5d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-ppo-table-fix.png)

- `pytest tests/test_mobile_column_width_css.py tests/test_mobile_contain_css.py -v` 通过

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1214e418-26bd-48c6-9f54-409a59884f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1214e418-26bd-48c6-9f54-409a59884f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

