### PR TITLE
fix(UI): 主页笔记卡片折叠为 5 篇，支持渐进展开与收起

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -360,6 +360,7 @@ a.index-chip-link:hover {
 
 .paper-list-toggle-group {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin: 0.2rem 0 0.6rem;
 }

--- a/index.html
+++ b/index.html
@@ -182,6 +182,10 @@ title: "Home"
         <button type="button" class="paper-list-toggle-btn paper-list-all-btn" data-fold-id="cat-{{ forloop.index }}-papers"
           data-en="Show all {{ fold_hidden }} notes ▾"
           data-zh="展开全部 {{ fold_hidden }} 篇 ▾">Show all {{ fold_hidden }} notes ▾</button>
+        <button type="button" class="paper-list-toggle-btn paper-list-collapse-btn" data-fold-id="cat-{{ forloop.index }}-papers"
+          data-en="Collapse to {{ fold_limit }} ▴"
+          data-zh="收起到 {{ fold_limit }} 篇 ▴"
+          hidden>Collapse to {{ fold_limit }} ▴</button>
       </div>
       {% endif %}
       {% else %}
@@ -285,9 +289,10 @@ title: "Home"
     return document.querySelector('.paper-list-toggle-group[data-fold-id="' + foldId + '"]');
   }
 
-  function updateFoldLabels(group, hiddenCount, step) {
+  function updateFoldLabels(group, hiddenCount, step, initial) {
     var moreBtn = group.querySelector('.paper-list-more-btn');
     var allBtn = group.querySelector('.paper-list-all-btn');
+    var collapseBtn = group.querySelector('.paper-list-collapse-btn');
     var useZh = getLang() === 'zh';
     var moreCount = Math.min(step, hiddenCount);
     if (moreBtn) {
@@ -300,6 +305,11 @@ title: "Home"
         ? '展开全部 ' + hiddenCount + ' 篇 ▾'
         : 'Show all ' + hiddenCount + ' notes ▾';
     }
+    if (collapseBtn) {
+      collapseBtn.textContent = useZh
+        ? '收起到 ' + initial + ' 篇 ▴'
+        : 'Collapse to ' + initial + ' ▴';
+    }
   }
 
   function updateFoldUI(list, persist) {
@@ -307,21 +317,32 @@ title: "Home"
     var group = getFoldGroup(foldId);
     var hiddenCount = getFoldedItems(list).length;
     var step = parseInt(list.getAttribute('data-fold-step') || '5', 10);
+    var initial = parseInt(list.getAttribute('data-fold-initial') || '5', 10);
+    var visibleCount = getVisibleCount(list);
+    var expandedBeyondDefault = visibleCount > initial;
 
     if (hiddenCount === 0) {
       list.classList.remove('is-folded');
-      if (group) group.style.display = 'none';
     } else {
       list.classList.add('is-folded');
-      if (group) {
-        group.style.display = '';
-        updateFoldLabels(group, hiddenCount, step);
-      }
     }
+
+    if (!group) return;
+
+    var moreBtn = group.querySelector('.paper-list-more-btn');
+    var allBtn = group.querySelector('.paper-list-all-btn');
+    var collapseBtn = group.querySelector('.paper-list-collapse-btn');
+
+    group.style.display = '';
+    if (moreBtn) moreBtn.hidden = hiddenCount === 0;
+    if (allBtn) allBtn.hidden = hiddenCount === 0;
+    if (collapseBtn) collapseBtn.hidden = !expandedBeyondDefault;
+
+    updateFoldLabels(group, hiddenCount, step, initial);
 
     if (persist && foldId) {
       try {
-        localStorage.setItem(FOLD_PREFIX + foldId, String(getVisibleCount(list)));
+        localStorage.setItem(FOLD_PREFIX + foldId, String(visibleCount));
       } catch (e) {}
     }
   }
@@ -358,6 +379,7 @@ title: "Home"
 
     var moreBtn = group.querySelector('.paper-list-more-btn');
     var allBtn = group.querySelector('.paper-list-all-btn');
+    var collapseBtn = group.querySelector('.paper-list-collapse-btn');
     if (moreBtn) {
       moreBtn.addEventListener('click', function() {
         var step = parseInt(list.getAttribute('data-fold-step') || '5', 10);
@@ -369,15 +391,22 @@ title: "Home"
         applyVisibleCount(list, list.querySelectorAll('li[data-search]').length, true);
       });
     }
+    if (collapseBtn) {
+      collapseBtn.addEventListener('click', function() {
+        var initial = parseInt(list.getAttribute('data-fold-initial') || '5', 10);
+        applyVisibleCount(list, initial, true);
+      });
+    }
   });
 
   document.addEventListener('cl-lang-changed', function() {
     foldLists.forEach(function(list) {
       var foldId = list.getAttribute('data-fold-id');
       var group = getFoldGroup(foldId);
-      if (!group || group.style.display === 'none') return;
+      if (!group) return;
       var step = parseInt(list.getAttribute('data-fold-step') || '5', 10);
-      updateFoldLabels(group, getFoldedItems(list).length, step);
+      var initial = parseInt(list.getAttribute('data-fold-initial') || '5', 10);
+      updateFoldLabels(group, getFoldedItems(list).length, step, initial);
     });
   });
 

--- a/tests/test_index_paper_fold.py
+++ b/tests/test_index_paper_fold.py
@@ -16,6 +16,7 @@ def test_index_declares_fold_exempt_categories():
     assert "paper-list-item-folded" in text
     assert "paper-list-more-btn" in text
     assert "paper-list-all-btn" in text
+    assert "paper-list-collapse-btn" in text
     assert "paper-list-toggle-group" in text
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

1. 首页各分类（除 `01`–`03` 豁免模块外）默认只展示最新 **5 篇**笔记
2. 超出部分提供三个按钮（按状态显示）：
   - **再展开 5 篇**：每次多显示 5 篇（剩余不足 5 篇时显示实际数量）
   - **展开全部**：一次性显示该分类所有笔记
   - **收起到 5 篇**：将列表收回到默认 5 篇状态（仅在已展开超过 5 篇时显示）
3. 全部展开后仅显示「收起」按钮；收起到默认后恢复两个展开按钮
4. 展开进度写入 `localStorage`，刷新后保持

## 修改文件

- `index.html`：三按钮 HTML + 渐进展开/收起 JS
- `assets/css/style.css`：`.paper-list-toggle-group` 并排布局（支持换行）
- `tests/test_index_paper_fold.py`：同步更新断言

## 验收

- `pytest tests/test_index_paper_fold.py -v` 全部通过
- 默认态：5 张卡片 +「再展开 5 篇」「展开全部」
- 全部展开后：仅显示「Collapse to 5 ▴」/「收起到 5 篇 ▴」，点击可回到默认态

![默认态：5 篇 + 两个展开按钮](https://cursor.com/artifacts/c/art-cdd89e57-013f-49af-bbaa-9c740ff8075f)

![全部展开后：收起按钮](https://cursor.com/artifacts/c/art-2e43058d-da24-4264-9d97-dbedbde9dd03)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c495547-1508-49bb-ae79-accf90a38b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c495547-1508-49bb-ae79-accf90a38b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

