### PR TITLE
fix(Home): 收紧主页底部到页脚的间距

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -724,9 +724,17 @@ body.index-search-active .paper-list-toggle-group {
     left: 0;
   }
 
-  /* Keep fold toggles above the floating sidebar FAB on narrow viewports. */
-  .index-main {
-    padding-bottom: calc(24px + 48px + 28px + env(safe-area-inset-bottom, 0px));
+  /* FAB scroll clearance belongs after the footer, not between content and footer. */
+  body:has(.index-layout) {
+    padding-bottom: calc(24px + 48px + 12px + env(safe-area-inset-bottom, 0px));
+  }
+
+  body:has(.index-layout) .site-footer {
+    margin-top: 0.5rem;
+  }
+
+  body:has(.index-layout) .category-section:last-child {
+    margin-bottom: 1rem;
   }
 }
 

--- a/tests/test_index_paper_fold.py
+++ b/tests/test_index_paper_fold.py
@@ -44,4 +44,5 @@ def test_style_hides_folded_items_when_collapsed():
     assert ".paper-list-toggle-group" in css
     assert ".paper-list-toggle-btn" in css
     assert "min-height: 44px" in css
-    assert ".index-main" in css
+    assert "body:has(.index-layout)" in css
+    assert ".index-main {\n    padding-bottom:" not in css


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端主页底部（折叠按钮区域）到 `site-footer` 之间留白过大，滚动到底部时可见约 100px 以上的空白区域。

## 原因

窄屏下 `.index-main` 设置了 `padding-bottom: calc(24px + 48px + 28px + …)`（约 100px），用于给左下角浮动侧边栏 FAB 预留滚动空间。但该 padding 位于主内容与页脚之间，导致页脚被整体下推。

## 修改

- 移除 `.index-main` 的 `padding-bottom`
- 将 FAB 滚动预留空间改到 `body:has(.index-layout)` 的 `padding-bottom`（位于页脚之后）
- 收紧首页页脚 `margin-top`（`1rem` → `0.5rem`）与末个分类区块 `margin-bottom`（`2rem` → `1rem`）

折叠按钮与页脚间距由约 132px 降至约 40px，FAB 仍可正常显示且不遮挡按钮。

## 验收

![修复后：主页底部到页脚间距（390×844）](https://cursor.com/artifacts/c/art-def515b9-3561-4c88-9a2e-aee4a8e49976)

- [x] `pytest tests/test_index_paper_fold.py -v` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c852b72a-3285-41cc-a752-c4318059560f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c852b72a-3285-41cc-a752-c4318059560f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

