### PR TITLE
fix(Home): 收紧主页底部间距并压缩页脚高度

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -724,17 +724,18 @@ body.index-search-active .paper-list-toggle-group {
     left: 0;
   }
 
-  /* FAB scroll clearance belongs after the footer, not between content and footer. */
-  body:has(.index-layout) {
-    padding-bottom: calc(24px + 48px + 12px + env(safe-area-inset-bottom, 0px));
-  }
-
   body:has(.index-layout) .site-footer {
     margin-top: 0.5rem;
+    padding: 10px 0 12px;
+    padding-bottom: max(12px, env(safe-area-inset-bottom, 0px));
   }
 
   body:has(.index-layout) .category-section:last-child {
     margin-bottom: 1rem;
+  }
+
+  body:has(.index-layout) .container {
+    padding-bottom: 0.5rem;
   }
 }
 

--- a/tests/test_index_paper_fold.py
+++ b/tests/test_index_paper_fold.py
@@ -44,5 +44,6 @@ def test_style_hides_folded_items_when_collapsed():
     assert ".paper-list-toggle-group" in css
     assert ".paper-list-toggle-btn" in css
     assert "min-height: 44px" in css
+    assert "body:has(.index-layout) .site-footer" in css
     assert "body:has(.index-layout)" in css
-    assert ".index-main {\n    padding-bottom:" not in css
+    assert "padding-bottom: calc(24px + 48px" not in css


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端主页底部（折叠按钮区域）到 `site-footer` 之间留白过大；首版修复后页脚又显得「过高」。

## 原因分析

上一版将 FAB 预留空间放到 `body { padding-bottom: 84px }`，滚到页面底部时：

| 区域 | 高度 |
|------|------|
| `.site-footer` padding（上 24 + 下 20） | ~44px |
| 版权文字（两行换行） | ~45px |
| `body` padding-bottom（与页脚同色） | **84px** |
| **视觉「页脚块」合计** | **~174px** |

`body` 底部留白与 footer 背景色相同，用户会把它当成页脚的一部分，所以看起来「页脚很高、文字悬在中间」。

## 修改

- **移除** `body:has(.index-layout) { padding-bottom: … }`
- **压缩首页页脚**：`padding: 10px 0 12px`（原 `24px 0 20px`）
- **收紧主容器底部**：首页 `container` 的 `padding-bottom` 改为 `0.5rem`

修复后（390×844，滚到底）：

- 折叠按钮 → 页脚分隔线：~32px
- 页脚总高度：~68px（贴近视口底部）
- `body` 底部留白：0

## 验收

![修复后：紧凑页脚（390×844）](https://cursor.com/artifacts/c/art-657eef59-2b7a-42cb-8e34-2873864592cc)

- [x] `pytest tests/test_index_paper_fold.py -v` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c852b72a-3285-41cc-a752-c4318059560f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c852b72a-3285-41cc-a752-c4318059560f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

