### PR TITLE
feat(Updates): 更新记录时间线增加收起至30天与回到顶部按钮

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2237,7 +2237,9 @@ a.updates-item-link:hover {
 }
 
 .updates-timeline-more-days,
-.updates-timeline-show-all {
+.updates-timeline-show-all,
+.updates-timeline-collapse,
+.updates-timeline-back-to-top {
   display: inline-block;
   padding: 0.3rem 0.9rem;
   font-family: 'Arial', 'Helvetica Neue', sans-serif;
@@ -2252,7 +2254,9 @@ a.updates-item-link:hover {
 }
 
 .updates-timeline-more-days:hover,
-.updates-timeline-show-all:hover {
+.updates-timeline-show-all:hover,
+.updates-timeline-collapse:hover,
+.updates-timeline-back-to-top:hover {
   color: var(--link-hover);
   border-color: var(--link-hover);
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2231,9 +2231,20 @@ a.updates-item-link:hover {
 .updates-timeline-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
   margin-top: 18px;
   padding-left: 18px;
+}
+
+.updates-timeline-actions-left {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.updates-timeline-back-to-top {
+  margin-left: auto;
 }
 
 .updates-timeline-more-days,

--- a/tests/test_updates_timeline.py
+++ b/tests/test_updates_timeline.py
@@ -1,0 +1,34 @@
+"""Update log timeline: expand/collapse/back-to-top controls."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UPDATES = ROOT / "updates.html"
+STYLE = ROOT / "assets" / "css" / "style.css"
+
+
+def test_updates_timeline_expand_and_collapse_controls():
+    text = UPDATES.read_text(encoding="utf-8")
+    assert "TIMELINE_WINDOW_DAYS = 30" in text
+    assert "updates-timeline-more-days" in text
+    assert "updates-timeline-show-all" in text
+    assert "updates-timeline-collapse" in text
+    assert "updates-timeline-back-to-top" in text
+    assert "collapseTo30Days" in text
+    assert "backToTop" in text
+    assert "isTimelineExpanded" in text
+    assert "收起至 30 天" in text
+    assert "回到顶部" in text
+
+
+def test_updates_timeline_collapse_resets_window():
+    text = UPDATES.read_text(encoding="utf-8")
+    assert "currentWindowDays = TIMELINE_WINDOW_DAYS" in text
+    assert "timelineShowAll = false" in text
+    assert "window.scrollTo({ top: 0, behavior: 'smooth' })" in text
+
+
+def test_style_includes_new_timeline_action_buttons():
+    css = STYLE.read_text(encoding="utf-8")
+    assert ".updates-timeline-collapse" in css
+    assert ".updates-timeline-back-to-top" in css

--- a/tests/test_updates_timeline.py
+++ b/tests/test_updates_timeline.py
@@ -28,7 +28,14 @@ def test_updates_timeline_collapse_resets_window():
     assert "window.scrollTo({ top: 0, behavior: 'smooth' })" in text
 
 
-def test_style_includes_new_timeline_action_buttons():
+def test_updates_timeline_back_to_top_always_rendered():
+    text = UPDATES.read_text(encoding="utf-8")
+    assert "updates-timeline-actions-left" in text
+    assert "updates-timeline-back-to-top" in text
+    assert "activeDate ? '' : timelineActionsHtml" not in text
+
+
+def test_style_back_to_top_right_aligned():
     css = STYLE.read_text(encoding="utf-8")
-    assert ".updates-timeline-collapse" in css
     assert ".updates-timeline-back-to-top" in css
+    assert "margin-left: auto" in css

--- a/updates.html
+++ b/updates.html
@@ -73,7 +73,9 @@ title: "Update Log"
       showMore: function(n) { return 'Show ' + n + ' more ▾'; },
       expandMoreDays: 'Expand 30 more days',
       expandAll: 'Show all records',
-      timelineActionsAria: 'Expand more update records',
+      collapseTo30Days: 'Collapse to 30 days ▴',
+      backToTop: '↑ Back to top',
+      timelineActionsAria: 'Timeline actions',
       timelineTitle: 'Timeline',
       heatmapAria: 'Note update activity heatmap; one square per day',
       cellAria: function(tip) { return tip + '. Click to filter the timeline to this day.'; },
@@ -99,7 +101,9 @@ title: "Update Log"
       showMore: function(n) { return '展开其余 ' + n + ' 项 ▾'; },
       expandMoreDays: '再展开 30 天',
       expandAll: '展开全部记录',
-      timelineActionsAria: '展开更多更新记录',
+      collapseTo30Days: '收起至 30 天 ▴',
+      backToTop: '↑ 回到顶部',
+      timelineActionsAria: '时间线操作',
       timelineTitle: '时间线',
       heatmapAria: '笔记更新活跃度热力图，每格代表一天',
       cellAria: function(tip) { return tip + '，点击筛选当日时间线'; },
@@ -355,13 +359,27 @@ title: "Update Log"
     return filtered;
   }
 
-  function timelineActionsHtml(lang, visibleDays, showAll) {
-    if (!days.length || showAll || visibleDays.length >= days.length) return '';
+  function isTimelineExpanded(windowDays, showAll) {
+    return showAll || windowDays > TIMELINE_WINDOW_DAYS;
+  }
+
+  function timelineActionsHtml(lang, visibleDays, windowDays, showAll) {
+    if (!days.length) return '';
+    var expanded = isTimelineExpanded(windowDays, showAll);
+    var hasMore = !showAll && visibleDays.length < days.length;
+    if (!expanded && !hasMore) return '';
     var t = I18N[lang];
+    var buttons = '';
+    if (hasMore) {
+      buttons += '<button type="button" class="updates-timeline-more-days">' + escapeHtml(t.expandMoreDays) + '</button>' +
+        '<button type="button" class="updates-timeline-show-all">' + escapeHtml(t.expandAll) + '</button>';
+    }
+    if (expanded) {
+      buttons += '<button type="button" class="updates-timeline-collapse">' + escapeHtml(t.collapseTo30Days) + '</button>' +
+        '<button type="button" class="updates-timeline-back-to-top">' + escapeHtml(t.backToTop) + '</button>';
+    }
     return '<div class="updates-timeline-actions" role="group" aria-label="' + escapeHtml(t.timelineActionsAria) + '">' +
-      '<button type="button" class="updates-timeline-more-days">' + escapeHtml(t.expandMoreDays) + '</button>' +
-      '<button type="button" class="updates-timeline-show-all">' + escapeHtml(t.expandAll) + '</button>' +
-      '</div>';
+      buttons + '</div>';
   }
 
   function timelineHtml(lang, activeDate, windowDays, showAll) {
@@ -379,7 +397,7 @@ title: "Update Log"
     for (var i = 0; i < shown.length; i++) {
       daysHtml += dayHtml(shown[i], lang);
     }
-    var actionsHtml = activeDate ? '' : timelineActionsHtml(lang, shown, showAll);
+    var actionsHtml = activeDate ? '' : timelineActionsHtml(lang, shown, windowDays, showAll);
     return '<div class="updates-timeline">' +
       '<h2 class="updates-timeline-title">📜 ' + escapeHtml(t.timelineTitle) + '</h2>' +
       filterBar +
@@ -429,6 +447,16 @@ title: "Update Log"
     if (ev.target.closest('button.updates-timeline-show-all')) {
       timelineShowAll = true;
       render();
+      return;
+    }
+    if (ev.target.closest('button.updates-timeline-collapse')) {
+      currentWindowDays = TIMELINE_WINDOW_DAYS;
+      timelineShowAll = false;
+      render();
+      return;
+    }
+    if (ev.target.closest('button.updates-timeline-back-to-top')) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   });
 

--- a/updates.html
+++ b/updates.html
@@ -363,23 +363,25 @@ title: "Update Log"
     return showAll || windowDays > TIMELINE_WINDOW_DAYS;
   }
 
-  function timelineActionsHtml(lang, visibleDays, windowDays, showAll) {
+  function timelineActionsHtml(lang, visibleDays, windowDays, showAll, activeDate) {
     if (!days.length) return '';
-    var expanded = isTimelineExpanded(windowDays, showAll);
-    var hasMore = !showAll && visibleDays.length < days.length;
-    if (!expanded && !hasMore) return '';
+    var expanded = !activeDate && isTimelineExpanded(windowDays, showAll);
+    var hasMore = !activeDate && !showAll && visibleDays.length < days.length;
     var t = I18N[lang];
-    var buttons = '';
-    if (hasMore) {
-      buttons += '<button type="button" class="updates-timeline-more-days">' + escapeHtml(t.expandMoreDays) + '</button>' +
-        '<button type="button" class="updates-timeline-show-all">' + escapeHtml(t.expandAll) + '</button>';
-    }
-    if (expanded) {
-      buttons += '<button type="button" class="updates-timeline-collapse">' + escapeHtml(t.collapseTo30Days) + '</button>' +
-        '<button type="button" class="updates-timeline-back-to-top">' + escapeHtml(t.backToTop) + '</button>';
+    var leftButtons = '';
+    if (!activeDate) {
+      if (hasMore) {
+        leftButtons += '<button type="button" class="updates-timeline-more-days">' + escapeHtml(t.expandMoreDays) + '</button>' +
+          '<button type="button" class="updates-timeline-show-all">' + escapeHtml(t.expandAll) + '</button>';
+      }
+      if (expanded) {
+        leftButtons += '<button type="button" class="updates-timeline-collapse">' + escapeHtml(t.collapseTo30Days) + '</button>';
+      }
     }
     return '<div class="updates-timeline-actions" role="group" aria-label="' + escapeHtml(t.timelineActionsAria) + '">' +
-      buttons + '</div>';
+      (leftButtons ? '<div class="updates-timeline-actions-left">' + leftButtons + '</div>' : '') +
+      '<button type="button" class="updates-timeline-back-to-top">' + escapeHtml(t.backToTop) + '</button>' +
+      '</div>';
   }
 
   function timelineHtml(lang, activeDate, windowDays, showAll) {
@@ -397,7 +399,7 @@ title: "Update Log"
     for (var i = 0; i < shown.length; i++) {
       daysHtml += dayHtml(shown[i], lang);
     }
-    var actionsHtml = activeDate ? '' : timelineActionsHtml(lang, shown, windowDays, showAll);
+    var actionsHtml = timelineActionsHtml(lang, shown, windowDays, showAll, activeDate);
     return '<div class="updates-timeline">' +
       '<h2 class="updates-timeline-title">📜 ' + escapeHtml(t.timelineTitle) + '</h2>' +
       filterBar +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

为更新记录页时间线操作区补充与主页折叠一致的「收起」能力，并增加回到顶部快捷入口：

- **收起至 30 天**：当时间线已展开超过默认 30 天窗口，或已「展开全部记录」时显示；点击后重置为最近 30 天视图。
- **回到顶部**：时间线底部**始终显示**，靠右对齐；点击后平滑滚动至页首。

展开按钮（「再展开 30 天」「展开全部记录」）逻辑不变，仅在仍有更多记录可展开时显示。

## 验收

![修复后：回到顶部按钮靠右常驻](https://cursor.com/artifacts/c/art-16475e14-ee6f-4407-8b34-df7642df933d)

- `pytest tests/test_updates_timeline.py -v` 通过
- 默认 30 天视图下即可见右侧「↑ 回到顶部」；展开全部后左侧显示收起按钮

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26d1f072-9a2b-4f8e-9621-3d91d34ac0f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26d1f072-9a2b-4f8e-9621-3d91d34ac0f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

