### PR TITLE
fix(ux): 移动端更新记录底部按钮改为纵向全宽排列

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2272,6 +2272,32 @@ a.updates-item-link:hover {
   border-color: var(--link-hover);
 }
 
+@media (max-width: 640px) {
+  .updates-timeline-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .updates-timeline-actions-left {
+    flex-direction: column;
+    width: 100%;
+    gap: 8px;
+  }
+  .updates-timeline-more-days,
+  .updates-timeline-show-all,
+  .updates-timeline-collapse,
+  .updates-timeline-back-to-top {
+    width: 100%;
+    padding: 10px 16px;
+    font-size: 0.88rem;
+  }
+  .updates-timeline-back-to-top {
+    margin-left: 0;
+  }
+}
+
 @media (max-width: 600px) {
   .updates-header h1 {
     font-size: 1.4rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

更新记录页（`updates.html`）底部「再展开 30 天 / 展开全部记录 / 收起至 30 天 / 回到顶部」在窄屏下原先横向挤在一行，观感拥挤。参考 [Robotics_Notebooks#946](https://github.com/ImChong/Robotics_Notebooks/pull/946)，在 `max-width: 640px` 下改为纵向全宽按钮，并略收紧内边距与字号。

## 变更类型

- [x] 前端（`assets/css/style.css`）

## 验证

- [x] 本地 `updates.html` 390px 视口截图，底部按钮纵向排列正常

## 验证截图

![移动端更新记录底部按钮纵向排列](https://cursor.com/artifacts/c/art-9a6ffde5-6809-48a0-b907-96bf3f054fc6)

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b05a83f1-f61d-4d15-9b16-b5047d5da060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b05a83f1-f61d-4d15-9b16-b5047d5da060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

