### PR TITLE
Refactor README & sort high-impact papers by displayed date

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,110 +5,16 @@
 [![Papers](https://img.shields.io/badge/Papers-656-orange.svg)](papers/PROGRESS.md)
 [![Notes](https://img.shields.io/badge/Notes-282-green.svg)](papers/)
 
-**来源**: [awesome-humanoid-robot-learning](https://github.com/YanjieZe/awesome-humanoid-robot-learning)
+人形机器人学习方向的每日论文精读笔记，逐篇部署为 [在线网页](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/)。
 
-**📖 待读论文清单**: [papers/PROGRESS.md](papers/PROGRESS.md) — 全量 531 篇论文的阅读进度表（来自上游 awesome 列表）。
-
-**🛠️ 仓库开发待办**: [papers/todos/TODO_v5.md](papers/todos/TODO_v5.md) — 笔记 / 站点 / 工具链的开发任务（最新 v5，侧重脚本健壮性与代码质量，历史版本见 [`papers/todos/`](papers/todos/)）。
-
-## Agent Skills & 工程质量
-
-项目已集成 [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) 生产级工程规范，在后续维护中强制执行以下质量门禁：
-
-- **Spec-driven & TDD**: 关键功能更新必须先有设计规格（Spec）和测试用例。
-- **Code Review**: 所有脚本更新需经过 5 轴审查（正确性、可读性、架构、安全、性能）。
-- **Source-driven**: 实现逻辑必须基于官方文档和最新源码，拒绝"AI 幻想"。
-
-当前正在执行的 **[TODO_v5](papers/todos/TODO_v5.md)** 计划涵盖了：
-1. **安全性**: 修复 YAML 前言生成中的引号转义隐患。
-2. **一致性**: 统一多脚本间的 `is_stub`（草稿判定）阈值。
-3. **健壮性**: 增加全局 UTF-8 编码支持与脚本模块化重构。
-
+**来源**：[awesome-humanoid-robot-learning](https://github.com/YanjieZe/awesome-humanoid-robot-learning) · **待读清单**：[papers/PROGRESS.md](papers/PROGRESS.md)
 
 ## 规则
 
-1. 每天早上 7:00 推送当日论文阅读提醒
-2. 冲回复"理解了"后，才进入下一篇
-3. 如果当天没有回复"理解了"，第二天继续提醒同一篇
-4. 回复"理解了"后，对话记录也会保存到对应的 MD 笔记中
-5. 可以随时说"读下一篇"跳到一篇
-
-## 项目结构
-
-```
-├── papers/                            # 论文笔记（按类别分目录）
-│   ├── 01_Foundational_RL/            # 基础 RL 算法（PPO、AWR、DeepMimic、AMP 等）
-│   ├── 02_Motion_Retargeting/         # 动作重定向（人体骨架 → 机器人骨架）
-│   ├── 03_High_Impact_Selection/      # 高影响力精选论文
-│   ├── 04_Loco-Manipulation_and_WBC/  # 全身控制与移动操作
-│   ├── 05_Locomotion/                 # 行走/跑酷等运动控制
-│   ├── 06_Manipulation/               # 操作与灵巧手
-│   ├── 07_Teleoperation/              # 遥操作
-│   ├── 08_Navigation/                 # 导航
-│   ├── 09_State_Estimation/           # 状态估计
-│   ├── 10_Sim-to-Real/                # 仿真到真实迁移
-│   ├── 11_Simulation_Benchmark/       # 仿真平台与基准测试
-│   ├── 12_Hardware_Design/           # 硬件设计
-│   ├── 13_Physics-Based_Animation/   # 基于物理的角色动画
-│   ├── 14_Human_Motion/              # 人体运动分析与合成
-│   ├── todos/                        # 仓库开发待办归档（TODO_v1/v2/v3/v4.md）
-│   └── PROGRESS.md                   # 全部论文阅读进度表（待读清单）
-├── progress.json                      # 当前阅读进度追踪（JSON）
-├── scripts/                           # 辅助脚本
-│   └── prepare_pages.py              # GitHub Pages 部署预处理
-├── _data/                             # Jekyll 数据文件
-│   └── papers.json                   # 论文索引数据
-├── .github/workflows/                 # CI/CD
-│   └── deploy.yml                   # GitHub Pages 自动部署
-├── _layouts/ _includes/ assets/       # Jekyll 网页模板和样式
-├── _config.yml                        # Jekyll 配置
-└── README.md                          # 本文件
-```
-
-每篇论文的笔记通过 [GitHub Pages](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/) 自动部署为在线网页。
-
-## 源码对照
-
-笔记中涉及的论文，**如果**在 [MimicKit](https://github.com/xbpeng/MimicKit)（xbpeng 大神的运动模仿框架）中有官方实现，笔记会附上「📁 MimicKit 源码对照」章节，包含：
-
-- **关键代码块**：与笔记讲解一一对应的源码（网络结构、loss 计算、训练循环等）
-- **配置示例**：YAML 超参数文件的关键参数说明
-- **训练 / 测试命令**：可一键运行的命令行
-
-> MimicKit 是一个轻量级的运动模仿框架，支持 Isaac Gym / Isaac Lab / Newton 等仿真后端。目前已覆盖：DeepMimic、AMP、AWR、ASE、LCP 等主流算法。源码地址：[https://github.com/xbpeng/MimicKit](https://github.com/xbpeng/MimicKit)
-
-## 笔记说明
-
-每篇笔记采用统一结构，兼顾**深度理解**和**面试准备**：
-
-### 正文部分
-
-| 章节 | 内容 | 示例 |
-|------|------|------|
-| 📋 基本信息 | arXiv、PDF、作者、机构、发表时间 | `arXiv: 1707.06347` |
-| 🎯 一句话总结 | 用一句大白话概括论文核心贡献 | "PPO 通过裁剪机制让策略更新既大胆又安全" |
-| 📌 英文缩写速查 | 论文中出现的术语缩写表 | 放在一句话总结之后、正文之前 |
-| ❓ 要解决什么问题 | 问题背景 + 生活化类比，零基础能看懂 | 用"走台阶 vs 瞎子爬山"类比 PPO vs TRPO |
-| 🔧 方法详解 | 逐步拆解核心方法，配公式、表格、流程图 | 概率比 → 优势函数 → 裁剪机制 → 训练流程 |
-| 🚶 具体实例 | **完整数值走通**：用人形机器人场景演示算法全过程 | 状态设定 → 采样 → GAE 计算 → 裁剪更新 → 训练进展 |
-| 🤖 工程价值 | 为什么这个方法对人形机器人控制重要 | PPO 成为 sim-to-real 首选的原因 |
-| 📁 MimicKit 源码对照 | *(可选，有源码时出现)* 对应的 MimicKit 官方实现代码与配置 | PPO/AWR/LCP 等主流算法均有覆盖 |
-| 🎤 面试高频 Q&A | 5-8 个高频问题 + 参考回答，直接可用 | "PPO 和 TRPO 的区别？""裁剪具体怎么起作用？" |
-| 💬 讨论记录 | 阅读过程中的疑问、讨论和澄清 | surrogate loss 的直觉理解 |
-
-### 附录部分
-
-| 附录 | 内容 |
-|------|------|
-| 算法变体 | 不同版本对比（如 PPO-Clip vs PPO-Penalty） |
-| Loss 完整拆解 | 含各项系数的完整公式 |
-| 网络架构 | Actor-Critic 的典型结构 |
-| 超参数速查表 | 常用超参数及推荐值 |
-| 训练过程可视化 | 各指标随训练的变化趋势 |
-| 实验结果 | 关键实验数据与对比 |
-| 相关工作 | 上下游论文关系 |
-
-> 💡 附录内容因论文而异，不是每篇都有全部附录。核心原则：**有用就写，没必要就省**。
+1. 每天早上 7:00 推送当日论文阅读提醒。
+2. 回复"理解了"才进入下一篇；当天未回复，次日继续同一篇。
+3. 回复"理解了"后，对话记录会一并保存到对应 MD 笔记。
+4. 可随时说"读下一篇"跳到下一篇。
 
 ## 学习路线图
 
@@ -158,13 +64,12 @@
   ↑ sim环境随机化迁移        ↑ 动作平滑，替代低通滤波器
 ```
 
-> 💡 **为什么把动作重定向单列一层**：精确模仿 / 风格学习 / 遥操作（OmniH2O、ExBody2 等）都依赖"人体动作 → 机器人可执行轨迹"的转换；重定向质量直接决定下游策略能学到什么动作，是被很多论文一笔带过、却最容易踩坑的工程环节。
->
-> 🚀 **从 WBC 到基础模型的上行支线**：全身控制（WBC）把底层技能 / 扩散策略落到整机关节后，路线分出**操作（Manipulation）**与**移动操作（Loco-Manipulation）**等分支；它们最终都汇聚到**基础模型终点**——以 GR00T N1 为代表的 **VLA**（视觉-语言-动作）和以 Behavior Foundation Model（BFM-Zero）为代表的 **BFM**（行为基础模型），即"一路从 PPO 上到 VLA / BFM"的顶点。
->
-> 🌍 **世界模型 / 世界-动作模型支线**：**世界模型（World Model）**——DreamDojo、1X World Model、HAIC（动力学感知 WM）——学会预测未来观测与动力学，既能"做梦"生成训练数据、又能做基于模型的规划；再进一步，**世界-动作模型（World Action Model, WAM）**（如 [DreamZero](papers/06_Manipulation/DreamZero_World_Action_Models_are_Zero-shot_Policies/DreamZero_World_Action_Models_are_Zero-shot_Policies.md)）让世界模型本身充当零样本策略，与 VLA / BFM 一同构成"通用机器人大模型"的顶层。
+- **动作重定向单列一层**：精确模仿 / 风格学习 / 遥操作都依赖"人体动作 → 机器人可执行轨迹"的转换，重定向质量直接决定下游策略能学到什么动作。
+- **从 WBC 上行到基础模型**：全身控制把底层技能 / 扩散策略落到整机关节后，分出操作、移动操作、世界模型等支线，最终都汇聚到 VLA（GR00T N1）与 BFM（行为基础模型）这一顶点。
 
-## 源码层面一览（基础强化学习 · 官方仓库与 MimicKit）
+### 基础强化学习 · 官方源码 / MimicKit
+
+笔记涉及的算法，**如果**在 [MimicKit](https://github.com/xbpeng/MimicKit)（xbpeng 的运动模仿框架，支持 Isaac Gym / Isaac Lab / Newton）中有官方实现，会附「📁 MimicKit 源码对照」章节，含关键代码块、YAML 配置与训练 / 测试命令。下表中 ✅ 表示已被 MimicKit 覆盖，❌ 表示有独立官方仓库、不在 MimicKit 内。
 
 | 论文 | 官方源码 | MimicKit | 核心实现 / 入口 |
 |------|----------|:--------:|-----------------|
@@ -179,9 +84,35 @@
 | CALM | [NVlabs/CALM](https://github.com/NVlabs/CALM) | ❌ | IsaacGym 独立实现，不在 MimicKit |
 | PULSE | [ZhengyiLuo/PULSE](https://github.com/ZhengyiLuo/PULSE) | ❌ | `phc/learning/amp_network_z_builder.py`（基于 PHC 扩展） |
 | Diffusion Policy | [columbia-ai-robotics/diffusion_policy](https://github.com/columbia-ai-robotics/diffusion_policy) | ❌ | 视觉模仿学习框架，与 MimicKit 定位不同 |
-| BeyondMimic | [HybridRobotics/whole_body_tracking](https://github.com/HybridRobotics/whole_body_tracking)（训练）<br>[HybridRobotics/motion_tracking_controller](https://github.com/HybridRobotics/motion_tracking_controller)（部署） | ❌ | Isaac Lab + RSL-RL；引导扩散部分尚未单独开源 |
-| Domain Randomization (2017) | 无官方代码；可参考 [matwilso/domrand](https://github.com/matwilso/domrand) 复现 | N/A | DR 作为通用技术在 MimicKit / Isaac 系 env 的 `events` 中体现 |
-| Understanding DR (2021) | 理论论文，无配套代码 | N/A | — |
+| BeyondMimic | [HybridRobotics/whole_body_tracking](https://github.com/HybridRobotics/whole_body_tracking)（训练）· [motion_tracking_controller](https://github.com/HybridRobotics/motion_tracking_controller)（部署） | ❌ | Isaac Lab + RSL-RL；引导扩散部分尚未单独开源 |
+| Domain Randomization | 无官方代码，可参考 [matwilso/domrand](https://github.com/matwilso/domrand) | N/A | 作为通用技术体现在各 env 的 `events` 中 |
 | MimicKit | [xbpeng/MimicKit](https://github.com/xbpeng/MimicKit) | ✅ | 框架本身，汇总上表 ✅ 项 |
 
-> 注：MimicKit 列打 ✅ 表示该算法在 [MimicKit](https://github.com/xbpeng/MimicKit) 有官方实现，且对应笔记含「📁 MimicKit 源码对照」章节；打 ❌ 表示有独立官方仓库、不在 MimicKit 内。
+### ⭐ 高影响力精选
+
+主线之外的重点补充阅读，按子模块与发表时间（旧→新）排列，跟踪进度见 [PROGRESS.md](papers/PROGRESS.md)：
+
+- **全身控制核心**：[Expressive WBC](https://arxiv.org/abs/2402.16796) · [HOVER](https://arxiv.org/abs/2410.21229) · [ExBody2](https://arxiv.org/abs/2412.13196) · [UH-1](https://arxiv.org/abs/2412.14172) · [HugWBC](https://arxiv.org/abs/2502.03206) · [SONIC](https://arxiv.org/abs/2511.07820)
+- **遥操作与模仿学习**：[OmniH2O](https://arxiv.org/abs/2406.08858) · [iDP3](https://arxiv.org/abs/2410.10803) · [HOMIE](https://arxiv.org/abs/2502.13013)
+- **行走经典**：Learning Quadrupedal Locomotion · [Real-World Humanoid Locomotion](https://arxiv.org/abs/2303.03381) · [Locomotion as Next Token Prediction](https://arxiv.org/abs/2402.19469) · [Humanoid Parkour](https://arxiv.org/abs/2406.10759) · [15-Minute Sim-to-Real](https://arxiv.org/abs/2512.01996) · [ECO](https://arxiv.org/abs/2602.06445)
+- **仿真到现实与基座模型**：[Agile Motor Skills (ANYmal)](https://arxiv.org/abs/1901.08652) · [ASAP](https://arxiv.org/abs/2502.01143) · [GR00T N1](https://arxiv.org/abs/2503.14734) · [Behavior Foundation Model](https://arxiv.org/abs/2509.13780)
+- **仿真平台与工具**：[Humanoid-Gym](https://arxiv.org/abs/2404.05695) · [BEHAVIOR Robot Suite](https://arxiv.org/abs/2503.05652) · Isaac Lab · [ProtoMotions3](https://arxiv.org/abs/2409.14393)
+
+## 笔记说明
+
+每篇笔记结构统一，兼顾深度理解与面试准备：
+
+- **正文**：基本信息 → 一句话总结 → 英文缩写速查 → 问题背景（生活化类比）→ 方法详解（公式 / 图表）→ 具体实例（数值走通）→ 工程价值 →（可选）MimicKit 源码对照 → 面试高频 Q&A → 讨论记录。
+- **附录**（按需）：算法变体、Loss 完整拆解、网络架构、超参数速查表、训练可视化、实验结果、相关工作。
+
+## 项目结构
+
+```
+papers/          # 论文笔记，按方向分 14 个目录（01_基础RL … 14_人体运动）
+                 # 另含 PROGRESS.md（全量进度表）与 todos/（开发待办）
+scripts/         # prepare_pages.py 等预处理 / 部署脚本
+_data/ _includes/ _layouts/ assets/   # Jekyll 站点数据、模板与样式
+_config.yml      # Jekyll 配置（baseurl = /Humanoid_Robot_Learning_Paper_Notebooks）
+```
+
+> 协作与工程规范（Spec/TDD、Code Review、站点构建与截图验收等）见 [AGENTS.md](AGENTS.md)。

--- a/_data/papers.json
+++ b/_data/papers.json
@@ -327,8 +327,8 @@
           }
         ],
         "zhname": "全身控制核心",
-        "sort_order_hint": "Paper tags ordered by arXiv date, oldest first",
-        "sort_order_hint_zh": "论文标签按 arXiv 发表时间旧→新排列"
+        "sort_order_hint": "Paper tags ordered by publication date, oldest first",
+        "sort_order_hint_zh": "论文标签按发表时间旧→新排列"
       },
       {
         "name": "Teleoperation & Imitation Learning",
@@ -370,8 +370,8 @@
           }
         ],
         "zhname": "遥操作与模仿学习",
-        "sort_order_hint": "Paper tags ordered by arXiv date, oldest first",
-        "sort_order_hint_zh": "论文标签按 arXiv 发表时间旧→新排列"
+        "sort_order_hint": "Paper tags ordered by publication date, oldest first",
+        "sort_order_hint_zh": "论文标签按发表时间旧→新排列"
       },
       {
         "name": "Locomotion Classics",
@@ -446,8 +446,8 @@
           }
         ],
         "zhname": "行走经典",
-        "sort_order_hint": "Paper tags ordered by arXiv date, oldest first",
-        "sort_order_hint_zh": "论文标签按 arXiv 发表时间旧→新排列"
+        "sort_order_hint": "Paper tags ordered by publication date, oldest first",
+        "sort_order_hint_zh": "论文标签按发表时间旧→新排列"
       },
       {
         "name": "Sim-to-Real & Foundation Model",
@@ -500,23 +500,12 @@
           }
         ],
         "zhname": "仿真到现实与基座模型",
-        "sort_order_hint": "Paper tags ordered by arXiv date, oldest first",
-        "sort_order_hint_zh": "论文标签按 arXiv 发表时间旧→新排列"
+        "sort_order_hint": "Paper tags ordered by publication date, oldest first",
+        "sort_order_hint_zh": "论文标签按发表时间旧→新排列"
       },
       {
         "name": "Simulation Platform & Tools",
         "papers": [
-          {
-            "title": "Isaac Lab: Unified GPU Simulation Platform for Robot Learning",
-            "path": "papers/03_High_Impact_Selection/Isaac_Lab_GPU_Simulation/Isaac_Lab_GPU_Simulation.md",
-            "url": "/papers/03_High_Impact_Selection/Isaac_Lab_GPU_Simulation/Isaac_Lab_GPU_Simulation.html",
-            "dir": "Isaac_Lab_GPU_Simulation",
-            "has_open_source": true,
-            "published_date_zh": "2025年9月 research page；项目源自 Orbit / Isaac Gym 生态演进",
-            "published_date_en": "Sep 2025 research page; evolved from the Orbit / Isaac Gym ecosystem",
-            "zhname": "Isaac Lab：面向机器人学习的 GPU 仿真统一平台",
-            "zh_title": "Isaac Lab：面向机器人学习的 GPU 仿真统一平台"
-          },
           {
             "title": "Humanoid-Gym: Reinforcement Learning for Humanoid Robot with Zero-Shot Sim2Real Transfer",
             "path": "papers/03_High_Impact_Selection/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer/Humanoid-Gym_Zero-Shot_Sim2Real_Transfer.md",
@@ -530,18 +519,6 @@
             "zh_title": "Humanoid-Gym：面向人形机器人零样本 Sim2Real 的 RL 框架"
           },
           {
-            "title": "ProtoMotions3: An Open-source Framework for Humanoid Simulation and Control",
-            "path": "papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.md",
-            "url": "/papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.html",
-            "dir": "ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control",
-            "arxiv": "2409.14393",
-            "has_open_source": true,
-            "published_date_zh": "2025年12月2日（GitHub v3 发布）",
-            "published_date_en": "Dec 2, 2025 (GitHub v3 release)",
-            "zhname": "ProtoMotions3：面向人形仿真与控制的开源框架",
-            "zh_title": "ProtoMotions3：面向人形仿真与控制的开源框架"
-          },
-          {
             "title": "BEHAVIOR Robot Suite: Streamlining Real-World Whole-Body Manipulation for Everyday Household Activities",
             "path": "papers/03_High_Impact_Selection/BEHAVIOR_Robot_Suite_Streamlining_Real-World_Whole-Body_Manipulation/BEHAVIOR_Robot_Suite_Streamlining_Real-World_Whole-Body_Manipulation.md",
             "url": "/papers/03_High_Impact_Selection/BEHAVIOR_Robot_Suite_Streamlining_Real-World_Whole-Body_Manipulation/BEHAVIOR_Robot_Suite_Streamlining_Real-World_Whole-Body_Manipulation.html",
@@ -552,15 +529,38 @@
             "published_date_en": "Mar 7, 2025 (arXiv), CoRL 2025",
             "zhname": "BEHAVIOR Robot Suite：面向日常家务的实机全身操作框架",
             "zh_title": "BEHAVIOR Robot Suite：面向日常家务的实机全身操作框架"
+          },
+          {
+            "title": "Isaac Lab: Unified GPU Simulation Platform for Robot Learning",
+            "path": "papers/03_High_Impact_Selection/Isaac_Lab_GPU_Simulation/Isaac_Lab_GPU_Simulation.md",
+            "url": "/papers/03_High_Impact_Selection/Isaac_Lab_GPU_Simulation/Isaac_Lab_GPU_Simulation.html",
+            "dir": "Isaac_Lab_GPU_Simulation",
+            "has_open_source": true,
+            "published_date_zh": "2025年9月 research page；项目源自 Orbit / Isaac Gym 生态演进",
+            "published_date_en": "Sep 2025 research page; evolved from the Orbit / Isaac Gym ecosystem",
+            "zhname": "Isaac Lab：面向机器人学习的 GPU 仿真统一平台",
+            "zh_title": "Isaac Lab：面向机器人学习的 GPU 仿真统一平台"
+          },
+          {
+            "title": "ProtoMotions3: An Open-source Framework for Humanoid Simulation and Control",
+            "path": "papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.md",
+            "url": "/papers/03_High_Impact_Selection/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control/ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control.html",
+            "dir": "ProtoMotions3_Open-source_Framework_for_Humanoid_Simulation_and_Control",
+            "arxiv": "2409.14393",
+            "has_open_source": true,
+            "published_date_zh": "2025年12月2日（GitHub v3 发布）",
+            "published_date_en": "Dec 2, 2025 (GitHub v3 release)",
+            "zhname": "ProtoMotions3：面向人形仿真与控制的开源框架",
+            "zh_title": "ProtoMotions3：面向人形仿真与控制的开源框架"
           }
         ],
         "zhname": "仿真平台与工具",
-        "sort_order_hint": "Paper tags ordered by arXiv date, oldest first",
-        "sort_order_hint_zh": "论文标签按 arXiv 发表时间旧→新排列"
+        "sort_order_hint": "Paper tags ordered by publication date, oldest first",
+        "sort_order_hint_zh": "论文标签按发表时间旧→新排列"
       }
     ],
-    "sort_order_hint": "Paper tags ordered by arXiv date, oldest first (same within subcategories)",
-    "sort_order_hint_zh": "论文标签按 arXiv 发表时间旧→新排列（各子模块同理）"
+    "sort_order_hint": "Paper tags ordered by publication date, oldest first (same within subcategories)",
+    "sort_order_hint_zh": "论文标签按发表时间旧→新排列（各子模块同理）"
   },
   "04_Loco-Manipulation_and_WBC": {
     "display_name": "Loco-Manipulation and WBC",

--- a/scripts/prepare_pages.py
+++ b/scripts/prepare_pages.py
@@ -81,6 +81,8 @@ _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
 _MD_CHARS_RE = re.compile(r"[*_`\[\]]")
 _CATEGORY_PREFIX_RE = re.compile(r"^\d+_")
 _ARXIV_ID_PARTS_RE = re.compile(r"^(\d{2})(\d{2})\.(\d{4,5})(?:v\d+)?$")
+# Matches the "YYYY年M月[D日]" prefix of a curated ``published_date_zh`` value.
+_PUBLISHED_DATE_ZH_RE = re.compile(r"(\d{4})\s*年\s*(\d{1,2})\s*月(?:\s*(\d{1,2})\s*日)?")
 _ARXIV_VERSION_SUFFIX_RE = re.compile(r"v\d+$")
 _ARXIV_FALLBACK_RE = re.compile(r"arxiv", re.IGNORECASE)
 _ARXIV_PATTERNS = [
@@ -107,8 +109,8 @@ CATEGORY_SORT_ORDER_HINT = {
         "zh": "论文标签按 arXiv 发表时间旧→新排列",
     },
     "03_High_Impact_Selection": {
-        "en": "Paper tags ordered by arXiv date, oldest first (same within subcategories)",
-        "zh": "论文标签按 arXiv 发表时间旧→新排列（各子模块同理）",
+        "en": "Paper tags ordered by publication date, oldest first (same within subcategories)",
+        "zh": "论文标签按发表时间旧→新排列（各子模块同理）",
     },
 }
 
@@ -118,8 +120,8 @@ DEFAULT_SORT_ORDER_HINT = {
 }
 
 _SUBCATEGORY_SORT_ORDER_HINT = {
-    "en": "Paper tags ordered by arXiv date, oldest first",
-    "zh": "论文标签按 arXiv 发表时间旧→新排列",
+    "en": "Paper tags ordered by publication date, oldest first",
+    "zh": "论文标签按发表时间旧→新排列",
 }
 
 
@@ -657,6 +659,38 @@ def sort_papers_by_arxiv(papers, *, newest_first: bool):
     )
 
 
+def _published_date_sort_key(paper):
+    """Return an oldest-first ``(year, month, day)`` key from the shown date.
+
+    Prefers the human-curated ``published_date_zh`` so notes without an arXiv id
+    (e.g. a simulation platform) and notes dated by a later release than their
+    arXiv preprint (e.g. a GitHub version tag) sort by the date printed on the
+    card. Falls back to the arXiv id, then to a sentinel that sorts first.
+    """
+    m = _PUBLISHED_DATE_ZH_RE.search(paper.get("published_date_zh") or "")
+    if m:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3) or 0))
+    yy, mm, _seq = _arxiv_sort_key(paper.get("arxiv"))
+    if (yy, mm) != (-1, -1):
+        return (2000 + yy, mm, 0)
+    return (-1, -1, -1)
+
+
+def sort_papers_by_published_date(papers):
+    """Sort papers oldest-first by displayed publication date (arXiv fallback).
+
+    Used for high-impact subcategories so the visible dates read strictly
+    old→new, which pure arXiv-id sorting cannot guarantee for entries whose
+    shown date differs from (or lacks) an arXiv id.
+    """
+    papers.sort(
+        key=lambda p: (
+            _published_date_sort_key(p),
+            _order_tiebreaker(p, newest_first=False),
+        )
+    )
+
+
 def parse_high_impact_h_order():
     """Parse PROGRESS.md rows whose first column is ``H1``…``H23``.
 
@@ -997,7 +1031,7 @@ def process_papers():
             entry["papers"] = ungrouped
             if category_dir in CATEGORIES_ARXIV_OLDEST_FIRST:
                 for sc in entry["subcategories"]:
-                    sort_papers_by_arxiv(sc["papers"], newest_first=False)
+                    sort_papers_by_published_date(sc["papers"])
 
         apply_sort_order_hint(entry, category_dir)
 

--- a/tests/test_prepare_pages.py
+++ b/tests/test_prepare_pages.py
@@ -110,6 +110,30 @@ def test_sort_papers_by_arxiv_oldest_first():
     assert [p["title"] for p in papers] == ["old", "new"]
 
 
+def test_sort_papers_by_published_date_uses_shown_date():
+    """Displayed date wins over arXiv id: no-arXiv and release-dated notes
+    sort by the date printed on the card, not by arXiv-id position."""
+    papers = [
+        # No arXiv id, dated ~Sep 2025 — must NOT sort first.
+        {"title": "platform", "published_date_zh": "2025年9月 research page"},
+        {"title": "old", "arxiv": "2404.05695", "published_date_zh": "2024年4月8日（arXiv）"},
+        # arXiv 2409 (Sep 2024) but dated by a Dec 2025 release — must sort last.
+        {"title": "release", "arxiv": "2409.14393", "published_date_zh": "2025年12月2日（GitHub v3 发布）"},
+        {"title": "mid", "arxiv": "2503.05652", "published_date_zh": "2025年3月7日（arXiv）"},
+    ]
+    prepare_pages.sort_papers_by_published_date(papers)
+    assert [p["title"] for p in papers] == ["old", "mid", "platform", "release"]
+
+
+def test_published_date_sort_key_falls_back_to_arxiv():
+    """When no ``published_date_zh`` is present, fall back to the arXiv id."""
+    assert prepare_pages._published_date_sort_key({"arxiv": "2404.05695"}) == (2024, 4, 0)
+    assert prepare_pages._published_date_sort_key(
+        {"published_date_zh": "2020年10月21日"}
+    ) == (2020, 10, 21)
+    assert prepare_pages._published_date_sort_key({}) == (-1, -1, -1)
+
+
 def test_category_sort_policy_constants():
     """Only foundational RL keeps PROGRESS order; motion retargeting & high impact are oldest-first."""
     assert prepare_pages.CATEGORIES_PROGRESS_ORDER == frozenset({"01_Foundational_RL"})
@@ -123,7 +147,7 @@ def test_apply_sort_order_hint_category_and_subcategories():
     entry = {"subcategories": [{"name": "Whole-Body Control Core", "papers": []}]}
     prepare_pages.apply_sort_order_hint(entry, "03_High_Impact_Selection")
     assert "旧→新" in entry["sort_order_hint_zh"]
-    assert entry["subcategories"][0]["sort_order_hint_zh"].startswith("论文标签按 arXiv")
+    assert entry["subcategories"][0]["sort_order_hint_zh"].startswith("论文标签按发表时间")
 
     newest_entry = {}
     prepare_pages.apply_sort_order_hint(newest_entry, "04_Loco-Manipulation_and_WBC")


### PR DESCRIPTION
## Summary
Streamline the README to focus on core learning content and user-facing rules, while improving the paper sorting logic for high-impact selections to respect manually curated publication dates (e.g., GitHub release dates) over arXiv IDs alone.

## Key Changes

### Documentation (README.md)
- **Condensed README**: Removed lengthy sections on engineering quality gates, project structure details, and verbose note-taking guidelines. Kept only essential user-facing information: daily reading rules, learning roadmap, and source code reference table.
- **Reorganized high-impact papers**: Moved the curated paper list (WBC, teleoperation, locomotion, sim-to-real, platforms) into a dedicated "⭐ 高影响力精选" section with clear subsections and arXiv links.
- **Simplified note structure**: Replaced detailed table of note sections with a concise bullet-point summary of the standard structure (正文 → 附录).
- **Updated source code table**: Clarified MimicKit coverage with ✅/❌ notation and simplified descriptions.

### Sorting Logic (scripts/prepare_pages.py)
- **New function `sort_papers_by_published_date()`**: Sorts papers oldest-first by the displayed publication date (from `published_date_zh` field), with fallback to arXiv ID, then to a sentinel. This ensures papers without arXiv IDs (e.g., simulation platforms) and papers dated by release tags (e.g., GitHub v3) sort by the date shown on the card, not by arXiv position.
- **New helper `_published_date_sort_key()`**: Extracts `(year, month, day)` from the curated `published_date_zh` field using regex `_PUBLISHED_DATE_ZH_RE`, enabling precise sorting even when the shown date differs from the arXiv preprint date.
- **Updated sort call**: High-impact subcategories now call `sort_papers_by_published_date()` instead of `sort_papers_by_arxiv(..., newest_first=False)`.
- **Updated sort hints**: Changed "arXiv 发表时间" → "发表时间" in sort order hints to reflect the broader date source.

### Data (\_data/papers.json)
- **Reordered simulation platform papers**: Moved Humanoid-Gym and BEHAVIOR Robot Suite before Isaac Lab and ProtoMotions3 to reflect chronological order by displayed date (2024 → 2025 releases).
- **Updated sort hints**: Replaced "arXiv date" with "publication date" in all high-impact subcategory hints.

### Tests (tests/test_prepare_pages.py)
- **New test `test_sort_papers_by_published_date_uses_shown_date()`**: Verifies that papers sort by displayed date (e.g., "2025年9月" or "2025年12月2日") rather than arXiv ID, with correct handling of no-arXiv and release-dated entries.
- **New test `test_published_date_sort_key_falls_back_to_arxiv()`**: Confirms fallback behavior from `published_date_zh` → arXiv ID → sentinel.
- **Updated test assertion**: Changed expected sort hint prefix from "论文标签按 arXiv" to "论文标签按发表时间".

## Implementation Details
- The regex `_PUBLISHED_DATE_ZH_RE` matches "YYYY年M月[D日]" prefixes, extracting year, month, and optional day. Missing day defaults to 0 for tiebreaking.
- Tiebreaker uses `_order_tiebreaker()` to maintain stable secondary ordering (e.g., by title or original list position).
- Fallback chain: curated date → arXiv ID (converted to YYYY-MM-00) → sentinel (-1, -1, -1) ensures all papers sort deterministically.

https://claude.ai/code/session_01HwFXpkygWPcSdmx4VYxiEm