### PR TITLE
fix(Updates): 热力图固定 53 周滑动窗口

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1954,17 +1954,17 @@ body.sponsor-dialog-open {
   padding: 2px;
 }
 
-/* Fluid width: 53 columns of minmax(floor, 1fr) share the row; on narrow
-   screens cells hit the floor, min-width kicks in and the wrapper scrolls
-   (anchored to the newest week via scrollLeft). */
+/* Fluid width: exactly 53 week columns share the row; on narrow screens cells
+   hit the floor, min-width kicks in and the wrapper scrolls (anchored to the
+   newest week via scrollLeft). */
 .updates-heatmap-inner {
   min-width: max-content;
+  max-width: 100%;
 }
 
 .updates-heatmap-months {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(var(--hm-cell-min), 1fr);
+  grid-template-columns: repeat(53, minmax(var(--hm-cell-min), 1fr));
   gap: var(--hm-gap);
   margin-left: calc(26px + var(--hm-gap));
   height: 18px;
@@ -2000,8 +2000,8 @@ body.sponsor-dialog-open {
   min-width: 0;
   display: grid;
   grid-auto-flow: column;
+  grid-template-columns: repeat(53, minmax(var(--hm-cell-min), 1fr));
   grid-template-rows: repeat(7, auto);
-  grid-auto-columns: minmax(var(--hm-cell-min), 1fr);
   gap: var(--hm-gap);
 }
 

--- a/tests/test_updates_heatmap.py
+++ b/tests/test_updates_heatmap.py
@@ -1,0 +1,25 @@
+"""Update log heatmap: fixed 53-week sliding window."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UPDATES = ROOT / "updates.html"
+STYLE = ROOT / "assets" / "css" / "style.css"
+
+
+def test_updates_heatmap_fixed_week_window():
+    text = UPDATES.read_text(encoding="utf-8")
+    assert "var WEEKS = 53" in text
+    assert "for (var week = 0; week < WEEKS; week++)" in text
+    assert "heatmapStartMs = heatmapLastWeekStartMs - (WEEKS - 1) * 7 * DAY_MS" in text
+    assert 'data-weeks="' in text
+    assert "sliding window" in text
+    assert "weekMs <= endWeekStartMs" not in text
+
+
+def test_updates_heatmap_css_locked_columns():
+    css = STYLE.read_text(encoding="utf-8")
+    assert "grid-template-columns: repeat(53, minmax(var(--hm-cell-min), 1fr))" in css
+    assert "grid-auto-flow: column" in css
+    assert ".updates-heatmap-grid" in css
+    assert ".updates-heatmap-months" in css

--- a/updates.html
+++ b/updates.html
@@ -40,7 +40,8 @@ title: "Update Log"
 
   var BASE = {{ site.baseurl | jsonify }} || '';
   var DAY_MS = 24 * 60 * 60 * 1000;
-  // GitHub-style fixed one-year window: 53 week columns, newest week rightmost.
+  // GitHub-style sliding window: exactly 53 week columns; as new days appear on
+  // the right, the same number of days drop off the left (never grow from min date).
   var WEEKS = 53;
   var FOLD_SHOW = 12;
   var FOLD_LIMIT = 14;
@@ -181,19 +182,23 @@ title: "Update Log"
     return 4;
   }
 
-  // Window ends at the later of today (viewer's local date) and the newest
-  // data day, so freshly generated data is always inside the grid.
+  function mondayWeekStartMs(ms) {
+    // getUTCDay(): 0 = Sunday → Monday-first row index is (day + 6) % 7.
+    return ms - ((new Date(ms).getUTCDay() + 6) % 7) * DAY_MS;
+  }
+
+  // Right edge = later of viewer-local today and newest data day; left edge is
+  // always exactly WEEKS columns earlier (sliding window, not earliest commit).
   var now = new Date();
   var todayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
-  var endMs = Math.max(todayMs, maxMs);
-  // getUTCDay(): 0 = Sunday → Monday-first row index is (day + 6) % 7.
-  var endWeekStartMs = endMs - ((new Date(endMs).getUTCDay() + 6) % 7) * DAY_MS;
-  var startMs = endWeekStartMs - (WEEKS - 1) * 7 * DAY_MS;
+  var heatmapEndMs = Math.max(todayMs, maxMs);
+  var heatmapLastWeekStartMs = mondayWeekStartMs(heatmapEndMs);
+  var heatmapStartMs = heatmapLastWeekStartMs - (WEEKS - 1) * 7 * DAY_MS;
 
   var yearTotal = 0;
   days.forEach(function(day) {
     var ms = parseDateMs(day.d);
-    if (ms !== null && ms >= startMs && ms <= endMs) yearTotal += dayCount(day);
+    if (ms !== null && ms >= heatmapStartMs && ms <= heatmapEndMs) yearTotal += dayCount(day);
   });
 
   function noteTitle(note, lang) {
@@ -230,9 +235,8 @@ title: "Update Log"
     var monthsHtml = '';
     var prevMonth = -1;
     var lastLabelWeek = -2;
-    var week = 0;
-
-    for (var weekMs = startMs; weekMs <= endWeekStartMs; weekMs += 7 * DAY_MS, week++) {
+    for (var week = 0; week < WEEKS; week++) {
+      var weekMs = heatmapStartMs + week * 7 * DAY_MS;
       var month = new Date(weekMs).getUTCMonth();
       var monthLabel = '';
       if (month !== prevMonth) {
@@ -247,7 +251,7 @@ title: "Update Log"
 
       for (var row = 0; row < 7; row++) {
         var dayMs = weekMs + row * DAY_MS;
-        if (dayMs > endMs) {
+        if (dayMs > heatmapEndMs) {
           cellsHtml += '<span class="updates-heatmap-cell is-pad" aria-hidden="true"></span>';
           continue;
         }
@@ -284,7 +288,7 @@ title: "Update Log"
       '<div class="updates-heatmap-months" aria-hidden="true">' + monthsHtml + '</div>' +
       '<div class="updates-heatmap-body">' +
       '<div class="updates-heatmap-weekdays" aria-hidden="true">' + weekdaysHtml + '</div>' +
-      '<div class="updates-heatmap-grid" role="group" aria-label="' + escapeHtml(t.heatmapAria) + '">' +
+      '<div class="updates-heatmap-grid" data-weeks="' + WEEKS + '" role="group" aria-label="' + escapeHtml(t.heatmapAria) + '">' +
       cellsHtml +
       '</div></div></div></div>' +
       '<div class="updates-heatmap-legend">' +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

更新记录页热力图若随数据日期范围向右扩展、左侧不裁剪，列数会持续增长，页面越来越宽。

## 修复

- **JS**：右缘锚定到「今日 / 最新数据日」所在周，左缘始终为恰好 **53 个周列**（GitHub 同款一年滑动窗口）；循环改为 `for (week = 0; week < WEEKS; week++)`，避免按起止毫秒差推算时列数漂移。
- **CSS**：`.updates-heatmap-grid` / `.updates-heatmap-months` 使用 `grid-template-columns: repeat(53, …)` 锁定列数，保留 `grid-auto-flow: column` 与按周填充的 DOM 顺序一致。
- **测试**：新增 `tests/test_updates_heatmap.py` 校验固定窗口逻辑与样式约束。

## 验收

![修复后：更新记录热力图固定 53 周列](https://cursor.com/artifacts/c/art-2d4b4807-cdea-4fff-9ad1-5c8def3a544f)

本地 `pytest tests/test_updates_heatmap.py tests/test_updates_timeline.py -v` 全部通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3491fc4-a727-4c18-a9be-3c47d05a0663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3491fc4-a727-4c18-a9be-3c47d05a0663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

