### PR TITLE
Add Humanoid-GPT paper to Teleoperation section

### DIFF
--- a/papers/PROGRESS.md
+++ b/papers/PROGRESS.md
@@ -427,7 +427,7 @@
 | 542  | [Learning Versatile Humanoid Manipulation with Touch Dreaming](https://arxiv.org/abs/2604.13015) ✅ [笔记](06_Manipulation/HTD__Learning_Versatile_Humanoid_Manipulation_with_Touch_Dreaming/HTD__Learning_Versatile_Humanoid_Manipulation_with_Touch_Dreaming.md) | 2026.04 | 2026-06-16 | ✅ 已总结 |
 
 
-### Teleoperation（24篇）
+### Teleoperation（25篇）
 
 
 | #   | 论文                                                                                                                                                             | 日期      | 🌟  | 状态   |
@@ -456,6 +456,7 @@
 | 535  | [EgoPoser: Robust Real-Time Egocentric Pose Estimation from Sparse and Intermittent Observations Everywhere](https://arxiv.org/pdf/2308.06493) 🌟              | ECCV 2024 |     | ⏳ 待读 |
 | 536  | [AvatarPoser: Articulated Full-Body Pose Tracking from Sparse Motion Sensing](https://arxiv.org/abs/2207.13784) 🌟                                             | ECCV 2022 |     | ⏳ 待读 |
 | 537  | [A Mobile Robot Hand-Arm Teleoperation System by Vision and IMU](https://arxiv.org/pdf/2003.05212) 🌟                                                          | IROS 2020 |     | ⏳ 待读 |
+| 555  | [Humanoid-GPT: Scaling Data and Structure for Zero-Shot Motion Tracking](https://arxiv.org/abs/2606.03985) 🌟                                                   | 2026.06 |     | ⏳ 待读 |
 
 
 ### Navigation（19篇）


### PR DESCRIPTION
## Summary
Updated the PROGRESS.md file to include a new paper in the Teleoperation section and incremented the section count.

## Changes Made
- Incremented the Teleoperation section count from 24 to 25 papers
- Added new paper entry: "Humanoid-GPT: Scaling Data and Structure for Zero-Shot Motion Tracking" (arxiv 2606.03985, June 2026)
  - Assigned paper ID #555
  - Marked as featured (🌟)
  - Status set to "待读" (to be read)

## Details
This addition expands the Teleoperation research collection with a recent paper focusing on zero-shot motion tracking for humanoid systems using GPT-based approaches.

https://claude.ai/code/session_011MST9M7tAjdiHoWNp3GvKT