### PR TITLE
docs(13_Physics-Based_Animation): 新增 BFMTrack 潜空间序列优化物理动作追踪论文笔记并同步进度

### DIFF
--- a/_data/papers.json
+++ b/_data/papers.json
@@ -3075,6 +3075,17 @@
     "display_name": "Physics-Based Animation",
     "papers": [
       {
+        "title": "BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models",
+        "path": "papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking.md",
+        "url": "/papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking.html",
+        "dir": "BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking",
+        "arxiv": "2606.25056",
+        "published_date_zh": "2026年6月23日（arXiv v1）",
+        "published_date_en": "Jun 23, 2026 (arXiv v1)",
+        "zhname": "BFMTrack：用潜空间序列优化让行为基础模型做物理动作追踪",
+        "zh_title": "BFMTrack：用潜空间序列优化让行为基础模型做物理动作追踪"
+      },
+      {
         "title": "Iterative Closed-Loop Motion Synthesis for Scaling the Capabilities of Humanoid Control",
         "path": "papers/13_Physics-Based_Animation/Iterative_Closed-Loop_Motion_Synthesis/Iterative_Closed-Loop_Motion_Synthesis.md",
         "url": "/papers/13_Physics-Based_Animation/Iterative_Closed-Loop_Motion_Synthesis/Iterative_Closed-Loop_Motion_Synthesis.html",

--- a/papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking.md
+++ b/papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking.md
@@ -1,0 +1,206 @@
+---
+layout: paper
+paper_order: 9
+title: "BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models"
+zhname: "BFMTrack：用潜空间序列优化让行为基础模型做物理动作追踪"
+category: "物理动画"
+---
+
+# BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models
+**把行为基础模型（BFM）冻结不动，只在潜空间里优化一条「时间相关」的潜向量序列，就能让它精确追踪动作——无需任何奖励工程**
+
+> 📅 阅读日期: 2026-07-19
+>
+> 🏷️ 板块: 13 Physics-Based Animation · 行为基础模型 / 动作追踪 / 潜空间优化 / Sim-to-Real
+>
+> 🔁 推进轨: 模块轮转（12_Hardware_Design → **13_Physics-Based_Animation**）
+
+---
+
+## 📋 基本信息
+
+| 项目 | 链接 |
+|---|---|
+| arXiv | [2606.25056](https://arxiv.org/abs/2606.25056) |
+| HTML | [在线阅读](https://arxiv.org/html/2606.25056v1) |
+| PDF | [下载](https://arxiv.org/pdf/2606.25056) |
+| 作者 | Thomas Rupf, Agon Serifi, David Müller, Sammy Christen, Ruben Grandia, Espen Knoop, Moritz Bächer |
+| 机构 | Disney Research（苏黎世） |
+| 平台 | Isaac Sim · SMPL 人形（69 DoF）· Lima 双足机器人（20 DoF） |
+| **发布时间** | 2026-06-23（arXiv v1） |
+| 源码 | 论文未公开代码/项目页（截至写入时未见官方仓库） |
+
+---
+
+## 🎯 一句话总结
+
+**行为基础模型（BFM）擅长「静态目标」（到达某姿态、优化状态奖励），却不擅长「随时间变化的目标」——比如追踪一整段动作。** 现有做法用「滑动窗口平均」把未来若干帧的潜向量取平均，粗暴地丢掉了窗口内的时间顺序：窗口大则平滑但抹掉快速转换，窗口小则精确但缺乏预判。BFMTrack 的思路是**冻结预训练的 BFM，只优化一条潜向量序列 `{z_t}`**：用 BFM 自带的 backward map 给序列初始化并提供「潜空间余弦相似度」追踪奖励，再用策略梯度（REINFORCE + leave-one-out 基线）在仿真里滚动优化，关键是把噪声从「逐帧白噪声」换成**时间相关的有色噪声（pink/red noise）**来保证轨迹平滑。整套优化「自洽」——不需要手工设计任何追踪奖励。
+
+---
+
+## ❓ 要解决什么问题？
+
+BFM（如 Forward-Backward / FB-CPR 框架）通过无监督 RL 训练出一个「潜向量条件策略」`π(s, z)`，一个潜向量 `z` 就对应一种行为。它对时不变任务很好用，但**动作追踪是时变任务**：
+
+- **潜空间不天然支持时序目标**：一个 `z` 编码一种稳态行为，而追踪要求策略在每一帧对齐不断变化的参考姿态；
+- **滑动窗口启发式的两难**：把未来窗口内多个目标的潜向量做平均当作当前 `z`，窗口一大就把快速动作（急停、转身）平滑掉，一小又失去预判上下文；
+- **奖励工程负担**：传统物理追踪要精调任务空间/关节空间的多项追踪+正则奖励，换动作/换角色都要重调。
+
+**本文目标**：不动预训练 BFM，用一种「潜空间序列优化」在无需奖励工程的前提下实现高保真追踪，并覆盖稠密追踪、稀疏关键帧、真机部署三种场景。
+
+---
+
+## 🔧 方法核心
+
+### ① 站在 Forward-Backward（BFM）肩上
+
+FB-CPR 训练出三样东西：潜向量条件策略 `π(s, z)`、把状态映射到潜嵌入的 **backward map `B`**、以及预测动作价值的 forward map `F`。BFMTrack 只用其中的 `π` 和 `B`，**全程冻结不再训练**。
+
+### ② 潜空间序列优化（LSO）：只优化 `{z_t}`
+
+不再为整段动作找「一个」潜向量，而是为每一帧优化「一条」潜向量序列：
+
+- **初始化**：用 backward map 直接把参考姿态嵌进潜空间，`μ_t = B(g_t)`；
+- **采样滚动**：以 `z_t ∼ N(μ_t, σ²I)` 采样 N 条并行轨迹在仿真里 rollout；
+- **潜空间追踪奖励**（无需手工设计）：当前状态与参考姿态在潜空间的余弦相似度
+  `r_t = B(s_t)ᵀB(g_t) / (‖B(s_t)‖·‖B(g_t)‖)`；
+- **更新**：REINFORCE 风格策略梯度 + leave-one-out 基线降方差，更新 `μ_t`，并 L2 归一化投影回单位超球面。
+
+因为初始化和奖励都来自同一个 backward map，整个优化是**自洽的**，不引入额外可调项。
+
+### ③ 时间相关的「有色噪声」：让序列平滑
+
+若逐帧独立采样白噪声，得到的潜序列抖动、动作不连贯。BFMTrack 改为**采样整条时间相关序列**——功率谱密度 `S(f) ∝ 1/f^β` 的有色噪声（β=1 为 pink noise，β=2 为 red noise）：
+
+- β 越大，低频占比越高、序列越平滑；
+- 实验中 **β=1（pink noise）** 在追踪精度与平滑度之间取得最佳平衡。
+
+### ④ 稀疏关键帧 = 同一框架 + 时间正则
+
+把动作先用「关节动能的 Difference-of-Gaussians 显著性」抽出关键帧，只在关键帧上给潜嵌入，中间帧用 **SLERP 球面插值**初始化、追踪奖励置零，靠有色噪声的时间正则把中间补成物理可行的连贯动作。
+
+---
+
+## 🧭 整体框架（mermaid）
+
+<div class="mermaid">
+flowchart TB
+    subgraph BFM["🧊 冻结的行为基础模型 (FB-CPR)"]
+        PI["潜条件策略 π(s, z)"]
+        BMAP["backward map B<br/>状态 → 潜嵌入"]
+    end
+
+    subgraph INIT["🎯 参考动作 → 潜序列初始化"]
+        REF["参考姿态序列 g_t"]
+        MU["μ_t = B(g_t)"]
+        REF --> MU
+        BMAP -.-> MU
+    end
+
+    subgraph LSO["🔁 潜空间序列优化 (LSO)"]
+        NOISE["时间相关有色噪声<br/>S(f) ∝ 1/f^β (pink)"]
+        SAMP["z_t ∼ N(μ_t, σ²) · N 条并行 rollout"]
+        SIM["Isaac Sim 仿真滚动"]
+        REW["潜空间余弦相似度奖励<br/>r_t = cos(B(s_t), B(g_t))"]
+        PG["策略梯度 REINFORCE<br/>+ leave-one-out 基线"]
+        NOISE --> SAMP --> SIM --> REW --> PG
+        PG -->|"更新 μ_t + 投影单位超球"| SAMP
+    end
+
+    subgraph OUT["🚀 三种场景"]
+        DENSE["稠密追踪 (990 AMASS)"]
+        SPARSE["稀疏关键帧 (DoG + SLERP)"]
+        REAL["真机 Lima：跑/跳舞/摔倒恢复"]
+    end
+
+    MU --> SAMP
+    PI -.-> SIM
+    PG --> DENSE
+    PG --> SPARSE
+    PG --> REAL
+
+    style BFM fill:#e6e0f7,stroke:#6a4caf,color:#2a1a4a
+    style INIT fill:#fff7e0,stroke:#d4a017,color:#5a3d00
+    style LSO fill:#e0f7fa,stroke:#0097a7,color:#003f47
+    style OUT fill:#e8fbe8,stroke:#27ae60,color:#0f3d1e
+</div>
+
+---
+
+## 📊 实验与结果
+
+三种评测场景：
+
+- **稠密追踪**：SMPL 人形（69 DoF）与 Lima 双足（20 DoF）复现 990 段 AMASS 动作，逐帧评测；
+- **稀疏关键帧**：用 DoG 显著性抽关键帧，SLERP 插值初始化，中间帧零奖励；
+- **真机部署**：Lima 机器人执行跑步、跳舞等动态动作，并能从摔倒中恢复，靠域随机化实现 sim-to-real。
+
+稠密追踪定量对比（越小越好）：
+
+| 方法 | MPJPE (cm) | MMPJPE (cm) |
+|---|---|---|
+| ER 基线（滑动窗 L=5） | 4.7 | 40.6 |
+| **LSO（β=1, pink noise，本文）** | **3.4** | **32.6** |
+
+- 在 EMD（Earth Mover's Distance）、DTW（动态时间规整）等动作保真指标上同样优于滑动窗基线；
+- **β=1** 在追踪精度与平滑度（MPJAE）之间取得最佳折中；
+- 稀疏关键帧下优于「分段常数潜向量」（转换生硬）与「球面样条参数化」两种基线。
+
+---
+
+## 💡 核心贡献
+
+1. **潜空间序列优化（LSO）**：冻结 BFM，只优化潜序列即可做高保真追踪，性能超过滑动窗启发式，且**完全无需奖励工程**；
+2. **时间相关有色噪声**：把逐帧白噪声换成 pink/red noise，用频域正则天然保证潜序列平滑，是精度-平滑折中的关键旋钮；
+3. **稀疏关键帧扩展**：同一框架 + SLERP 初始化 + 零中间奖励，从少量关键帧补出连贯物理动作，还支持动作拼接；
+4. **真机验证**：在 Lima 双足机器人上完成跑步/跳舞/摔倒恢复的 sim-to-real 迁移。
+
+---
+
+## 🤖 对人形机器人的启示
+
+| 方向 | 影响 |
+|---|---|
+| **复用基础模型** | 不必为每个新任务重训策略：冻结一个通用 BFM，把「新任务」变成潜空间里的一次优化，大幅降低追踪任务的工程与算力门槛 |
+| **奖励自洽** | backward map 同时提供初始化与奖励，避免了物理追踪最痛的「多项奖励精调」，换动作/换角色几乎零改动 |
+| **有色噪声即正则** | 用噪声的频谱（而非额外损失项）来约束轨迹平滑，是一个简洁、可迁移到其他序列优化任务的技巧 |
+| **稀疏输入** | 关键帧 + 插值即可生成连贯动作，契合「用稀疏指令驱动人形」的交互式控制方向 |
+
+---
+
+## ⚠️ 局限与可改进点
+
+- **离线优化、非实时**：每段动作需预先优化（RTX 5090 上「数分钟」），不适合实时交互或机载在线自适应；
+- **依赖大规模数据训 BFM**：FB-CPR 需要有代表性的大动作库，对非人形或风格化角色（缺数据）难以直接套用；
+- **潜空间奖励的天花板**：追踪保真度受 backward map 潜表示质量约束，极端/罕见动作可能表征不足；
+- **暂未开源**：截至写入未见官方代码/项目页，复现需自行搭建 FB-CPR 与 LSO 管线。
+
+---
+
+## 🎤 面试参考
+
+**Q：为什么 BFM 不擅长动作追踪？BFMTrack 怎么补上的？**
+A：一个潜向量 `z` 编码一种稳态行为，动作追踪却是逐帧变化的时变目标；滑动窗平均会丢掉窗口内的时间顺序，导致快速动作被抹平。BFMTrack 不改 BFM，而是把「找一个 z」升级成「优化一条随时间变化的潜序列 `{z_t}`」，用仿真滚动 + 策略梯度去拟合参考动作。
+
+**Q：追踪奖励是怎么来的？为什么说「无需奖励工程」？**
+A：用 BFM 自带的 backward map `B` 把当前状态和参考姿态各映射到潜空间，奖励就是两者的余弦相似度。初始化 `μ_t=B(g_t)` 也来自同一个 `B`，整个流程自洽，不需要人工设计任务空间/关节空间的多项追踪奖励。
+
+**Q：为什么要用有色噪声而不是普通高斯白噪声？**
+A：逐帧独立的白噪声会让优化出的潜序列抖动、动作不连贯。有色噪声（PSD ∝ 1/f^β）加大低频占比，天然让相邻帧相关、轨迹平滑；β 就是精度与平滑之间的旋钮，实验中 β=1（pink noise）最佳。
+
+**Q：稀疏关键帧场景是怎么做的？**
+A：用关节动能的 DoG 显著性抽出关键帧，只在关键帧给潜嵌入，中间帧用 SLERP 球面插值初始化且追踪奖励置零，靠有色噪声的时间正则把中间补成连贯的物理可行动作。
+
+---
+
+## 🔗 相关阅读
+
+- [Behavior Foundation Model for Humanoid Robots](../../03_High_Impact_Selection/Behavior_Foundation_Model_for_Humanoid_Robots/Behavior_Foundation_Model_for_Humanoid_Robots.html) — 本文所依赖的 BFM 范式在人形控制中的代表工作
+- [Fast Adaptation with Behavioral Foundation Models (2025)](https://arxiv.org/abs/2504.07896) — 同样围绕「冻结 BFM + 下游快速适配」的思路
+- [DeepMimic (SIGGRAPH 2018)](https://arxiv.org/abs/1804.02717) — 传统「显式奖励」物理动作追踪范式，与本文「潜空间自洽奖励」形成对照
+- [Perpetual Humanoid Control (ICCV 2023)](https://arxiv.org/abs/2305.06456) — 通用动作追踪策略代表作
+- [AMASS 数据集](https://amass.is.tue.mpg.de/) — 本文稠密追踪的参考动作来源
+
+---
+
+> 备注：本笔记基于 arXiv 摘要与 HTML v1 版整理；具体定量数值（MPJPE / MMPJPE / EMD / DTW 等）以官方 PDF 为准。截至写入时未见官方代码/项目页，若后续开源可在「基本信息」表补充仓库链接。机构信息以 arXiv 作者单位为准（Disney Research, Zurich）。

--- a/progress.json
+++ b/progress.json
@@ -41,16 +41,28 @@
     "13_Physics-Based_Animation",
     "14_Human_Motion"
    ],
-   "last_module": "12_Hardware_Design",
+   "last_module": "13_Physics-Based_Animation",
    "last_index": null,
-   "last_title": "MCR-Bionic Hand: Anatomical Structural Priors for Dexterous Manipulation (arXiv:2606.13601)",
-   "next_module": "13_Physics-Based_Animation"
+   "last_title": "BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models (arXiv:2606.25056)",
+   "next_module": "14_Human_Motion"
   },
   "last_summary_index": null,
-  "last_summary_date": "2026-07-18",
-  "last_summary_title": "MCR-Bionic Hand: Anatomical Structural Priors for Dexterous Manipulation",
+  "last_summary_date": "2026-07-19",
+  "last_summary_title": "BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models",
   "next_summary_index": null,
   "log": [
+   {
+    "date": "2026-07-19",
+    "index": "—",
+    "title": "BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models",
+    "folder": "papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking",
+    "module": "13_Physics-Based_Animation",
+    "category": "13_Physics-Based_Animation",
+    "note_path": "papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking.md",
+    "track": "module_rotation",
+    "arxiv": "2606.25056",
+    "source": "Disney Research 苏黎世(Thomas Rupf, Agon Serifi, Ruben Grandia, Espen Knoop, Moritz Bächer 等) · 冻结行为基础模型(FB-CPR)、只在潜空间优化一条随时间变化的潜序列 {z_t} 做物理动作追踪、无需奖励工程 · 潜空间序列优化 LSO：backward map B 提供初始化 μ_t=B(g_t) 与余弦相似度追踪奖励，REINFORCE+leave-one-out 基线策略梯度在 Isaac Sim 滚动更新 · 关键把逐帧白噪声换成时间相关有色噪声(PSD∝1/f^β，pink noise β=1 精度-平滑最优)保证序列平滑 · 三场景:稠密追踪 990 段 AMASS(SMPL 69DoF/Lima 20DoF)、稀疏关键帧(DoG 显著性抽帧+SLERP 插值+零中间奖励)、Lima 双足真机跑/跳舞/摔倒恢复 sim-to-real · 稠密 MPJPE 3.4cm vs 滑动窗基线 4.7cm · 局限:离线优化(RTX5090 数分钟)非实时、FB-CPR 依赖大动作库 · 截至写入未见公开代码/项目页 · 模块轮转（13_Physics-Based_Animation → 14_Human_Motion）"
+   },
    {
     "date": "2026-07-18",
     "index": "—",


### PR DESCRIPTION
## 概述

按模块轮转推进「每日论文总结」（12_Hardware_Design → **13_Physics-Based_Animation**），新增 **BFMTrack** 论文笔记，并同步 `progress.json` 与自动生成的 `_data/papers.json`。

## 本次论文

**BFMTrack: Latent Sequence Optimization for Physics-Based Motion Tracking with Behavioral Foundation Models**（arXiv:2606.25056，Disney Research 苏黎世，2026-06）

- 📄 [arXiv](https://arxiv.org/abs/2606.25056) · [HTML](https://arxiv.org/html/2606.25056v1) · [PDF](https://arxiv.org/pdf/2606.25056)
- 💻 源码：截至写入未见公开代码/项目页

### 一句话
冻结预训练的行为基础模型（BFM，FB-CPR），**只在潜空间里优化一条随时间变化的潜向量序列 `{z_t}`** 来做物理动作追踪——backward map 同时提供初始化 `μ_t=B(g_t)` 与「潜空间余弦相似度」追踪奖励，配合 REINFORCE + leave-one-out 基线在 Isaac Sim 滚动更新，关键把逐帧白噪声换成**时间相关有色噪声（pink noise，β=1）**保证轨迹平滑。全程**无需奖励工程**。

### 要点
- 三种评测场景：稠密追踪（990 段 AMASS，SMPL 69DoF / Lima 20DoF）、稀疏关键帧（DoG 显著性抽帧 + SLERP 插值 + 零中间奖励）、Lima 双足真机跑/跳舞/摔倒恢复的 sim-to-real。
- 稠密追踪 MPJPE 3.4cm，优于滑动窗基线 4.7cm。
- 局限：离线优化（RTX 5090 数分钟）非实时；FB-CPR 依赖大规模动作库。
- 笔记含一句话总结、方法核心、整体框架 **mermaid 流程图**、实验结果、启示、局限与面试参考。

## 改动文件
- `papers/13_Physics-Based_Animation/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking/BFMTrack__Latent_Sequence_Optimization_for_Physics-Based_Motion_Tracking.md`（新增笔记）
- `progress.json`（新增每日总结日志、模块轮转推进至 `next_module = 14_Human_Motion`）
- `_data/papers.json`（`prepare_pages.py` 自动重新生成）

## 自检
- ✅ `python3 scripts/prepare_pages.py` 通过，`zh_title` 正确识别为论文名称
- ✅ `pytest tests/test_prepare_pages.py tests/test_mermaid_adaptation.py tests/test_roadmap_quality.py` 全部通过（27 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ziFTnfGbfSutv4TsUjh3P

---
_Generated by [Claude Code](https://claude.ai/code/session_015ziFTnfGbfSutv4TsUjh3P)_