### PR TITLE
fix(Mermaid): 修复 sequenceDiagram 中 &lt;br/&gt; 导致的语法错误

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,7 +78,7 @@
       mermaid.initialize(config);
       window.roadmapMermaidConfigured = true;
       
-      // 1. Snapshot source once (keep <br> as newlines); re-render from snapshot on theme changes.
+      // 1. Snapshot source once (restore <br> as literal <br/>); re-render from snapshot on theme changes.
       document.querySelectorAll('.mermaid:not(#roadmap-mermaid)').forEach(function(el) {
         var readSource =
           typeof window.readMermaidBlockSource === 'function'

--- a/assets/js/mermaid-config.js
+++ b/assets/js/mermaid-config.js
@@ -134,14 +134,21 @@
   window.MERMAID_RENDER_SCALE = MERMAID_RENDER_SCALE;
   window.MERMAID_LIGHTBOX_SCALE = MERMAID_LIGHTBOX_SCALE;
 
-  /** Preserve <br> line breaks when snapshotting Mermaid source from built HTML. */
+  /**
+   * Preserve <br> line breaks when snapshotting Mermaid source from built HTML.
+   *
+   * Jekyll emits author-written `<br/>` as real <br> DOM nodes. We must restore
+   * the literal `<br/>` tag (not a newline): flowcharts accept either form inside
+   * quoted labels, but sequenceDiagram `participant … as Alias<br/>…` becomes a
+   * hard parse error if the break is turned into a line split.
+   */
   window.readMermaidBlockSource = function (el) {
     if (!el) return '';
     var stored = el.getAttribute('data-original-code');
     if (stored) return stored;
     var clone = el.cloneNode(true);
     clone.querySelectorAll('br').forEach(function (br) {
-      br.replaceWith(document.createTextNode('\n'));
+      br.replaceWith(document.createTextNode('<br/>'));
     });
     return clone.textContent.trim();
   };

--- a/tests/test_mermaid_config.py
+++ b/tests/test_mermaid_config.py
@@ -72,3 +72,38 @@ def test_sanitize_mermaid_svg_keeps_foreign_object():
     assert "sanitizeMermaidSvg" in text
     assert "foreignObject" in text
     assert "USE_PROFILES" in text
+
+
+def test_read_mermaid_block_source_restores_br_tag_not_newline():
+    """sequenceDiagram participant aliases use <br/>; converting to \\n breaks parse."""
+    text = CONFIG_JS.read_text(encoding="utf-8")
+    assert "readMermaidBlockSource" in text
+    assert "createTextNode('<br/>')" in text
+    assert "createTextNode('\\n')" not in text
+    # Regression note must stay so future edits don't reintroduce \\n.
+    assert "sequenceDiagram" in text
+
+
+def test_foundational_rl_sequence_diagrams_use_br_in_participants():
+    """PR #387 sequence diagrams rely on <br/> in participant aliases surviving the site pipeline."""
+    import re
+
+    seq_files = list(
+        (ROOT / "papers" / "01_Foundational_RL").rglob("*.md")
+    )
+    found = 0
+    for path in seq_files:
+        text = path.read_text(encoding="utf-8")
+        for block in re.findall(
+            r'<div class="mermaid"[^>]*>(.*?)</div>', text, re.DOTALL
+        ):
+            if not block.lstrip().startswith("sequenceDiagram"):
+                continue
+            found += 1
+            assert "<br" in block, f"{path.name}: sequence diagram missing <br> aliases"
+            # No raw newline mid-participant (would already be broken in source)
+            for line in block.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("participant ") and "<br" in stripped:
+                    assert stripped.count("<br") >= 1
+    assert found >= 10, f"expected ≥10 sequence diagrams from PR #387, found {found}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

修复 [PR #387](https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks/pull/387) 新增的 13 张源码运行时序图在网页上全部报 Mermaid 语法错误的问题。

## Root cause

站点 `readMermaidBlockSource`（`assets/js/mermaid-config.js`）在从已渲染 HTML 快照 Mermaid 源码时，把 DOM 中的 `<br>` **转成换行符 `\n`**。这对 flowchart 引号节点标签是安全的，但会把 sequenceDiagram 的：

```text
participant AG as PPOAgent<br/>(ppo_agent.py)
```

拆成两行，导致全部 13 张时序图解析失败。

## Fix

- 将 `<br>` 还原为字面量 `<br/>`（与作者 Markdown 及 Mermaid 11.4.1 行为一致）
- 补充回归测试，防止再次改回 `\n`

## Verification

- `pytest` mermaid 相关用例通过
- Mermaid 11.4.1 模拟「HTML 解析 → readMermaidBlockSource → parse」：13/13 OK
- 本地 `jekyll serve` + headless Chrome：13/13 张 sequenceDiagram 均有 SVG、无 Syntax error；同页 flowchart 未回归

### 渲染验收截图

修复后：PPO 源码运行时序图（含 `<br/>` 参与者别名）

![修复后：PPO sequenceDiagram](https://cursor.com/artifacts/c/art-d39c1d47-9d3b-4354-964a-a621066a47ce)

修复后：BeyondMimic 源码运行时序图

![修复后：BeyondMimic sequenceDiagram](https://cursor.com/artifacts/c/art-46ca5030-5af1-4941-a81f-693d2a0f049b)

页面视口（PPO 时序图段落）

![修复后：PPO 时序图页面视口](https://cursor.com/artifacts/c/art-faf4c4ca-309f-4a1c-8ebc-b28f392fc08e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fb10041-517f-48b6-83a7-378e34385741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fb10041-517f-48b6-83a7-378e34385741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

