### PR TITLE
style(Mermaid): PC 端灯箱接近全屏，仅保留窗口边缘间隙

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -920,6 +920,14 @@ body.mermaid-lightbox-open {
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
 }
 
+@media (min-width: 1201px) {
+  .mermaid-lightbox__panel {
+    width: calc(100vw - 2rem);
+    height: calc(100vh - 2rem);
+    padding: 0.6rem 0.85rem 0.85rem;
+  }
+}
+
 .mermaid-lightbox__close {
   position: absolute;
   top: 0.45rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

PC 端（`min-width: 1201px`）Mermaid 灯箱由原先 `min(96vw, 1200px) × min(92vh, 900px)` 改为接近全屏：

- 宽度：`calc(100vw - 2rem)`（左右各约 1rem 间隙）
- 高度：`calc(100vh - 2rem)`（上下各约 1rem 间隙）
- 内边距略收紧，把更多空间留给图表视口

平板与移动端仍沿用原有基础尺寸，不受影响。

## 验收

1440×900 桌面视口打开 HOMIE 论文 Mermaid 图灯箱：

![修复后：PC 端 Mermaid 灯箱接近全屏（1440×900）](https://cursor.com/artifacts/c/art-446374b0-3fe4-4a22-bf1f-14957193ef81)

## 测试

- `pytest tests/test_mermaid_config.py -v` 全部通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b53571a-91c6-4657-b2ed-6d4ccab6b8c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b53571a-91c6-4657-b2ed-6d4ccab6b8c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

