### PR TITLE
docs(01_Foundational_RL): 为基础强化学习模块笔记新增类图、状态图与 xychart

### DIFF
--- a/papers/01_Foundational_RL/ADD_Adversarial_Differential_Discriminators/ADD_Adversarial_Differential_Discriminators.md
+++ b/papers/01_Foundational_RL/ADD_Adversarial_Differential_Discriminators/ADD_Adversarial_Differential_Discriminators.md
@@ -402,6 +402,43 @@ ADD 更偏“目标跟踪驱动器”。
 
 ADD 在 MimicKit 里已经有官方实现，而且实现很清楚：**它就是在 AMPAgent 基础上，把判别器输入从“动作片段本身”改成了“参考与当前的差值”。**
 
+### 源码类图：ADD 对 AMP 的最小增量
+
+先看静态结构（接着 AMP 笔记的类图往下长）。`ADDModel` 几乎是空的——网络结构与 AMP 完全一致，全部改动都在 **Agent 侧的数据流**：判别器喂什么、正负样本怎么造：
+
+<div class="mermaid">
+classDiagram
+    class AMPAgent {
+        amp_agent.py
+        #_compute_disc_loss() 真样本=mocap
+    }
+    class ADDAgent {
+        add_agent.py
+        #_build_pos_diff() 正样本=全0差向量
+        #_record_data_post_step() 记录diff
+        #_compute_rewards() 奖励全靠判别器
+        #_compute_disc_loss() 负样本=当前diff+replay
+    }
+    class AMPModel {
+        amp_model.py
+        +eval_disc(disc_obs)
+    }
+    class ADDModel {
+        add_model.py 仅改输入维度
+    }
+    class DiffNormalizer {
+        diff_normalizer.py
+        位置/角度/速度分量纲归一化
+    }
+    AMPAgent <|-- ADDAgent : 继承
+    AMPModel <|-- ADDModel : 继承
+    ADDAgent o-- ADDModel : _model
+    ADDAgent o-- DiffNormalizer : 归一化差向量
+</div>
+
+- 对照 AMP 类图看增量：判别器输入从 $(s_t, s_{t+1})$ 状态对变成 `tar_disc_obs − disc_obs` 差向量；真样本从 mocap 片段变成**固定的全 0 张量**。
+- `DiffNormalizer` 是 ADD 专属的辅助类——差向量里位置（米）、角度（弧度）、速度量纲不同，必须分量归一化后判别器才学得动。
+
 ### 源码运行时序图
 
 以第 8 节的训练命令 `python mimickit/run.py --mode train --agent_config add_*_agent.yaml` 为入口。`ADDAgent` 继承 `AMPAgent`，时序骨架与 AMP 一致，但**判别器的输入与正负样本构造完全不同**：

--- a/papers/01_Foundational_RL/AMP_Adversarial_Motion_Priors_for_Stylized_Physics-Based_Character_Control/AMP_Adversarial_Motion_Priors_for_Stylized_Physics-Based_Character_Control.md
+++ b/papers/01_Foundational_RL/AMP_Adversarial_Motion_Priors_for_Stylized_Physics-Based_Character_Control/AMP_Adversarial_Motion_Priors_for_Stylized_Physics-Based_Character_Control.md
@@ -548,6 +548,52 @@ AMP 是从"精确模仿"到"风格学习"的关键转折点：
 
 下面按 **PPO 笔记同样的模式**，把 AMP 在 MimicKit 中对应的实现模块对上。说明一下：你当前 workspace 里没有直接放 MimicKit 源码仓，但 `Robotics_Notebooks/Train/MimicKit` 里已经整理过对应代码结构和关键片段，所以这里按那套整理结果做源码映射。
 
+### 源码类图：AMP = PPO + 判别器分支
+
+先看静态结构（接着 PPO 笔记的类图往下长）。AMP 在 Agent 和 Model 两条继承链上各加一层，所有新增成员都围绕**判别器**展开；后续 ASE / ADD 又会从 `AMPAgent` 再往下长：
+
+<div class="mermaid">
+classDiagram
+    class PPOAgent {
+        ppo_agent.py
+        #_compute_actor_loss() PPO-Clip
+        #_compute_critic_loss() MSE
+    }
+    class AMPAgent {
+        amp_agent.py
+        #_build_train_data() 风格奖励替换
+        #_update_model() 增加判别器更新
+        #_compute_disc_loss(batch) 真假二分类+GP
+        #_compute_disc_acc() 判别器准确率
+    }
+    class PPOModel {
+        ppo_model.py
+        +eval_actor(obs)
+        +eval_critic(obs)
+    }
+    class AMPModel {
+        amp_model.py
+        +eval_disc(disc_obs) 判别器打分
+        +get_disc_logit_weights() 用于GP正则
+        #_build_disc(config, env)
+    }
+    class ASEAgent {
+        ase_agent.py 下一篇
+    }
+    class ADDAgent {
+        add_agent.py ADD笔记
+    }
+    PPOAgent <|-- AMPAgent : 继承
+    PPOModel <|-- AMPModel : 继承
+    AMPAgent o-- AMPModel : _model
+    AMPAgent <|-- ASEAgent
+    AMPAgent <|-- ADDAgent
+    AMPAgent ..> MotionLib : 采样真样本 demo
+</div>
+
+- 对照 PPO 类图看增量就够了：**Agent 侧**多了 `_compute_disc_loss()`（真假二分类 + gradient penalty），**Model 侧**多了 `eval_disc()`（第三个网络头）。
+- `ASEAgent`、`ADDAgent` 都继承 `AMPAgent`——这条继承链本身就是论文谱系：PPO → AMP → ASE / ADD。
+
 ### 源码运行时序图
 
 以 `python mimickit/run.py --mode train --agent_config amp_*_agent.yaml` 为入口。AMP 复用 PPO 的训练骨架（`AMPAgent` 继承 `PPOAgent`），额外多出**判别器奖励替换**与**判别器更新**两处：

--- a/papers/01_Foundational_RL/ASE_Adversarial_Skill_Embeddings_for_Large-Scale_Motion_Control/ASE_Adversarial_Skill_Embeddings_for_Large-Scale_Motion_Control.md
+++ b/papers/01_Foundational_RL/ASE_Adversarial_Skill_Embeddings_for_Large-Scale_Motion_Control/ASE_Adversarial_Skill_Embeddings_for_Large-Scale_Motion_Control.md
@@ -430,6 +430,44 @@ ASE 在 MimicKit 里的实现非常适合拿来学，因为它把论文里的三
 2. encoder 从行为片段预测 latent  
 3. diversity loss 保证不同 latent 真对应不同动作
 
+### 源码类图：ASE = AMP + latent 管理 + Encoder
+
+先看静态结构（接着 AMP 笔记的类图往下长）。继承链 `PPOAgent → AMPAgent → ASEAgent` 本身就是论文谱系，ASE 这层的所有新增成员都围绕 **latent z** 展开：
+
+<div class="mermaid">
+classDiagram
+    class AMPAgent {
+        amp_agent.py
+        #_compute_disc_loss() 判别器
+    }
+    class ASEAgent {
+        ase_agent.py
+        #_update_latents() 到期重采样z
+        #_sample_latents(n) 单位球均匀采样
+        #_compute_rewards() 0.5·disc+0.5·enc
+        #_compute_enc_loss(batch) 余弦对齐
+        #_compute_diversity_loss() 防latent塌缩
+    }
+    class AMPModel {
+        amp_model.py
+        +eval_disc(disc_obs)
+    }
+    class ASEModel {
+        ase_model.py
+        +eval_actor(obs, z) 多了z输入
+        +eval_critic(obs, z) 多了z输入
+        +eval_enc(enc_obs) 恢复ẑ
+        #_build_latent_space()
+    }
+    AMPAgent <|-- ASEAgent : 继承
+    AMPModel <|-- ASEModel : 继承
+    ASEAgent o-- ASEModel : _model
+    ASEAgent o-- LatentBuf : 每个env当前的z
+</div>
+
+- 对照 AMP 类图看增量：**Model 侧**的 `eval_actor` / `eval_critic` 签名从 `(obs)` 变成 `(obs, z)`——latent 是策略输入的一等公民；再加一个 `eval_enc()` 头。
+- **Agent 侧**新增的五个方法正好对应论文三件事：latent 管理（`_update_latents` / `_sample_latents`）、编码器目标（`_compute_enc_loss`）、多样性正则（`_compute_diversity_loss`）。
+
 ### 源码运行时序图
 
 以 `python mimickit/run.py --mode train --agent_config ase_*_agent.yaml` 为入口。`ASEAgent` 在 AMP 的骨架上再叠一层 **latent 管理 + Encoder**，一轮训练要同时更新 4 套参数（Actor / Critic / Disc / Enc）：

--- a/papers/01_Foundational_RL/AWR_Advantage_Weighted_Regression/AWR_Advantage_Weighted_Regression.md
+++ b/papers/01_Foundational_RL/AWR_Advantage_Weighted_Regression/AWR_Advantage_Weighted_Regression.md
@@ -284,6 +284,46 @@ AWR 本身在人形机器人控制中不是最常用的算法（PPO 用得更多
 
 以下代码块对应 [MimicKit](https://github.com/xbpeng/MimicKit) 中 AWR 的实现，与上述讲解的各模块一一对应。
 
+### 源码类图：AWR 与 PPO 平行的另一条分支
+
+先看静态结构。和 AMP/ASE 不同，`AWRAgent` **不继承 PPOAgent**，而是与它平行、直接挂在 `BaseAgent` 下——因为 AWR 的 Actor 更新是加权回归，跟 PPO 的概率比裁剪完全是两套逻辑：
+
+<div class="mermaid">
+classDiagram
+    class BaseAgent {
+        base_agent.py 抽象基类
+        +train_model(max_samples)
+        #_rollout_train(num_steps)
+    }
+    class PPOAgent {
+        ppo_agent.py PPO笔记
+        #_compute_actor_loss() 概率比+Clip
+    }
+    class AWRAgent {
+        awr_agent.py
+        #_build_train_data() 优势→指数权重w
+        #_compute_actor_loss() −mean(w·logπ)
+        #_compute_critic_loss() MSE
+        #_get_exp_prob() 探索概率调度
+    }
+    class BaseModel {
+        base_model.py
+    }
+    class AWRModel {
+        awr_model.py
+        +eval_actor(obs)
+        +eval_critic(obs)
+    }
+    BaseAgent <|-- PPOAgent : 平行分支
+    BaseAgent <|-- AWRAgent : 平行分支
+    BaseModel <|-- AWRModel
+    AWRAgent o-- AWRModel : _model
+    AWRAgent o-- ExperienceBuffer : 可复用旧数据
+</div>
+
+- 继承关系直接反映算法关系：AMP/ASE/LCP 都长在 `PPOAgent` 下面（on-policy 家族），AWR 独立成枝——它的 buffer 可以保留旧数据（off-policy 倾向），Actor loss 是监督式的加权最大似然。
+- 读源码抓两处就够：`_build_train_data()` 里的 `w = clamp(exp(Â/β))`，和 `_compute_actor_loss()` 里的加权回归。
+
 ### 源码运行时序图
 
 以 `python mimickit/run.py --mode train` 为入口（agent 配置换成 `*_awr_agent.yaml`），训练时序与 PPO 共享同一骨架，差别集中在 **`_build_train_data()` 里算指数权重、Actor 用加权回归更新**：

--- a/papers/01_Foundational_RL/BeyondMimic/BeyondMimic.md
+++ b/papers/01_Foundational_RL/BeyondMimic/BeyondMimic.md
@@ -337,6 +337,16 @@ flowchart LR
 | 速度跟踪误差（仿真） | 步行 **12.14%**，跑步 **13.65%** |
 | 长跑 | 跑道连续 **50 m+** |
 
+用户研究（N=77）的偏好对比画成图，差距更直观——动作越动态（跑步），BeyondMimic 的自然性优势越大：
+
+<div class="mermaid">
+xychart-beta
+    title "自然性用户偏好（%）：BeyondMimic vs Unitree 原生"
+    x-axis ["整体 BeyondMimic", "整体 Unitree", "跑步 BeyondMimic", "跑步 Unitree"]
+    y-axis "偏好比例（%）" 0 --> 100
+    bar [70.8, 29.2, 84.7, 15.3]
+</div>
+
 ### 扩散控制（阶段 2）
 
 | 任务 | 设置 | 指标 |

--- a/papers/01_Foundational_RL/CALM_Conditional_Adversarial_Latent_Models_for_Directable_Virtual_Characters/CALM_Conditional_Adversarial_Latent_Models_for_Directable_Virtual_Characters.md
+++ b/papers/01_Foundational_RL/CALM_Conditional_Adversarial_Latent_Models_for_Directable_Virtual_Characters/CALM_Conditional_Adversarial_Latent_Models_for_Directable_Virtual_Characters.md
@@ -367,6 +367,23 @@ class FSMScheduler:
         return action
 ```
 
+FSM 本身就是一个状态机，拿 `HumanoidStrikeFSM`（走向目标并攻击）画出来最直观——注意**每个状态里 latent z 的来源不同**，这正是 CALM 分层设计的价值：
+
+<div class="mermaid">
+stateDiagram-v2
+    state "direction_locomotion：HLC 选方向 latent，走向目标" as WALK
+    state "fixed_skill：用 E(攻击动作) 的 latent，执行攻击" as STRIKE
+    state "fixed_skill：用 E(庆祝动作) 的 latent" as WIN
+    [*] --> WALK
+    WALK --> WALK : 距目标 > 攻击范围
+    WALK --> STRIKE : 进入攻击范围
+    STRIKE --> WALK : 目标未倒，重新接近
+    STRIKE --> WIN : 目标倒下
+    WIN --> [*]
+</div>
+
+> 🔑 状态切换条件（距离、目标状态）是**手写的**，但每个状态内的动作全部由预训练策略生成——FSM 只负责"什么时候换 z"，动作质量由 LLC 保证。整个阶段三**零训练**。
+
 ### 5. 训练命令（NVIDIA 官方）
 
 ```bash

--- a/papers/01_Foundational_RL/DeepMimic_Example-Guided_Deep_RL_of_Physics-Based_Character_Skills/DeepMimic_Example-Guided_Deep_RL_of_Physics-Based_Character_Skills.md
+++ b/papers/01_Foundational_RL/DeepMimic_Example-Guided_Deep_RL_of_Physics-Based_Character_Skills/DeepMimic_Example-Guided_Deep_RL_of_Physics-Based_Character_Skills.md
@@ -237,6 +237,28 @@ def sample_time(self, motion_ids, truncate_time=None):
 - **ET** 在失败时快速终止 → 不浪费时间
 - 两者结合：智能体能高效地在各个阶段反复练习，快速迭代
 
+用状态机把一个 episode 的完整生命周期串起来（终止标志对应 MimicKit `base_env.py` 的 `DoneFlags`）：
+
+<div class="mermaid">
+stateDiagram-v2
+    state "RSI 初始化：随机采样参考相位 t₀" as RSI
+    state "跟踪参考动作：π 输出 PD 目标" as TRACK
+    state "FAIL：非脚触地 / 姿态偏离 > 阈值" as FAIL
+    state "SUCC：非循环动作播完" as SUCC
+    state "TIME：循环动作走满 20s" as TIME
+    [*] --> RSI
+    RSI --> TRACK
+    TRACK --> TRACK : 每步算模仿奖励 r_I
+    TRACK --> FAIL : ET 提前终止
+    TRACK --> SUCC : motion_end
+    TRACK --> TIME : timeout
+    FAIL --> RSI : reset（换一个随机相位）
+    SUCC --> RSI : reset
+    TIME --> RSI : reset
+</div>
+
+> 🔑 注意 FAIL 之后不是"回到起点"，而是**重新随机采样相位**——这就是 RSI 和 ET 的配合点：失败得越快，重开得越快，各阶段被练到的次数就越多。
+
 <div class="mermaid">
 flowchart TB
     subgraph noET["无 ET"]
@@ -554,7 +576,60 @@ class KinCharModel():
 
 ## 📁 MimicKit 源码运行时序图
 
-DeepMimic 在 [MimicKit](https://github.com/xbpeng/MimicKit) 中由 `deepmimic_env.py`（RSI / 拼观测 / 5 项奖励 / pose termination）+ `ppo_agent.py`（PPO 更新骨架）组合实现。以 `python mimickit/run.py --mode train` 为入口，一次完整训练的调用时序如下：
+DeepMimic 在 [MimicKit](https://github.com/xbpeng/MimicKit) 中由 `deepmimic_env.py`（RSI / 拼观测 / 5 项奖励 / pose termination）+ `ppo_agent.py`（PPO 更新骨架）组合实现。
+
+### 源码类图：DeepMimic = 环境侧创新
+
+先看静态结构。和 PPO 笔记的类图对照着看会发现一件有意思的事：**DeepMimic 在 MimicKit 里没有自己的 Agent 类**——算法侧直接复用 `PPOAgent`，论文的全部创新（RSI、ET、模仿奖励）都落在**环境继承链**的 `DeepMimicEnv` 里：
+
+<div class="mermaid">
+classDiagram
+    class BaseEnv {
+        envs/base_env.py 抽象基类
+        DoneFlags NULL FAIL SUCC TIME
+    }
+    class SimEnv {
+        sim_env.py
+        物理引擎步进
+    }
+    class CharEnv {
+        char_env.py
+        角色加载 接触检测
+    }
+    class DeepMimicEnv {
+        deepmimic_env.py
+        #_ref_state_init(env_ids) RSI
+        #_compute_obs() 拼前瞻参考帧
+        +compute_reward() 5项指数奖励
+        +compute_done() ET判定
+    }
+    class MotionLib {
+        anim/motion_lib.py
+        +sample_time() 随机采样相位
+        +calc_motion_frame() SLERP插值
+    }
+    class KinCharModel {
+        anim/kin_char_model.py
+        +forward_kinematics()
+    }
+    class PPOAgent {
+        learning/ppo_agent.py
+        直接复用 零改动
+    }
+    BaseEnv <|-- SimEnv
+    SimEnv <|-- CharEnv
+    CharEnv <|-- DeepMimicEnv
+    DeepMimicEnv o-- MotionLib : _motion_lib
+    MotionLib o-- KinCharModel : _kin_char_model
+    PPOAgent ..> DeepMimicEnv : _step_env()
+</div>
+
+- 这个"算法不动、只换环境"的结构是 MimicKit 的通用套路：想读懂一篇模仿学习论文的实现，优先去 `envs/` 找它的环境类，`learning/` 里往往只是复用。
+- 后续 AMP 会同时动两边：环境侧加 `AMPEnv`（提供鉴别器观测），算法侧加 `AMPAgent`（训练鉴别器）。
+
+### 源码运行时序图
+
+以 `python mimickit/run.py --mode train` 为入口，一次完整训练的调用时序如下：
 
 <div class="mermaid">
 sequenceDiagram

--- a/papers/01_Foundational_RL/LCP_Sim-to-Real_Action_Smoothing/LCP_Sim-to-Real_Action_Smoothing.md
+++ b/papers/01_Foundational_RL/LCP_Sim-to-Real_Action_Smoothing/LCP_Sim-to-Real_Action_Smoothing.md
@@ -498,6 +498,36 @@ $$
 
 以下代码块对应 [MimicKit](https://github.com/xbpeng/MimicKit) 中 LCP 的实现，与上述讲解的各模块一一对应。
 
+### 源码类图：LCP 是最薄的一层
+
+先看静态结构（接着 PPO 笔记的类图往下长）。整个 MimicKit 里 LCP 是**改动最小**的算法——`lcp_agent.py` 全文不到 50 行，`LCPModel` 只是改名，真正的新东西只有一个方法：
+
+<div class="mermaid">
+classDiagram
+    class PPOAgent {
+        ppo_agent.py
+        #_compute_actor_loss() PPO-Clip
+    }
+    class LCPAgent {
+        lcp_agent.py 不到50行
+        #_load_params() 读入lcp_weight
+        #_compute_actor_loss() 加一项GP
+        #_compute_lcp_loss() ‖∇ₒ log π‖²
+    }
+    class PPOModel {
+        ppo_model.py
+    }
+    class LCPModel {
+        lcp_model.py 纯继承 零改动
+    }
+    PPOAgent <|-- LCPAgent : 继承
+    PPOModel <|-- LCPModel : 继承
+    LCPAgent o-- LCPModel : _model
+</div>
+
+- 这张图本身就是论文卖点的证明：**平滑性约束不需要新网络、不需要新奖励项**，一个对观测的梯度惩罚就够——所以类图上只多了 `_compute_lcp_loss()` 一个成员。
+- 对照 AMP/ASE 的类图看：同样继承 `PPOAgent`，AMP 加了一整个判别器分支，LCP 只加了一项 loss——继承树上的"层厚"直接反映论文改动量。
+
 ### 源码运行时序图
 
 以第 7 节的训练命令 `python mimickit/run.py --mode train --agent_config lcp_g1_agent.yaml` 为入口。`LCPAgent` 继承 `PPOAgent`，整条训练时序与 PPO 完全一致，**唯一的差别发生在 Actor 更新这一步**——多算一次对观测的梯度惩罚：

--- a/papers/01_Foundational_RL/MimicKit_A_Reinforcement_Learning_Framework_for_Motion_Imitation_and_Control/MimicKit_A_Reinforcement_Learning_Framework_for_Motion_Imitation_and_Control.md
+++ b/papers/01_Foundational_RL/MimicKit_A_Reinforcement_Learning_Framework_for_Motion_Imitation_and_Control/MimicKit_A_Reinforcement_Learning_Framework_for_Motion_Imitation_and_Control.md
@@ -92,6 +92,22 @@ MimicKit 官方仓库明确提供多个常用方法的实现入口：
 
 因此，MimicKit 本身也可以当成“物理角色控制论文谱系”的代码索引：从 DeepMimic 的 tracking reward，到 AMP/ASE 的 adversarial reward，再到 ADD 的差异判别。
 
+把这条谱系按时间摊开（都是本模块里有笔记的论文），每一步解决的都是上一步暴露的问题：
+
+<div class="mermaid">
+timeline
+    title 运动模仿方法谱系（模块 01 论文，均收录于 MimicKit 或其思想源头）
+    2017 : PPO — 通用 on-policy 优化骨架
+    2018 : DeepMimic — 手写模仿奖励 + RSI/ET，单 clip 精确跟踪
+    2019 : AWR — 加权回归式策略更新，另一条优化路线
+    2021 : AMP — 判别器替代手写奖励，学风格不逐帧
+    2022 : ASE — 技能压进 latent 空间，一个策略多技能
+    2023 : CALM — 条件判别器 + 高层选 latent，技能可定向
+    2024 : LCP — 梯度惩罚做动作平滑，sim-to-real 落地
+    2025 : ADD — 判别器吃「差异」，兼得跟踪精度与免调参
+         : MimicKit — 把整条谱系收进一个统一框架
+</div>
+
 ### 3. 框架设计偏轻量
 
 论文摘要强调的是 lightweight、modular、configurable，而不是一个巨大的闭环机器人系统。
@@ -370,6 +386,70 @@ MimicKit 这篇论文的“源码对照”就是官方仓库本身：
 2. 再看 `deepmimic_env.py`，把 reference motion reward 跑通。
 3. 然后看 `amp_agent.py`，理解 discriminator reward 如何接进 PPO。
 4. 最后看 `ase_agent.py` / `add_agent.py`，比较 latent skill 和差异判别的变化点。
+
+### 源码类图：整个框架的"家谱"
+
+这张图把 `mimickit/learning/` 与 `mimickit/envs/` 两条继承树画在一起——**继承树就是论文谱系树**，每篇论文的笔记里都有对应子树的放大版：
+
+<div class="mermaid">
+classDiagram
+    class BaseAgent {
+        base_agent.py 训练骨架
+        +train_model() #_rollout_train()
+    }
+    class PPOAgent {
+        ppo_agent.py PPO笔记
+        PPO-Clip 更新
+    }
+    class AWRAgent {
+        awr_agent.py AWR笔记
+        指数加权回归
+    }
+    class AMPAgent {
+        amp_agent.py AMP笔记
+        +判别器分支
+    }
+    class ASEAgent {
+        ase_agent.py ASE笔记
+        +latent z +Encoder
+    }
+    class ADDAgent {
+        add_agent.py ADD笔记
+        判别器吃差异对
+    }
+    class LCPAgent {
+        lcp_agent.py LCP笔记
+        +梯度惩罚项
+    }
+    class BaseEnv {
+        envs/base_env.py
+    }
+    class CharEnv {
+        char_env.py 经SimEnv
+    }
+    class DeepMimicEnv {
+        deepmimic_env.py DeepMimic笔记
+        RSI ET 手写5项奖励
+    }
+    class AMPEnv {
+        amp_env.py
+        提供disc_obs
+    }
+    BaseAgent <|-- PPOAgent
+    BaseAgent <|-- AWRAgent
+    PPOAgent <|-- AMPAgent
+    PPOAgent <|-- LCPAgent
+    AMPAgent <|-- ASEAgent
+    AMPAgent <|-- ADDAgent
+    BaseEnv <|-- CharEnv
+    CharEnv <|-- DeepMimicEnv
+    CharEnv <|-- AMPEnv
+    PPOAgent ..> DeepMimicEnv : DeepMimic组合
+    AMPAgent ..> AMPEnv : AMP组合
+</div>
+
+- 竖着看是**继承**（算法演进），横着的虚线是**组合**（哪个算法配哪个环境）——DeepMimic 的特殊之处一眼可见：它是唯一"Agent 零改动、只做环境"的论文。
+- 每个类框里标注了对应的笔记，可以把这张图当模块 01 源码阅读的**总目录**。
 
 ### 源码运行时序图
 

--- a/papers/01_Foundational_RL/PHC_Perpetual_Humanoid_Control/PHC_Perpetual_Humanoid_Control.md
+++ b/papers/01_Foundational_RL/PHC_Perpetual_Humanoid_Control/PHC_Perpetual_Humanoid_Control.md
@@ -348,6 +348,23 @@ self._terminate_buf[is_recovery] = 0
 
 这就是 PHC 真正“perpetual”的地方：不是口头上说永续，而是训练机制上就不允许你靠 reset 逃避失败。
 
+把运行时的模式切换画成状态机，“永续”的含义就非常直白——DeepMimic 摔倒只能 reset，PHC 摔倒后多了一条**自己爬起来接回轨迹**的回路：
+
+<div class="mermaid">
+stateDiagram-v2
+    state "模仿模式：精确跟踪全身参考姿态" as IM
+    state "恢复模式：只追根节点位置（r_point）" as REC
+    state "recovery 窗口（90 步）：reset_buf 强制为 0" as WIN
+    [*] --> IM
+    IM --> REC : 摔倒 / 偏离参考 2~5m
+    REC --> WIN : 进入恢复窗口，禁止 reset
+    WIN --> WIN : Pᶠ 主导：翻身 → 起身 → 走向目标
+    WIN --> IM : 根节点距参考 < 0.5m，切回模仿
+    IM --> IM : composer 混合 P¹…P³ 持续跟踪
+</div>
+
+> 🔑 对照 DeepMimic 笔记的 episode 状态机看：DeepMimic 的 FAIL 是**终态**（只能 reset 重来），PHC 把 FAIL 变成了**中间态**（恢复模式），这正是论文标题里 “Perpetual” 的机制来源。
+
 ---
 
 ## 📁 PHC 源码对照

--- a/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
+++ b/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
@@ -178,6 +178,28 @@ t=48:  s₄₈ = [重新站立...],  继续收集到 t=63                       
 > - **速度快**：GPU 向量化计算，32个环境几乎和1个一样快（如 Isaac Gym）
 > - **覆盖更广**：同时有的环境在站立，有的在行走，有的刚摔倒重置
 
+#### Episode 生命周期（状态图）
+
+单个环境里，一个 episode 从初始化到终止的完整状态流转如下。先记住 done 在哪里发生，下一步就能明白 GAE 为什么要"在 done 边界截断"：
+
+<div class="mermaid">
+stateDiagram-v2
+    direction LR
+    state "初始化：站立姿态" as INIT
+    state "交互中：s_t → a_t → r_t" as RUN
+    state "FAIL：摔倒" as FAIL
+    state "TIME：走满 1000 步" as TIME
+    [*] --> INIT
+    INIT --> RUN
+    RUN --> RUN : 每步记录 (s, a, r, logp)
+    RUN --> FAIL : 质心高度低于 0.8m
+    RUN --> TIME : 达到步数上限
+    FAIL --> INIT : 自动 reset，开启新轨迹
+    TIME --> INIT : 自动 reset
+</div>
+
+> 💡 done（FAIL / TIME）就是**轨迹边界**：上面 t=47 摔倒后 t=48 重新站立，两段属于不同轨迹。GAE 逆序递推到边界必须停下，不能把下一条轨迹的信息传过来——这就是第 2 步里"done 边界截断"的含义。
+
 ### 第 2 步：计算优势（GAE）
 
 #### 为什么要算优势？
@@ -283,6 +305,16 @@ flowchart TB
 
 $\lambda$ 从 0 调到 1，对"即将摔倒"的敏感度从**完全无视**升到**完全计入**；$0.95$ 是"看得见、又别被单条轨迹噪声带太偏"的折中。
 
+同一段"3 步后摔倒"的轨迹，三个 λ 算出的 Â₀ 画在一起，差距一目了然：
+
+<div class="mermaid">
+xychart-beta
+    title "同一条摔倒轨迹：不同 λ 下的 Â₀"
+    x-axis ["λ=0 一步TD", "λ=0.95 实用值", "λ=1 蒙特卡洛"]
+    y-axis "Â₀（优势估计）" -70 --> 10
+    bar [0.5, -49.3, -58.6]
+</div>
+
 > 💡 实战还会把 $\hat{A}$ 按 batch **减均值除标准差再截断**（配置 `norm_adv_clip: 4.0`），所以进裁剪公式的是"相对大小"，绝对量级不重要。
 
 结果：站稳时 $\hat{A}_t > 0$（好动作），摔倒前 $\hat{A}_t \ll 0$（差动作）。
@@ -331,6 +363,16 @@ for epoch in range(10):                                  # 同一批 2048 个样
 | **步态优化** | 800-2000 | ~3000 | 步态流畅，速度提升 |
 | **收敛** | 2000+ | ~5000+ | 高效稳定的行走步态 |
 
+把这张表画成学习曲线，能直观看到 PPO 的典型形态——前期爬升慢（在学"不摔倒"），中期陡增（学会走后回报快速兑现），后期平台（收敛）：
+
+<div class="mermaid">
+xychart-beta
+    title "Humanoid-v4 训练学习曲线（示意）"
+    x-axis "迭代次数" [0, 100, 300, 800, 2000, 3000]
+    y-axis "平均回报" 0 --> 5500
+    line [30, 50, 200, 1000, 3000, 5000]
+</div>
+
 ### 完整流程图
 
 <div class="mermaid">
@@ -367,6 +409,53 @@ flowchart TB
 ## 📁 MimicKit 源码对照
 
 以下代码块对应 [MimicKit](https://github.com/xbpeng/MimicKit) 中 PPO 的实现，与上述讲解的各模块一一对应。
+
+### 源码类图：PPO 在 MimicKit 中的位置
+
+先看静态结构。MimicKit 的所有算法都挂在 `BaseAgent` 的训练骨架下，PPO 是其中一条分支；后续论文（AMP、ASE、LCP……）的 Agent 都**继承自 PPOAgent**，所以这张图也是整个模块 01 源码的"地基"：
+
+<div class="mermaid">
+classDiagram
+    class BaseAgent {
+        base_agent.py 抽象基类
+        +train_model(max_samples)
+        #_train_iter() 一轮迭代
+        #_rollout_train(num_steps) 收集经验
+        #_build_train_data() 算训练目标
+        #_update_model() 参数更新
+        #_decide_action(obs, info)
+    }
+    class PPOAgent {
+        ppo_agent.py
+        #_build_train_data() TD(λ)回报+优势
+        #_update_model() 先Critic后Actor
+        #_compute_critic_loss(batch) MSE
+        #_compute_actor_loss(batch) PPO-Clip
+    }
+    class BaseModel {
+        base_model.py
+        #_build_action_distribution()
+    }
+    class PPOModel {
+        ppo_model.py
+        +eval_actor(obs) 动作分布
+        +eval_critic(obs) V(s)
+        #_build_actor() #_build_critic()
+    }
+    class ExperienceBuffer {
+        experience_buffer.py
+        +record(name, data)
+        +sample(n) 随机mini-batch
+    }
+    BaseAgent <|-- PPOAgent : 继承
+    BaseModel <|-- PPOModel : 继承
+    PPOAgent o-- PPOModel : _model
+    PPOAgent o-- ExperienceBuffer : _exp_buffer
+    PPOAgent ..> Env : _step_env()
+</div>
+
+- 读代码时按这个分工找：**采样循环**在 `BaseAgent`（`_rollout_train`），**PPO 特有的东西**全在 `PPOAgent` 的四个覆写方法里，**网络前向**在 `PPOModel`。
+- 后续笔记的类图会在这张图基础上"往下长"：AMPAgent 继承 PPOAgent 加鉴别器，ASEAgent 再继承 AMPAgent 加编码器。
 
 ### 源码运行时序图
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

模块 01 的笔记此前只使用两种 Mermaid 图（`flowchart` + `sequenceDiagram`）。本 PR 引入四类新图型，补足「代码静态结构」「运行状态迁移」「定量直觉」「方法谱系」四个缺口，帮助读者更快理解论文与源代码：

- **`classDiagram` 源码类图**：展示 MimicKit 类继承链——继承树本身就是论文谱系（`PPOAgent → AMPAgent → ASEAgent/ADDAgent`、`PPOAgent → LCPAgent`、`AWRAgent` 平行分支、`BaseEnv → … → DeepMimicEnv`），一眼看清每篇论文在代码里新增/覆写了哪些类与方法。
- **`stateDiagram-v2` 状态图**：episode 生命周期（PPO）、RSI+ET 回合状态机（DeepMimic）、模仿↔恢复模式切换（PHC）、FSM 技能调度（CALM）。
- **`xychart-beta` 图表**：GAE 不同 λ 的 Â₀ 对比、训练学习曲线（PPO）、用户研究偏好对比（BeyondMimic）。
- **`timeline` 时间线**：2017–2025 运动模仿方法谱系（MimicKit 总览篇）。

## 改动（11 篇笔记，共 12 张新图）

| 笔记 | 新增 |
|------|------|
| PPO | 类图、episode 状态图、λ 对比柱状图、学习曲线 |
| DeepMimic | 环境侧类图、RSI/ET 状态机 |
| PHC | 模仿/恢复模式状态机 |
| AMP / ASE / ADD / LCP / AWR | 各自的源码类图（沿继承链逐层"往下长"） |
| MimicKit | 框架"家谱"总类图、方法谱系时间线 |
| CALM | FSM 技能调度状态机 |
| BeyondMimic | 用户研究偏好柱状图 |

类图内容已对照 MimicKit 真实源码（`xbpeng/MimicKit`）核实类名与方法名。

## 验证

- `python3 scripts/prepare_pages.py`、`ruff check`、`pytest -q`（160 passed）
- 无头 Chrome 用站点同版本 Mermaid 11.4.1 + `securityLevel: strict` 批量 parse 全部 11 页共 82 个 mermaid 块：全部 PASS
- 本地 `jekyll serve` 浏览器验收：明/暗主题、lightbox 缩放、移动端 390×844 视口

## 渲染截图

![PPO 源码类图（浅色主题）](https://cursor.com/artifacts/c/art-d9b1b149-a4e3-42df-bd70-fbc9fbc14459)
![PPO 源码类图（深色主题）](https://cursor.com/artifacts/c/art-ccdb08de-18c5-4c7f-a6d0-648ce7fd2bae)
![DeepMimic 环境继承链类图](https://cursor.com/artifacts/c/art-e2687321-87aa-41a6-964d-84e05e78ce3e)
![MimicKit 框架家谱类图](https://cursor.com/artifacts/c/art-317bcea1-332c-4809-9b28-d0e61637e385)
![MimicKit 方法谱系时间线](https://cursor.com/artifacts/c/art-937b30c1-f6fb-46b7-b6e4-40787a750bc4)
![MimicKit 时间线（深色主题）](https://cursor.com/artifacts/c/art-35430e24-864a-43a1-a84e-b30d7f2e4c19)
![AMP 源码类图](https://cursor.com/artifacts/c/art-8fd2e995-8b00-4adc-9906-5bf83b71a118)
![PPO episode 生命周期状态图](https://cursor.com/artifacts/c/art-6ae441a5-102a-46dc-acf9-2bf4c447631b)
![DeepMimic RSI+ET 状态机](https://cursor.com/artifacts/c/art-08c2f340-d43b-4f91-bdb8-b955ecf14161)
![PHC 模仿/恢复模式状态机](https://cursor.com/artifacts/c/art-c990095a-817b-4d45-9525-6d87c6cfc3bd)
![CALM FSM 状态机](https://cursor.com/artifacts/c/art-16b962a0-221e-4d4d-932c-a92e675c1e66)
![GAE λ 对比柱状图](https://cursor.com/artifacts/c/art-13b5f020-8e24-4529-ba63-288ea66225f2)
![训练学习曲线折线图](https://cursor.com/artifacts/c/art-d5a50481-2585-4f87-a3d6-c10c844fbc0a)
![BeyondMimic 用户研究柱状图](https://cursor.com/artifacts/c/art-5e0bf97d-34fe-45a4-abcd-68409209bba9)
![移动端 390×844 渲染](https://cursor.com/artifacts/c/art-fdf88260-8f88-47e9-8c08-cc1ad1399d6a)

## 演示视频

试点验收（PPO/DeepMimic 类图、lightbox、暗色、移动端）：

<a href="https://cursor.com/agents/bc-fabf0c24-13bb-402b-8f96-e957eb697bcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpilot_new_diagrams_verification.mp4"><img src="https://cursor.com/artifacts/c/art-54cd1556-c575-4399-8cee-fef86b10798d" alt="pilot_new_diagrams_verification.mp4" /></a>

推广验收（时间线、家谱类图、CALM FSM、BeyondMimic 柱状图、暗色时间线）：

<a href="https://cursor.com/agents/bc-fabf0c24-13bb-402b-8f96-e957eb697bcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frollout_new_diagrams_verification.mp4"><img src="https://cursor.com/artifacts/c/art-2a85b64f-60b2-451b-b8ac-396c0ce7fcb6" alt="rollout_new_diagrams_verification.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fabf0c24-13bb-402b-8f96-e957eb697bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fabf0c24-13bb-402b-8f96-e957eb697bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

