### PR TITLE
feat(Updates): 更新记录 emoji 随日期自动切换

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,6 +63,8 @@
   <script src="{{ '/assets/js/mermaid-config.js' | relative_url }}{% if mermaid_config_js %}?v={{ mermaid_config_js.modified_time | date: '%s' }}{% endif %}"></script>
   {% assign mermaid_zoom_js = site.static_files | where: "path", "/assets/js/mermaid-zoom.js" | first %}
   <script src="{{ '/assets/js/mermaid-zoom.js' | relative_url }}{% if mermaid_zoom_js %}?v={{ mermaid_zoom_js.modified_time | date: '%s' }}{% endif %}" defer></script>
+  {% assign updates_emoji_js = site.static_files | where: "path", "/assets/js/updates-emoji.js" | first %}
+  <script src="{{ '/assets/js/updates-emoji.js' | relative_url }}{% if updates_emoji_js %}?v={{ updates_emoji_js.modified_time | date: '%s' }}{% endif %}" defer></script>
   <script>
     function initMermaid(theme) {
       if (typeof mermaid === 'undefined') return;

--- a/assets/js/updates-emoji.js
+++ b/assets/js/updates-emoji.js
@@ -1,0 +1,99 @@
+/**
+ * Seasonal / holiday emoji for the Update Log entry points.
+ *
+ * Replaces every `.js-updates-emoji` node with an emoji chosen from the
+ * viewer's local calendar date (specific MM-DD first, then month fallback).
+ * Default remains 📅 when nothing matches.
+ */
+(function (global) {
+  'use strict';
+
+  var DEFAULT_EMOJI = '📅';
+
+  // Fixed solar-calendar days (MM-DD). Checked before month rules.
+  var DAY_EMOJI = {
+    '01-01': '🎊', // New Year
+    '02-14': '💝', // Valentine's Day
+    '03-08': '🌸', // International Women's Day
+    '04-01': '🃏', // April Fools'
+    '05-01': '🛠️', // Labor Day
+    '06-01': '🎈', // Children's Day
+    '10-01': '🎉', // National Day / early autumn festivity
+    '10-31': '🎃', // Halloween
+    '12-24': '🎄', // Christmas Eve
+    '12-25': '🎄', // Christmas
+    '12-31': '🎆'  // New Year's Eve
+  };
+
+  // Month fallbacks (1–12) when no specific day rule applies.
+  var MONTH_EMOJI = {
+    1: '❄️',
+    2: '🧧', // Spring Festival season
+    3: '🌱',
+    4: '🌸',
+    5: '🌿',
+    6: '☀️',
+    7: '🌊',
+    8: '🍉',
+    9: '🍂',
+    10: '🍁',
+    11: '🍁',
+    12: '🎄'
+  };
+
+  function pad2(n) {
+    return n < 10 ? '0' + n : String(n);
+  }
+
+  /**
+   * @param {Date=} date Local date to resolve; defaults to now.
+   * @returns {string} Emoji for that calendar day.
+   */
+  function coerceDate(date) {
+    // Prefer duck-typing over `instanceof Date` so Node vm / iframe realms work.
+    if (date && typeof date.getMonth === 'function' && typeof date.getDate === 'function'
+        && typeof date.getTime === 'function' && !isNaN(date.getTime())) {
+      return date;
+    }
+    return new Date();
+  }
+
+  function getUpdatesEmoji(date) {
+    var d = coerceDate(date);
+    var key = pad2(d.getMonth() + 1) + '-' + pad2(d.getDate());
+    if (Object.prototype.hasOwnProperty.call(DAY_EMOJI, key)) {
+      return DAY_EMOJI[key];
+    }
+    var monthEmoji = MONTH_EMOJI[d.getMonth() + 1];
+    return monthEmoji || DEFAULT_EMOJI;
+  }
+
+  function applyUpdatesEmoji(date) {
+    var emoji = getUpdatesEmoji(date);
+    var nodes = document.querySelectorAll('.js-updates-emoji');
+    for (var i = 0; i < nodes.length; i++) {
+      if (nodes[i].textContent !== emoji) {
+        nodes[i].textContent = emoji;
+      }
+    }
+    return emoji;
+  }
+
+  global.getUpdatesEmoji = getUpdatesEmoji;
+  global.applyUpdatesEmoji = applyUpdatesEmoji;
+
+  // Expose tables for tests (read-only intent; do not mutate at runtime).
+  global.__UPDATES_EMOJI_DAY__ = DAY_EMOJI;
+  global.__UPDATES_EMOJI_MONTH__ = MONTH_EMOJI;
+  global.__UPDATES_EMOJI_DEFAULT__ = DEFAULT_EMOJI;
+
+  function boot() {
+    applyUpdatesEmoji();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})(typeof window !== 'undefined' ? window : this);

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: "Home"
       <span data-en="{{ paper_count | escape }} papers" data-zh="共 {{ paper_count | escape }} 篇笔记">{{ paper_count | escape }} papers</span>
     </span>
     <a href="{{ '/updates.html' | relative_url }}" class="index-chip index-chip-link">
-      <span aria-hidden="true">📅</span>
+      <span class="js-updates-emoji" aria-hidden="true">📅</span>
       <span data-en="Update Log" data-zh="更新记录">Update Log</span>
       <span class="index-chip-arrow" aria-hidden="true">→</span>
     </a>

--- a/tests/test_updates_emoji.py
+++ b/tests/test_updates_emoji.py
@@ -1,0 +1,75 @@
+"""Update Log seasonal emoji: date rules + markup hooks."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EMOJI_JS = ROOT / "assets" / "js" / "updates-emoji.js"
+INDEX = ROOT / "index.html"
+UPDATES = ROOT / "updates.html"
+LAYOUT = ROOT / "_layouts" / "default.html"
+
+
+def test_updates_emoji_markup_hooks():
+    index = INDEX.read_text(encoding="utf-8")
+    updates = UPDATES.read_text(encoding="utf-8")
+    layout = LAYOUT.read_text(encoding="utf-8")
+
+    assert 'class="js-updates-emoji"' in index
+    assert 'class="js-updates-emoji"' in updates
+    assert "assets/js/updates-emoji.js" in layout
+    # Emoji is separated from i18n text so language toggle does not wipe it.
+    assert 'data-en="Update Log"' in updates
+    assert 'data-zh="更新记录"' in updates
+    assert 'data-en="📅 Update Log"' not in updates
+
+
+def test_updates_emoji_calendar_via_node():
+    """Resolve a few fixed dates through the shipped JS (viewer-local calendar)."""
+    script = f"""
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync({str(EMOJI_JS)!r}, 'utf8');
+const sandbox = {{
+  window: {{}},
+  document: {{
+    readyState: 'complete',
+    querySelectorAll: () => [],
+    addEventListener: () => {{}},
+  }},
+}};
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+
+function d(y, m, day) {{ return new Date(y, m - 1, day); }}
+const cases = [
+  [d(2026, 1, 1), '🎊'],
+  [d(2026, 2, 14), '💝'],
+  [d(2026, 4, 1), '🃏'],
+  [d(2026, 7, 21), '🌊'],  // July month fallback
+  [d(2026, 10, 31), '🎃'],
+  [d(2026, 12, 25), '🎄'],
+  [d(2026, 2, 10), '🧧'],  // February month (Spring Festival season)
+];
+for (const [date, expect] of cases) {{
+  const got = sandbox.getUpdatesEmoji(date);
+  if (got !== expect) {{
+    console.error('mismatch', date.toISOString().slice(0, 10), 'got', got, 'want', expect);
+    process.exit(1);
+  }}
+}}
+if (sandbox.__UPDATES_EMOJI_DEFAULT__ !== '📅') process.exit(2);
+console.log('ok');
+"""
+    result = subprocess.run(
+        ["node", "-e", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "ok" in result.stdout

--- a/updates.html
+++ b/updates.html
@@ -4,7 +4,7 @@ title: "Update Log"
 ---
 <div class="updates-page">
   <div class="updates-header">
-    <h1 data-en="📅 Update Log" data-zh="📅 更新记录">📅 Update Log</h1>
+    <h1><span class="js-updates-emoji" aria-hidden="true">📅</span> <span data-en="Update Log" data-zh="更新记录">Update Log</span></h1>
     <p class="updates-subtitle"
        data-en="Note update activity from commit history. Click a day to filter."
        data-zh="基于提交历史的笔记更新记录，点击方格筛选当日。">Note update activity from commit history. Click a day to filter.</p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

更新记录相关 emoji 会按访客**本地日历日期**自动切换，覆盖：

- 首页「更新记录」入口按钮
- 更新记录子页（`updates.html`）标题

## 规则

1. 优先匹配固定公历节日（如元旦 🎊、圣诞 🎄、万圣 🎃）
2. 否则按月份季节回退（如 7 月 🌊、2 月 🧧）
3. 无匹配时仍为 📅

实现为客户端脚本 `assets/js/updates-emoji.js`，无需重新部署即可随日期变化。标题 emoji 与中英文文案分离，语言切换不会覆盖季节 emoji。

## 验收截图

当前日期为 7 月，季节 emoji 为 🌊：

![首页入口按钮：🌊 Update Log](https://cursor.com/artifacts/c/art-c40b042b-a83c-4be2-9c4b-ecd78c2811cd)

![更新记录子页标题：🌊 Update Log](https://cursor.com/artifacts/c/art-7e638e27-b01b-42fa-9af7-d9c96e87976c)

节日规则抽查（强制设为 12-25）：

![圣诞节日规则演示：🎄 Update Log](https://cursor.com/artifacts/c/art-8917c2a9-1819-4db8-bc2a-aa344072f9d8)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf48937f-ce27-4c97-b582-47b2b0528a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf48937f-ce27-4c97-b582-47b2b0528a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

