### PR TITLE
fix(01_Foundational_RL): 修复 PPO 逆序递推 GAE 公式渲染

### DIFF
--- a/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
+++ b/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.md
@@ -273,7 +273,7 @@ flowchart TB
 δ₄ = -10 + 0(done) - 20 = -30.0    # done，不加 γV(s₅)
 ```
 
-**② 逆序递推 GAE** $\hat{A}_t = \delta_t + 0.9405\,\hat{A}_{t+1}$（从最后一步往前推，即源码里 `for i in reversed(...)`）：
+**② 逆序递推 GAE** $\hat{A}\_t = \delta_t + 0.9405\,\hat{A}\_{t+1}$（从最后一步往前推，即源码里 `for i in reversed(...)`）：
 
 ```
 Â₄ = -30.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

[PPO 笔记页](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/01_Foundational_RL/PPO_Proximal_Policy_Optimization/PPO_Proximal_Policy_Optimization.html) 中「② 逆序递推 GAE」行内公式渲染异常。

根因：Kramdown GFM 把 `$\hat{A}_t = ... \hat{A}_{t+1}$` 里成对的 `_`（落在 `}` 后，属于词间强调边界）解析成 `<em>`，KaTeX 收到残缺源码，显示为 `Ât` / `Â{t+1}` 一类乱码。

## 修复

将下标下划线转义为 `\_`：

```markdown
$\hat{A}\_t = \delta_t + 0.9405\,\hat{A}\_{t+1}$
```

Kramdown 输出为完整的 `$\hat{A}_t = \delta_t + 0.9405\,\hat{A}_{t+1}$`（无 `<em>`），KaTeX 正常渲染。

## 验收

![修复后：② 逆序递推 GAE 公式（KaTeX 下标正常）](https://cursor.com/artifacts/c/art-3260bb35-8332-4f10-a888-8ea6b46b2171)

本地 headless Chrome 确认该段落含 `.katex` 节点，MathML 为 `Â_t = δ_t + 0.9405 Â_{t+1}`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9bedbcd-131f-4ecc-a7a1-26a4d4fb8a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9bedbcd-131f-4ecc-a7a1-26a4d4fb8a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

