### PR TITLE
chore(Env): 添加 Cloud Agent 开发环境配置

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Humanoid Robot Learning Paper Notebooks",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "jekyll-serve",
+      "command": "python3 scripts/prepare_pages.py && bundle exec jekyll serve --host 0.0.0.0 --port 4000",
+      "description": "Regenerates paper front matter/_data index, then serves the site at http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/ (auto-rebuilds on file changes)."
+    }
+  ],
+  "ports": [
+    {
+      "name": "jekyll",
+      "port": 4000
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent install for the Jekyll paper-notebook site.
+# Safe to run repeatedly and against a cached/prebuilt snapshot.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# --- System toolchain: Ruby (for Jekyll 4.3) + build deps for native gems ---
+if ! command -v ruby >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends \
+    ruby-full ruby-bundler build-essential zlib1g-dev
+fi
+
+# --- Ruby gems for the static site (Jekyll + plugins) ---
+# Gems install system-wide under /var/lib/gems, hence sudo (see AGENTS.md).
+sudo bundle install
+
+# --- Python tooling: lint (ruff), tests (pytest), and the HTML sanitizer deps ---
+# Installed system-wide so `ruff`/`pytest` are on the default PATH for every shell.
+sudo pip3 install --break-system-packages -r requirements-dev.txt
+
+# --- Preprocess Markdown -> YAML front matter + _data/papers.json ---
+# Required before any Jekyll build; idempotent (skips notes already prepared).
+python3 scripts/prepare_pages.py


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

为本仓库新增 Cloud Agent 开发环境配置，使 Jekyll 静态站点 + Python 预处理/质检脚本可在云端一键复现。此前环境为空（无 `.cursor/environment.json`，VM 仅有 Python 3.12，缺 Ruby/Jekyll 与 `ruff`/`pytest`）。

采用**仓库托管**配置：`.cursor/environment.json` 提交进仓库，是最高优先级的环境来源，随分支/PR 走，合并本 PR 即生效（无需在面板另存会冲突的 dashboard 环境）。

## 改动

- 新增 `.cursor/environment.json`：声明 `install`、`jekyll-serve` 终端（4000 端口）与端口暴露。
- 新增 `.cursor/install.sh`（幂等）：
  - 缺失时用 apt 安装 Ruby/Bundler/build-essential/zlib（`ruby-full ruby-bundler build-essential zlib1g-dev`）。
  - `sudo bundle install` 安装 Jekyll 4.x 及插件。
  - 系统级安装 `requirements-dev.txt`（`ruff`/`pytest`/`nh3`/`beautifulsoup4`），使 `ruff`/`pytest` 落在默认 `PATH`（`/usr/local/bin`）。
  - 运行 `python3 scripts/prepare_pages.py` 预处理论文页并生成 `_data/papers.json`。

配置遵循 `AGENTS.md` 的 Cursor Cloud 说明（apt 安装 Ruby、`sudo bundle install`、`python3`、`baseurl` 前缀等）。

## 验证

在当前 VM 上完成端到端验证：

| 检查项 | 结果 |
| --- | --- |
| `ruff check scripts/ tests/` | All checks passed |
| `pytest -v` | 160 passed |
| `python3 scripts/prepare_pages.py` | 生成 312 篇论文 / 14 分类，幂等无 diff |
| `bundle exec jekyll build` | done in ~2.5s |
| `sanitize_paper_html.py _site` | Sanitized 312 file(s) |
| `bundle exec jekyll serve` | 首页/论文页 HTTP 200 |
| `install.sh` 幂等性 | 二次运行为 no-op（apt 跳过、gems/pip 已满足） |
| 草稿构建（本分支，默认镜像全新 checkout） | SUCCEEDED — apt 装 Ruby、bundle 安装 37 个 gem（jekyll 4.4.1）、pip 装质检依赖、`prepare_pages` 通过 |

站点渲染（`http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/`）：语言切换（中/英）与论文详情页均正常。

![首页渲染（桌面 1440 宽）](https://cursor.com/artifacts/c/art-dc12ad2a-0806-4f56-88b0-3aaa06f91330)

![首页渲染（移动端 390×844）](https://cursor.com/artifacts/c/art-e6a2f4f9-1b31-4871-b94d-dda4fb7c3f1b)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43266f70-03f7-44c0-af24-0b8cd20f52b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43266f70-03f7-44c0-af24-0b8cd20f52b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

