### PR TITLE
docs: 将网页名同步为 Robot Learning Paper Notebooks

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,11 +1,11 @@
 {
-  "name": "Humanoid Robot Learning Paper Notebooks",
+  "name": "Robot Learning Paper Notebooks",
   "install": "bash .cursor/install.sh",
   "terminals": [
     {
       "name": "jekyll-serve",
       "command": "python3 scripts/prepare_pages.py && bundle exec jekyll serve --host 0.0.0.0 --port 4000",
-      "description": "Regenerates paper front matter/_data index, then serves the site at http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/ (auto-rebuilds on file changes)."
+      "description": "Regenerates paper front matter/_data index, then serves the site at http://localhost:4000/Robot_Learning_Paper_Notebooks/ (auto-rebuilds on file changes)."
     }
   ],
   "ports": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ pip3 install -r requirements-dev.txt
    - **站点 HTML 消毒脚本依赖**：`pip3 install -r requirements-site.txt`（与 Deploy 流程一致）。
 
 1. **Preprocess**: `python3 scripts/prepare_pages.py` (must run before Jekyll build whenever paper `.md` files change).
-2. **Serve**: `bundle exec jekyll serve --host 0.0.0.0 --port 4000` — site is at `http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/`.
+2. **Serve**: `bundle exec jekyll serve --host 0.0.0.0 --port 4000` — site is at `http://localhost:4000/Robot_Learning_Paper_Notebooks/`.
 3. Jekyll auto-rebuilds on file changes (LiveReload not configured; refresh browser manually).
 4. **Optional (match production HTML)**: After `bundle exec jekyll build`, run `python3 scripts/sanitize_paper_html.py _site` (install deps once with `pip3 install -r requirements-site.txt`). GitHub Pages deploy runs this automatically; `jekyll serve` alone does not.
 
@@ -123,7 +123,7 @@ pip3 install -r requirements-dev.txt
 - `python` is not symlinked on this VM — always use `python3`.
 - `bundle install` must run with `sudo` (gems install to `/var/lib/gems/`); `bundle exec jekyll ...` does NOT need sudo.
 - There is no `Gemfile.lock` committed; Bundler resolves versions fresh on each install.
-- The `baseurl` in `_config.yml` is `/Humanoid_Robot_Learning_Paper_Notebooks` — local URLs always include this prefix.
+- The `baseurl` in `_config.yml` is `/Robot_Learning_Paper_Notebooks` — local URLs always include this prefix.
 
 ### Pull Request：须附「修复页」渲染截图
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # 📚 每日论文阅读计划
 
-[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Live-brightgreen.svg)](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/)
+[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Live-brightgreen.svg)](https://imchong.github.io/Robot_Learning_Paper_Notebooks/)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/Papers-726-orange.svg)](papers/PROGRESS.md)
 [![Notes](https://img.shields.io/badge/Notes-330-green.svg)](papers/)
 
-人形机器人学习方向的每日论文精读笔记，逐篇部署为 [在线网页](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/)。
+人形机器人学习方向的每日论文精读笔记，逐篇部署为 [在线网页](https://imchong.github.io/Robot_Learning_Paper_Notebooks/)。
 
 **来源**：[awesome-humanoid-robot-learning](https://github.com/YanjieZe/awesome-humanoid-robot-learning) · **待读清单**：[papers/PROGRESS.md](papers/PROGRESS.md)
 
@@ -112,7 +112,7 @@ papers/          # 论文笔记，按方向分 14 个目录（01_基础RL … 14
                  # 另含 PROGRESS.md（全量进度表）与 todos/（开发待办）
 scripts/         # prepare_pages.py 等预处理 / 部署脚本
 _data/ _includes/ _layouts/ assets/   # Jekyll 站点数据、模板与样式
-_config.yml      # Jekyll 配置（baseurl = /Humanoid_Robot_Learning_Paper_Notebooks）
+_config.yml      # Jekyll 配置（baseurl = /Robot_Learning_Paper_Notebooks）
 ```
 
 > 协作与工程规范（Spec/TDD、Code Review、站点构建与截图验收等）见 [AGENTS.md](AGENTS.md)。

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
-title: "Humanoid Robot Learning Paper Notebooks"
-description: "人形机器人强化学习论文笔记"
+title: "Robot Learning Paper Notebooks"
+description: "机器人学习论文笔记"
 url: "https://imchong.github.io"
-baseurl: "/Humanoid_Robot_Learning_Paper_Notebooks"
+baseurl: "/Robot_Learning_Paper_Notebooks"
 
 markdown: kramdown
 kramdown:

--- a/_data/i18n.json
+++ b/_data/i18n.json
@@ -1,19 +1,19 @@
 {
   "site_title": {
-    "en": "Humanoid Robot Learning Paper Notebooks",
-    "zh": "人形机器人学习论文笔记"
+    "en": "Robot Learning Paper Notebooks",
+    "zh": "机器人学习论文笔记"
   },
   "site_title_full": {
-    "en": "📚 Humanoid Robot Learning Paper Notebooks",
-    "zh": "📚 人形机器人学习论文笔记"
+    "en": "📚 Robot Learning Paper Notebooks",
+    "zh": "📚 机器人学习论文笔记"
   },
   "index_header_h1": {
-    "en": "Humanoid Robot Learning Paper Notebooks",
-    "zh": "人形机器人学习论文笔记"
+    "en": "Robot Learning Paper Notebooks",
+    "zh": "机器人学习论文笔记"
   },
   "index_header_p": {
-    "en": "Paper reading notes on humanoid robot reinforcement learning",
-    "zh": "人形机器人强化学习论文阅读笔记"
+    "en": "Paper reading notes on robot learning",
+    "zh": "机器人学习论文阅读笔记"
   },
   "total_papers": {
     "en": "{count} papers",

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,8 @@
 <header class="site-header">
   <div class="header-inner">
-    <a href="{{ '/' | relative_url }}" class="site-title" aria-label="Home - Humanoid Robot Learning Paper Notebooks">📚 Humanoid Robot Learning Paper Notebooks | 人形机器人学习论文笔记</a>
+    <a href="{{ '/' | relative_url }}" class="site-title" aria-label="Home - {{ site.title | escape }}">📚 {{ site.title | escape }} | {{ site.description | escape }}</a>
     <div class="header-right">
-      <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="View source on GitHub">GitHub</a>
+      <a href="https://github.com/ImChong/Robot_Learning_Paper_Notebooks" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="View source on GitHub">GitHub</a>
       <button id="lang-toggle" class="lang-toggle" aria-label="Switch language">
         <span class="lang-label">中文</span>
       </button>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 title: "Home"
 ---
 <div class="index-header">
-  <h1 data-en="📚 Humanoid Robot Learning Paper Notebooks" data-zh="📚 人形机器人学习论文笔记">📚 Humanoid Robot Learning Paper Notebooks</h1>
+  <h1 data-en="📚 {{ site.title | escape }}" data-zh="📚 {{ site.description | escape }}">📚 {{ site.title | escape }}</h1>
   {% assign paper_count = 0 %}
   {% for cat in site.data.papers %}
     {% assign cat_papers_size = cat[1].papers | size %}

--- a/papers/todos/TODO_v1.md
+++ b/papers/todos/TODO_v1.md
@@ -1,8 +1,8 @@
-# 项目待办计划：Humanoid Robot Learning Paper Notebooks
+# 项目待办计划：Robot Learning Paper Notebooks
 
 ## Context（背景）
 
-本项目是一个基于 Jekyll 的双语（中/英）人形机器人强化学习论文笔记站点，通过 GitHub Pages 部署到 <https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/>。README 已列出明确的学习路线图（基础 RL → 精确模仿 → 风格学习 → 技能组合 → 扩散终点 → Sim-to-Real），但当前笔记完成情况与路线图仍有差距：部分路线图论文仅有骨架（🚧 标记待核对），部分旧 stub 已扩写完毕，10 个分类目录中仅 `05_Locomotion` 起步了 1 篇骨架，其余仍为空。本计划基于 git 日志、`papers/` 目录与 README 路线图对比生成，目标是把学习路线图主干补齐到"能发布"的状态，并沉淀下一步的长期扩展方向。
+本项目是一个基于 Jekyll 的双语（中/英）机器人学习论文笔记站点，通过 GitHub Pages 部署到 <https://imchong.github.io/Robot_Learning_Paper_Notebooks/>。README 已列出明确的学习路线图（基础 RL → 精确模仿 → 风格学习 → 技能组合 → 扩散终点 → Sim-to-Real），但当前笔记完成情况与路线图仍有差距：部分路线图论文仅有骨架（🚧 标记待核对），部分旧 stub 已扩写完毕，10 个分类目录中仅 `05_Locomotion` 起步了 1 篇骨架，其余仍为空。本计划基于 git 日志、`papers/` 目录与 README 路线图对比生成，目标是把学习路线图主干补齐到"能发布"的状态，并沉淀下一步的长期扩展方向。
 
 ## 当前快照（2026-04-18，复核后）
 

--- a/papers/todos/TODO_v2.md
+++ b/papers/todos/TODO_v2.md
@@ -1,4 +1,4 @@
-# 项目待办计划 v2：Humanoid Robot Learning Paper Notebooks
+# 项目待办计划 v2：Robot Learning Paper Notebooks
 
 > **版本**：v2（继承自 `TODO_v1.md`；v1 计划于 2026-04-18 本轮执行）
 > **上一版定位**：把 `papers/` 主干从"骨架蔓生"收敛到"路线图可读"。

--- a/papers/todos/TODO_v3.md
+++ b/papers/todos/TODO_v3.md
@@ -1,4 +1,4 @@
-# 项目待办计划 v3：Humanoid Robot Learning Paper Notebooks
+# 项目待办计划 v3：Robot Learning Paper Notebooks
 
 > **版本**：v3（继承自 `TODO_v2.md`；v2 计划于 2026-04-19 部分执行）
 > **上一版定位**：从 5 个新分类的"骨架先覆盖"扩到 4 个剩余空分类、并把工具链补齐。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "humanoid-robot-learning-paper-notebooks"
+name = "robot-learning-paper-notebooks"
 version = "0.0.0"
-description = "Maintenance scripts for the Jekyll-based humanoid robot learning paper notebook site."
+description = "Maintenance scripts for the Jekyll-based robot learning paper notebook site."
 requires-python = ">=3.10"
 
 [tool.ruff]

--- a/tests/test_site_identity.py
+++ b/tests/test_site_identity.py
@@ -1,0 +1,58 @@
+"""Regression: site branding follows the Robot_Learning_Paper_Notebooks rename."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OLD_SLUG = "Humanoid_Robot_Learning_Paper_Notebooks"
+NEW_SLUG = "Robot_Learning_Paper_Notebooks"
+OLD_TITLE = "Humanoid Robot Learning Paper Notebooks"
+NEW_TITLE = "Robot Learning Paper Notebooks"
+OLD_ZH = "人形机器人学习论文笔记"
+NEW_ZH = "机器人学习论文笔记"
+
+
+def test_config_uses_renamed_title_and_baseurl():
+    text = (ROOT / "_config.yml").read_text(encoding="utf-8")
+    assert f'title: "{NEW_TITLE}"' in text
+    assert f'description: "{NEW_ZH}"' in text
+    assert f'baseurl: "/{NEW_SLUG}"' in text
+    assert OLD_SLUG not in text
+    assert OLD_TITLE not in text
+
+
+def test_header_points_at_new_github_repo():
+    text = (ROOT / "_includes/header.html").read_text(encoding="utf-8")
+    assert f"https://github.com/ImChong/{NEW_SLUG}" in text
+    assert OLD_SLUG not in text
+    assert "site.title" in text
+    assert "site.description" in text
+
+
+def test_index_h1_binds_to_site_title():
+    text = (ROOT / "index.html").read_text(encoding="utf-8")
+    assert 'data-en="📚 {{ site.title | escape }}"' in text
+    assert 'data-zh="📚 {{ site.description | escape }}"' in text
+    assert OLD_TITLE not in text
+    assert OLD_ZH not in text
+
+
+def test_i18n_site_titles_match_new_branding():
+    text = (ROOT / "_data/i18n.json").read_text(encoding="utf-8")
+    assert NEW_TITLE in text
+    assert NEW_ZH in text
+    assert OLD_TITLE not in text
+    assert OLD_ZH not in text
+
+
+def test_readme_and_agents_use_new_pages_url():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    pages = f"https://imchong.github.io/{NEW_SLUG}/"
+    local = f"http://localhost:4000/{NEW_SLUG}/"
+    assert pages in readme
+    assert f"baseurl = /{NEW_SLUG}" in readme
+    assert local in agents
+    assert f"`/{NEW_SLUG}`" in agents
+    assert OLD_SLUG not in readme
+    assert OLD_SLUG not in agents


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
仓库已更名为 [`Robot_Learning_Paper_Notebooks`](https://github.com/ImChong/Robot_Learning_Paper_Notebooks)，本 PR 把网页标题、中文站名、Jekyll `baseurl`、GitHub Pages 链接与仓库入口一并改掉，避免站点仍指向旧路径。

## 变更要点

- 英文站名：`Humanoid Robot Learning Paper Notebooks` → `Robot Learning Paper Notebooks`
- 中文站名：`人形机器人学习论文笔记` → `机器人学习论文笔记`
- `baseurl` / Pages 路径：`/Humanoid_Robot_Learning_Paper_Notebooks` → `/Robot_Learning_Paper_Notebooks`
- 页头 GitHub 链接改为新仓库地址
- 首页 H1 与页头改为读取 `_config.yml` 的 `site.title` / `site.description`，避免再硬编码旧名
- 补充 `tests/test_site_identity.py` 防止旧 slug / 旧标题回潮

论文笔记正文与论文自身标题未改（例如 PvP 等论文名中的 Humanoid 仍保留）。

## 渲染验收

本地 `bundle exec jekyll serve` 后：
- 新路径 `http://localhost:4000/Robot_Learning_Paper_Notebooks/` 返回 200
- 旧路径 `http://localhost:4000/Humanoid_Robot_Learning_Paper_Notebooks/` 返回 404
- 首页 / 论文页 / 中英切换均显示新站名，页头 GitHub 指向新仓库

![修复后：英文首页标题与新 baseurl](https://cursor.com/artifacts/c/art-960bde16-87f5-4be3-8ae6-213cc747e8a7)
![修复后：中文首页 H1 为机器人学习论文笔记](https://cursor.com/artifacts/c/art-db0b8080-4a8a-48bb-ac8f-78feb15bce70)
![修复后：页头 GitHub 链接指向新仓库](https://cursor.com/artifacts/c/art-ffbe8c72-c5f9-42cd-aed6-0e5dcd83c1f8)
![修复后：论文页页头沿用新站名](https://cursor.com/artifacts/c/art-b729ae57-e5c4-4ff5-bce6-cd0ca0b22250)
![修复后：中文首页页脚](https://cursor.com/artifacts/c/art-385134ac-8eaf-4d60-b143-54113b220ef0)
![修复后：中文首页移动端视口](https://cursor.com/artifacts/c/art-f2eacac3-1a2e-49ba-a6b8-d9267698e2b2)

<a href="https://cursor.com/agents/bc-eeadd01a-113c-486e-a6b4-239780f09b47/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frename_site_title_en_zh_github.mp4"><img src="https://cursor.com/artifacts/c/art-6233e83d-0228-4e24-a99b-d80bbe75af95" alt="rename_site_title_en_zh_github.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eeadd01a-113c-486e-a6b4-239780f09b47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeadd01a-113c-486e-a6b4-239780f09b47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

