### PR TITLE
feat(UI): 各页面右下角新增回到顶部按钮

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -138,6 +138,70 @@
   </button>
   <div class="sidebar-overlay" id="sidebar-overlay"></div>
 
+  <!-- 回到顶部：右下角 FAB，与左下角 #sidebar-toggle 关于页面中轴线镜面对称 -->
+  <button type="button" class="back-to-top" id="back-to-top"
+          data-en-aria-label="Back to top" data-zh-aria-label="回到顶部"
+          aria-label="Back to top" aria-hidden="true" tabindex="-1">
+    <span class="back-to-top-arrow" aria-hidden="true">↑</span>
+  </button>
+
+  <script>
+    /* ─── Back to Top ───────────────────────────────── */
+    (function() {
+      var btn = document.getElementById('back-to-top');
+      if (!btn) return;
+
+      var visible = false;
+      var lastProgress = -1;
+
+      function update() {
+        var doc = document.documentElement;
+        var scrolled = window.pageYOffset || doc.scrollTop || 0;
+        var scrollable = doc.scrollHeight - window.innerHeight;
+        var progress = scrollable > 0 ? Math.min(1, Math.max(0, scrolled / scrollable)) : 0;
+        // Quantise to 1% before writing back, so the ring is not repainted every frame
+        var rounded = Math.round(progress * 100) / 100;
+        if (rounded !== lastProgress) {
+          lastProgress = rounded;
+          btn.style.setProperty('--btt-progress', String(rounded));
+        }
+        // Appear after 0.6 viewport, or 35% of a short page's scroll range;
+        // pages with under 240px of scroll never get the button.
+        var shouldShow = scrollable >= 240 &&
+          scrolled > Math.min(window.innerHeight * 0.6, scrollable * 0.35);
+        if (shouldShow !== visible) {
+          visible = shouldShow;
+          btn.classList.toggle('is-visible', shouldShow);
+          btn.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+          btn.tabIndex = shouldShow ? 0 : -1;
+        }
+      }
+
+      var ticking = false;
+      function onScroll() {
+        if (ticking) return;
+        ticking = true;
+        window.requestAnimationFrame(function() {
+          update();
+          ticking = false;
+        });
+      }
+
+      window.addEventListener('scroll', onScroll, { passive: true });
+      window.addEventListener('resize', onScroll, { passive: true });
+
+      btn.addEventListener('click', function() {
+        var reduce = false;
+        try {
+          reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        } catch (e) { /* old browsers without matchMedia: keep smooth scrolling */ }
+        window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+      });
+
+      update();
+    })();
+  </script>
+
   <script>
     /* ─── Sidebar Logic ────────────────────────────────────── */
     (function() {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -599,6 +599,69 @@ body.index-search-active .paper-list-toggle-group {
   opacity: 1;
 }
 
+/* ===== Back to Top（右下角进度环 FAB，_layouts/default.html 注入） =====
+   落位与左下角的 .sidebar-toggle 关于页面中轴线镜面对称：
+   同样的 bottom: 24px 与 48x48 尺寸，left: 20px 镜像成 right: 20px。
+   两者不共用断点尺寸覆盖，以免任一侧变化后破坏镜像关系。 */
+.back-to-top {
+  --btt-progress: 0;
+  --btt-track: color-mix(in srgb, var(--text-secondary) 32%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  bottom: 24px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  /* 外圈 = 阅读进度环，由 JS 更新 --btt-progress（0~1） */
+  background: conic-gradient(var(--link) calc(var(--btt-progress) * 360deg), var(--btt-track) 0);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  cursor: pointer;
+  z-index: 1100;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+.back-to-top.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+/* 内圈实心底，把 conic-gradient 削成一条 3px 宽的环 */
+.back-to-top::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+}
+.back-to-top:hover::before {
+  background: var(--bg-secondary);
+}
+.back-to-top:active {
+  transform: scale(0.9);
+}
+.back-to-top-arrow {
+  position: relative;
+  font-size: 1.05rem;
+  line-height: 1;
+  color: var(--text);
+}
+.back-to-top:hover .back-to-top-arrow {
+  color: var(--link);
+}
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top {
+    transition: none;
+  }
+}
+
 /* Sticky left TOC needs ~1440px viewport (960px container + 24px padding +
    260px negative margin). Below that, use the drawer to avoid left-edge clipping. */
 @media (max-width: 1439px) {

--- a/tests/test_back_to_top_css.py
+++ b/tests/test_back_to_top_css.py
@@ -1,0 +1,58 @@
+"""Back-to-top FAB must mirror the sidebar toggle across the page's centre axis."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STYLE = ROOT / "assets" / "css" / "style.css"
+LAYOUT = ROOT / "_layouts" / "default.html"
+
+
+def _rule(selector: str) -> str:
+    text = STYLE.read_text(encoding="utf-8")
+    match = re.search(
+        r"(?m)^\s*" + re.escape(selector) + r"\s*\{(.*?)^\}",
+        text,
+        re.DOTALL,
+    )
+    assert match, f"rule {selector} not found"
+    return match.group(1)
+
+
+def _decl(block: str, prop: str) -> str:
+    match = re.search(r"(?m)^\s*" + re.escape(prop) + r"\s*:\s*([^;]+);", block)
+    assert match, f"{prop} not declared"
+    return match.group(1).strip()
+
+
+def test_back_to_top_mirrors_sidebar_toggle():
+    fab = _rule(".back-to-top")
+    toggle = _rule(".sidebar-toggle")
+
+    # Mirror symmetry: same distance from the bottom and the near horizontal
+    # edge, same size — only the anchored side flips (left <-> right).
+    assert _decl(fab, "right") == _decl(toggle, "left")
+    assert _decl(fab, "bottom") == _decl(toggle, "bottom")
+    assert _decl(fab, "width") == _decl(toggle, "width")
+    assert _decl(fab, "height") == _decl(toggle, "height")
+    assert "left:" not in fab
+    assert "right:" not in toggle
+
+
+def test_back_to_top_has_no_breakpoint_offset_override():
+    """A media-query override of the geometry would break the mirror."""
+    text = STYLE.read_text(encoding="utf-8")
+    blocks = re.findall(r"(?m)^\s*\.back-to-top\s*\{(.*?)^\s*\}", text, re.DOTALL)
+    assert len(blocks) >= 1
+    for prop in ("bottom", "right", "left", "width", "height"):
+        declared = sum(
+            1 for block in blocks if re.search(r"(?m)^\s*" + prop + r"\s*:", block)
+        )
+        assert declared <= 1, f"{prop} declared {declared} times on .back-to-top"
+
+
+def test_back_to_top_button_is_injected_on_every_page():
+    layout = LAYOUT.read_text(encoding="utf-8")
+    assert 'class="back-to-top" id="back-to-top"' in layout
+    assert 'data-zh-aria-label="回到顶部"' in layout
+    assert "window.scrollTo({ top: 0" in layout


### PR DESCRIPTION
参考 Robotics_Notebooks 的进度环 FAB 实现，在 _layouts/default.html
注入全站「回到顶部」按钮：

- 落位与左下角 .sidebar-toggle 关于页面中轴线镜面对称
  （bottom: 24px、48x48 一致，left: 20px 镜像为 right: 20px），
  且不做断点尺寸覆盖，避免任一侧改动后破坏镜像关系
- 外圈为阅读进度环，随滚动更新（量化到 1% 再写回，减少重绘）
- 滚动超过 0.6 屏（短页面按可滚距离 35%）后淡入；可滚距离不足
  240px 的页面不显示
- 颜色接入仓库现有 CSS 变量（--link / --card-bg / --border），
  深色与浅色主题均可辨识；尊重 prefers-reduced-motion
- aria-label 走 data-en-aria-label / data-zh-aria-label 中英切换
- 新增 tests/test_back_to_top_css.py 锁定镜像对称关系

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2FPxv84EMf6PfhR1ThJvC